### PR TITLE
Upgrade testcontainers version

### DIFF
--- a/flink-connector-clickhouse-1.17/build.gradle.kts
+++ b/flink-connector-clickhouse-1.17/build.gradle.kts
@@ -30,7 +30,8 @@ val flinkVersion = System.getenv("FLINK_VERSION") ?: "1.17.2"
 extra.apply {
     set("flinkVersion", flinkVersion)
     set("log4jVersion","2.17.2")
-    set("testContainersVersion", "1.21.0")
+    set("testContainersVersion", "2.0.2")
+    set("testContainersClickHouseVersion", "1.21.3")
     set("byteBuddyVersion", "1.17.5")
 }
 
@@ -74,7 +75,7 @@ dependencies {
     testImplementation("org.apache.flink:flink-test-utils:${project.extra["flinkVersion"]}")
     //
     testImplementation("org.testcontainers:testcontainers:${project.extra["testContainersVersion"]}")
-    testImplementation("org.testcontainers:clickhouse:${project.extra["testContainersVersion"]}")
+    testImplementation("org.testcontainers:clickhouse:${project.extra["testContainersClickHouseVersion"]}")
     testImplementation("org.scalatest:scalatest_2.13:3.2.19")
     testRuntimeOnly("org.scalatestplus:junit-4-13_2.13:3.2.18.0")
 }

--- a/flink-connector-clickhouse-2.0.0/build.gradle.kts
+++ b/flink-connector-clickhouse-2.0.0/build.gradle.kts
@@ -27,7 +27,8 @@ repositories {
 extra.apply {
     set("flinkVersion", "2.0.0") // the default still will be 2.0.0 since it is more popular currently
     set("log4jVersion","2.17.2")
-    set("testContainersVersion", "1.21.0")
+    set("testContainersVersion", "2.0.2")
+    set("testContainersClickHouseVersion", "1.21.3")
     set("byteBuddyVersion", "1.17.5")
 }
 
@@ -70,7 +71,7 @@ dependencies {
     testImplementation("org.apache.flink:flink-test-utils:${project.extra["flinkVersion"]}")
     //
     testImplementation("org.testcontainers:testcontainers:${project.extra["testContainersVersion"]}")
-    testImplementation("org.testcontainers:clickhouse:${project.extra["testContainersVersion"]}")
+    testImplementation("org.testcontainers:clickhouse:${project.extra["testContainersClickHouseVersion"]}")
     testImplementation("org.scalatest:scalatest_2.13:3.2.19")
     testRuntimeOnly("org.scalatestplus:junit-4-13_2.13:3.2.18.0")
 //    testRuntimeOnly("org.pegdown:pegdown:1.6.0") // sometimes required by ScalaTest

--- a/flink-connector-clickhouse-integration/build.gradle.kts
+++ b/flink-connector-clickhouse-integration/build.gradle.kts
@@ -21,7 +21,7 @@ repositories {
 
 extra.apply {
     set("log4jVersion","2.17.2")
-    set("testContainersVersion", "1.21.0")
+    set("testContainersVersion", "2.0.2")
     set("byteBuddyVersion", "1.17.5")
 }
 

--- a/flink-connector-clickhouse-integration/src/test/java/com/clickhouse/flink/integration/FlinkTests.java
+++ b/flink-connector-clickhouse-integration/src/test/java/com/clickhouse/flink/integration/FlinkTests.java
@@ -2,7 +2,7 @@ package com.clickhouse.flink.integration;
 
 import com.clickhouse.flink.Cluster;
 import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
-import org.junit.Assert;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -126,7 +126,7 @@ public class FlinkTests {
             Thread.sleep(2000);
         }
         int count = ClickHouseServerForTests.countRows(tableName);
-        Assert.assertEquals(NUMBERS_OF_RECORDS, count);
+        Assertions.assertEquals(NUMBERS_OF_RECORDS, count);
         // destroy cluster
         cluster.tearDown();
     }


### PR DESCRIPTION
## Summary

Upgrade for testcontainers to support the latest Docker version 
```
 Version:           29.1.2
 API version:       1.52
```

Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
