### PR TITLE
Upgrade foojay to 1.0.0

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,7 @@
 
 plugins {
     // Apply the foojay-resolver plugin to allow automatic download of JDKs
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "flink-connector-clickhouse"


### PR DESCRIPTION
## Summary
Upgrade foojay to `1.0.0` to make it compatible with the current gradle wrapper version (9.0).

Closes https://github.com/ClickHouse/flink-connector-clickhouse/issues/93

## Checklist
- [ ] Closes #93
