### PR TITLE
Change `version.txt` owner to integrations-ecosystem team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-version.txt @mzitnik @kurnoolsaketh
+version.txt @ClickHouse/integrations-ecosystem


### PR DESCRIPTION
## Summary
Instead of hardcoding GH handles, change the owner of `version.txt` to the `integrations-ecosystem` team. We will manually review changes to the main project version this way.
