### PR TITLE
DRAFT: Add `waitingFor` successful health-check and associated timeout to integration test

### DIFF
--- a/flink-connector-clickhouse-base/src/testFixtures/java/org/apache/flink/connector/test/embedded/clickhouse/ClickHouseServerForTests.java
+++ b/flink-connector-clickhouse-base/src/testFixtures/java/org/apache/flink/connector/test/embedded/clickhouse/ClickHouseServerForTests.java
@@ -7,7 +7,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.clickhouse.ClickHouseContainer;
 import org.testcontainers.containers.Network;
+import org.testcontainers.containers.wait.strategy.Wait;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 
@@ -59,6 +61,8 @@ public class ClickHouseServerForTests {
                    .withNetwork(Network.newNetwork());
 
             }
+            db.waitingFor(Wait.forHealthcheck());
+            db.withStartupTimeout(Duration.ofSeconds(60));
             db.start();
         }
         initConfiguration();


### PR DESCRIPTION
## Summary
### WIP - not ready for review

Prevents flakiness when the container isn’t fully ready before the integration tests start running.

Closes https://github.com/ClickHouse/flink-connector-clickhouse/issues/39
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #39