### PR TITLE
Basic support for formats with headers like RowBinaryWithNames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.4
 * Add JSON type support https://github.com/ClickHouse/flink-connector-clickhouse/pull/106
 * Enhance instrument api https://github.com/ClickHouse/flink-connector-clickhouse/pull/99
+* Adding support for file formats with headers, such as RowBinaryWithNames https://github.com/ClickHouse/flink-connector-clickhouse/pull/108
 ## 0.1.3
 * Added an option to configure the client with server-side parameters. https://github.com/ClickHouse/flink-connector-clickhouse/pull/85 
 * Added check if ClickHouse is alive before start. https://github.com/ClickHouse/flink-connector-clickhouse/issues/76 

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
@@ -21,10 +21,6 @@ import java.io.IOException;
 import com.clickhouse.utils.writer.DataWriter;
 
 public class ClickHouseConvertorWithHeader<InputT> extends ClickHouseConvertor<InputT> implements SupportsHeader {
-    public ClickHouseConvertorWithHeader(Class<?> clazz) {
-        super(clazz);
-    }
-
     public <T extends POJOConvertor<InputT> & SupportsHeader> ClickHouseConvertorWithHeader(Class<?> clazz,
             T pojoConvertor) {
         super(clazz, pojoConvertor);

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2026 Aviatrix, Inc.
+ * Copyright (c) 2026 Aviatrix Systems, Inc.
  * 
- * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.connector.clickhouse.convertor;

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Aviatrix, Inc.
+ * 
+ * All rights reserved.
+ */
+
+package org.apache.flink.connector.clickhouse.convertor;
+
+import java.io.IOException;
+
+import com.clickhouse.utils.writer.DataWriter;
+
+public class ClickHouseConvertorWithHeader<InputT> extends ClickHouseConvertor<InputT> implements SupportsHeader {
+    public ClickHouseConvertorWithHeader(Class<?> clazz) {
+        super(clazz);
+    }
+
+    public <T extends POJOConvertor<InputT> & SupportsHeader> ClickHouseConvertorWithHeader(Class<?> clazz,
+            T pojoConvertor) {
+        super(clazz, pojoConvertor);
+    }
+
+    @Override
+    public void header(DataWriter dataWriter) throws IOException {
+        SupportsHeader convertor = (SupportsHeader) this.pojoConvertor;
+        convertor.header(dataWriter);
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSink.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSink.java
@@ -2,15 +2,19 @@ package org.apache.flink.connector.clickhouse.sink;
 
 
 import com.clickhouse.data.ClickHouseFormat;
+import com.clickhouse.utils.writer.DataWriter;
+
 import org.apache.flink.api.connector.sink2.Sink;
 import org.apache.flink.connector.base.sink.AsyncSinkBase;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.connector.clickhouse.convertor.SupportsHeader;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -56,6 +60,21 @@ public class ClickHouseAsyncSink<InputT> extends AsyncSinkBase<InputT, ClickHous
 
     @Override
     public StatefulSinkWriter<InputT, BufferedRequestState<ClickHousePayload>> restoreWriter(Sink.InitContext context, Collection<BufferedRequestState<ClickHousePayload>> collection) throws IOException {
+        byte[] header = null;
+        if (clickHouseFormat != null && clickHouseFormat.hasHeader()) {
+            ElementConverter<InputT, ClickHousePayload> converter = getElementConverter();
+            if (converter == null || (!(converter instanceof SupportsHeader))) {
+                // unable to compute the header. Generate an error
+                throw new IllegalStateException("A converter that supports headers is required for the format " + clickHouseFormat.name());
+            }
+
+            SupportsHeader headerConvertor = (SupportsHeader) converter;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            DataWriter dataWriter = DataWriter.of(true, out);
+            headerConvertor.header(dataWriter);
+            header = out.toByteArray();
+        }
+
         return new ClickHouseAsyncWriter<>(
                 getElementConverter(),
                 context,
@@ -67,6 +86,7 @@ public class ClickHouseAsyncSink<InputT> extends AsyncSinkBase<InputT, ClickHous
                 getMaxRecordSizeInBytes(),
                 clickHouseClientConfig,
                 clickHouseFormat,
+                header,
                 collection
         );
     }

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
@@ -36,6 +36,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
 
     private final ClickHouseClientConfig clickHouseClientConfig;
     private ClickHouseFormat clickHouseFormat = null;
+    private byte[] header = null;
     private int numberOfRetries = DEFAULT_MAX_RETRIES;
 
     private final Counter numBytesSendCounter;
@@ -59,6 +60,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
                                  int numberOfRetries,
                                  ClickHouseClientConfig clickHouseClientConfig,
                                  ClickHouseFormat clickHouseFormat,
+                                 byte[] header, 
                                  Collection<BufferedRequestState<ClickHousePayload>> state) {
         super(elementConverter,
                 context,
@@ -73,6 +75,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
                 state);
         this.clickHouseClientConfig = clickHouseClientConfig;
         this.clickHouseFormat = clickHouseFormat;
+        this.header = header;
         this.numberOfRetries = numberOfRetries;
         final SinkWriterMetricGroup metricGroup = context.metricGroup();
         this.numBytesSendCounter = metricGroup.getNumBytesSendCounter();
@@ -96,6 +99,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
                                  long maxRecordSizeInBytes,
                                  ClickHouseClientConfig clickHouseClientConfig,
                                  ClickHouseFormat clickHouseFormat,
+                                 byte[] header,
                                  Collection<BufferedRequestState<ClickHousePayload>> state) {
         this(elementConverter,
              context,
@@ -108,6 +112,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
              clickHouseClientConfig.getNumberOfRetries(),
              clickHouseClientConfig,
              clickHouseFormat,
+             header,
              state
         );
     }
@@ -142,6 +147,10 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
         long writeStartTime = System.currentTimeMillis();
         try {
             CompletableFuture<InsertResponse> response = chClient.insert(tableName, out -> {
+                if (header != null) {
+                    this.numBytesSendCounter.inc(header.length);
+                    out.write(header);
+                }
                 for (ClickHousePayload requestEntry : requestEntries) {
                     if (requestEntry.getPayload() != null) {
                         byte[] payload = requestEntry.getPayload();

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -7,9 +7,11 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertorWithHeader;
 import org.apache.flink.connector.clickhouse.convertor.POJOConvertor;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.connector.clickhouse.sink.convertor.CovidPOJOConvertor;
+import org.apache.flink.connector.clickhouse.sink.convertor.CovidPOJOWithHeaderConvertor;
 import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOConvertor;
 import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOWithJSONConvertor;
 import org.apache.flink.connector.clickhouse.sink.pojo.CovidPOJO;
@@ -141,6 +143,78 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 MAX_RECORD_SIZE_IN_BYTES,
                 clickHouseClientConfig
         );
+
+        Path filePath = new Path("./src/test/resources/epidemiology_top_10000.csv.gz");
+
+        FileSource<String> source = FileSource
+                .forRecordStreamFormat(new TextLineInputFormat(), filePath)
+                .build();
+        // read csv data from file
+        DataStreamSource<String> lines = env.fromSource(
+                source,
+                WatermarkStrategy.noWatermarks(),
+                "GzipCsvSource"
+        );
+
+        // convert to POJO
+        DataStream<CovidPOJO> covidPOJOs = lines.map(new MapFunction<String, CovidPOJO>() {
+            @Override
+            public CovidPOJO map(String value) throws Exception {
+                return new CovidPOJO(value);
+            }
+        });
+        // send to a sink
+        covidPOJOs.sinkTo(covidPOJOSink);
+        int rows = executeAsyncJob(env, tableName, 10, EXPECTED_ROWS);
+        Assertions.assertEquals(EXPECTED_ROWS, rows);
+    }
+
+    @Test
+    void CovidPOJOHeaderDataTest() throws Exception {
+        String tableName = "covid_pojo";
+
+        String dropTable = String.format("DROP TABLE IF EXISTS `%s`.`%s`", getDatabase(), tableName);
+        ClickHouseServerForTests.executeSql(dropTable);
+        // create table
+        String tableSql = "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` (" +
+                "date Date," +
+                "location_key LowCardinality(String)," +
+                "new_confirmed Int32," +
+                "new_deceased Int32," +
+                "new_recovered Int32," +
+                "new_tested Int32," +
+                "cumulative_confirmed Int32," +
+                "cumulative_deceased Int32," +
+                "cumulative_recovered Int32," +
+                "cumulative_tested Int32," +
+                "dummy Int32 null," +
+                "dummy2 String default 'orig'" + 
+                ") " +
+                "ENGINE = MergeTree " +
+                "ORDER BY (location_key, date); ";
+        ClickHouseServerForTests.executeSql(tableSql);
+
+        TableSchema covidTableSchema = ClickHouseServerForTests.getTableSchema(tableName);
+
+        CovidPOJOWithHeaderConvertor covidPOJOConvertor = new CovidPOJOWithHeaderConvertor();
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(STREAM_PARALLELISM);
+
+        ClickHouseClientConfig clickHouseClientConfig = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        clickHouseClientConfig.setSupportDefault(covidTableSchema.hasDefaults());
+        ElementConverter<CovidPOJO, ClickHousePayload> convertorCovid = new ClickHouseConvertorWithHeader<>(CovidPOJO.class, covidPOJOConvertor);
+
+        ClickHouseAsyncSink<CovidPOJO> covidPOJOSink = new ClickHouseAsyncSink<>(
+                convertorCovid,
+                MAX_BATCH_SIZE,
+                MAX_IN_FLIGHT_REQUESTS,
+                MAX_BUFFERED_REQUESTS,
+                MAX_BATCH_SIZE_IN_BYTES,
+                MAX_TIME_IN_BUFFER_MS,
+                MAX_RECORD_SIZE_IN_BYTES,
+                clickHouseClientConfig
+        );
+        covidPOJOSink.setClickHouseFormat(ClickHouseFormat.RowBinaryWithNames);
 
         Path filePath = new Path("./src/test/resources/epidemiology_top_10000.csv.gz");
 

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -239,6 +239,17 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         covidPOJOs.sinkTo(covidPOJOSink);
         int rows = executeAsyncJob(env, tableName, 10, EXPECTED_ROWS);
         Assertions.assertEquals(EXPECTED_ROWS, rows);
+
+        // verify that missing columns are left as NULL/default via header-based column mapping  
+        List<GenericRecord> records =  
+                ClickHouseServerForTests.extractData(ClickHouseServerForTests.getDatabase(), tableName, "date");  
+        Assertions.assertFalse(records.isEmpty(), "No records found in ClickHouse table " + tableName);  
+        GenericRecord firstRecord = records.get(0);  
+        // column "dummy" should be NULL when not provided in the header-based mapping  
+        Assertions.assertNull(firstRecord.getValues().get("dummy"));  
+        // column "dummy2" should take its default value (e.g. 'orig') when not provided  
+        Assertions.assertEquals("orig", firstRecord.getString("dummy2"));  
+
     }
 
     @Test

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2026 Aviatrix, Inc.
+ * Copyright (c) 2026 Aviatrix Systems, Inc.
  * 
- * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.connector.clickhouse.sink.convertor;

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Aviatrix, Inc.
+ * 
+ * All rights reserved.
+ */
+
+package org.apache.flink.connector.clickhouse.sink.convertor;
+
+import java.io.IOException;
+
+import org.apache.flink.connector.clickhouse.convertor.SupportsHeader;
+
+import com.clickhouse.utils.writer.DataWriter;
+
+public class CovidPOJOWithHeaderConvertor extends CovidPOJOConvertor implements SupportsHeader {
+    public CovidPOJOWithHeaderConvertor() {
+        super(false); // RowBinaryWithNames is incompatible with defaults
+    }
+
+    @Override
+    public void header(DataWriter dataWriter) throws IOException {  
+        String[] columns = {
+            "date"                ,
+            "location_key"        ,
+            "new_confirmed"       ,
+            "new_deceased"        ,
+            "new_recovered"       ,
+            "new_tested"          ,
+            "cumulative_confirmed",
+            "cumulative_deceased" ,
+            "cumulative_recovered",
+            "cumulative_tested"   
+        };
+
+        dataWriter.writeVarInt(columns.length);
+        for (String col : columns) {
+            dataWriter.writeRawString(col);
+        }
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
@@ -21,10 +21,6 @@ import java.io.IOException;
 import com.clickhouse.utils.writer.DataWriter;
 
 public class ClickHouseConvertorWithHeader<InputT> extends ClickHouseConvertor<InputT> implements SupportsHeader {
-    public ClickHouseConvertorWithHeader(Class<?> clazz) {
-        super(clazz);
-    }
-
     public <T extends POJOConvertor<InputT> & SupportsHeader> ClickHouseConvertorWithHeader(Class<?> clazz,
             T pojoConvertor) {
         super(clazz, pojoConvertor);

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2026 Aviatrix, Inc.
+ * Copyright (c) 2026 Aviatrix Systems, Inc.
  * 
- * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.connector.clickhouse.convertor;

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertorWithHeader.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Aviatrix, Inc.
+ * 
+ * All rights reserved.
+ */
+
+package org.apache.flink.connector.clickhouse.convertor;
+
+import java.io.IOException;
+
+import com.clickhouse.utils.writer.DataWriter;
+
+public class ClickHouseConvertorWithHeader<InputT> extends ClickHouseConvertor<InputT> implements SupportsHeader {
+    public ClickHouseConvertorWithHeader(Class<?> clazz) {
+        super(clazz);
+    }
+
+    public <T extends POJOConvertor<InputT> & SupportsHeader> ClickHouseConvertorWithHeader(Class<?> clazz,
+            T pojoConvertor) {
+        super(clazz, pojoConvertor);
+    }
+
+    @Override
+    public void header(DataWriter dataWriter) throws IOException {
+        SupportsHeader convertor = (SupportsHeader) this.pojoConvertor;
+        convertor.header(dataWriter);
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSink.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSink.java
@@ -2,17 +2,21 @@ package org.apache.flink.connector.clickhouse.sink;
 
 
 import com.clickhouse.data.ClickHouseFormat;
+import com.clickhouse.utils.writer.DataWriter;
+
 import org.apache.flink.api.connector.sink2.SinkWriter;
 import org.apache.flink.api.connector.sink2.StatefulSinkWriter;
 import org.apache.flink.api.connector.sink2.WriterInitContext;
 import org.apache.flink.connector.base.sink.AsyncSinkBase;
 import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
+import org.apache.flink.connector.clickhouse.convertor.SupportsHeader;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.core.io.SimpleVersionedSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,6 +62,21 @@ public class ClickHouseAsyncSink<InputT> extends AsyncSinkBase<InputT, ClickHous
 
     @Override
     public StatefulSinkWriter<InputT, BufferedRequestState<ClickHousePayload>> restoreWriter(WriterInitContext writerInitContext, Collection<BufferedRequestState<ClickHousePayload>> collection) throws IOException {
+        byte[] header = null;
+        if (clickHouseFormat != null && clickHouseFormat.hasHeader()) {
+            ElementConverter<InputT, ClickHousePayload> converter = getElementConverter();
+            if (converter == null || (!(converter instanceof SupportsHeader))) {
+                // unable to compute the header. Generate an error
+                throw new IllegalStateException("A converter that supports headers is required for the format " + clickHouseFormat.name());
+            }
+
+            SupportsHeader headerConvertor = (SupportsHeader) converter;
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            DataWriter dataWriter = DataWriter.of(true, out);
+            headerConvertor.header(dataWriter);
+            header = out.toByteArray();
+        }
+
         return new ClickHouseAsyncWriter<>(
                 getElementConverter(),
                 writerInitContext,
@@ -69,6 +88,7 @@ public class ClickHouseAsyncSink<InputT> extends AsyncSinkBase<InputT, ClickHous
                 getMaxRecordSizeInBytes(),
                 clickHouseClientConfig,
                 clickHouseFormat,
+                header,
                 collection
         );
     }

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
@@ -34,6 +34,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
 
     private final ClickHouseClientConfig clickHouseClientConfig;
     private ClickHouseFormat clickHouseFormat = null;
+    private byte[] header = null;
     private int numberOfRetries = DEFAULT_MAX_RETRIES;
 
     private final Counter numBytesSendCounter;
@@ -56,6 +57,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
                                  int numberOfRetries,
                                  ClickHouseClientConfig clickHouseClientConfig,
                                  ClickHouseFormat clickHouseFormat,
+                                 byte[] header, 
                                  Collection<BufferedRequestState<ClickHousePayload>> state) {
         super(elementConverter,
                 context,
@@ -70,6 +72,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
                 state);
         this.clickHouseClientConfig = clickHouseClientConfig;
         this.clickHouseFormat = clickHouseFormat;
+        this.header = header;
         this.numberOfRetries = numberOfRetries;
         final SinkWriterMetricGroup metricGroup = context.metricGroup();
         this.numBytesSendCounter = metricGroup.getNumBytesSendCounter();
@@ -93,6 +96,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
                                  long maxRecordSizeInBytes,
                                  ClickHouseClientConfig clickHouseClientConfig,
                                  ClickHouseFormat clickHouseFormat,
+                                 byte[] header, 
                                  Collection<BufferedRequestState<ClickHousePayload>> state) {
         this(elementConverter,
              context,
@@ -105,6 +109,7 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
              clickHouseClientConfig.getNumberOfRetries(),
              clickHouseClientConfig,
              clickHouseFormat,
+             header,
              state
         );
     }
@@ -144,6 +149,10 @@ public class ClickHouseAsyncWriter<InputT> extends ExtendedAsyncSinkWriter<Input
         long writeStartTime = System.currentTimeMillis();
         try {
             CompletableFuture<InsertResponse> response = chClient.insert(tableName, out -> {
+                if (header != null) {
+                    this.numBytesSendCounter.inc(header.length);
+                    out.write(header);
+                }
                 for (ClickHousePayload requestEntry : requestEntries) {
                     if (requestEntry.getPayload() != null) {
                         byte[] payload = requestEntry.getPayload();

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -170,13 +170,18 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         Assertions.assertEquals(EXPECTED_ROWS, rows);
     }
 
+    // This test validates that data can be inserted using the RowBinaryWithNames format,
+    // and specifically tests inserting into a table when not all the columns in the table 
+    // are present in the convertor or underlying data. The missing columns should be 
+    // left as null or their default value.
     @Test
     void CovidPOJOHeaderDataTest() throws Exception {
         String tableName = "covid_pojo";
 
         String dropTable = String.format("DROP TABLE IF EXISTS `%s`.`%s`", getDatabase(), tableName);
         ClickHouseServerForTests.executeSql(dropTable);
-        // create table
+        // create table that has two extra columns  (dummy and dummy2) that aren't available
+        // in the data being inserted. 
         String tableSql = "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` (" +
                 "date Date," +
                 "location_key LowCardinality(String)," +

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -7,9 +7,11 @@ import org.apache.flink.api.common.eventtime.WatermarkStrategy;
 import org.apache.flink.api.common.functions.MapFunction;
 import org.apache.flink.connector.base.sink.writer.ElementConverter;
 import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertorWithHeader;
 import org.apache.flink.connector.clickhouse.convertor.POJOConvertor;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.connector.clickhouse.sink.convertor.CovidPOJOConvertor;
+import org.apache.flink.connector.clickhouse.sink.convertor.CovidPOJOWithHeaderConvertor;
 import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOConvertor;
 import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOWithJSONConvertor;
 import org.apache.flink.connector.clickhouse.sink.pojo.CovidPOJO;
@@ -142,6 +144,78 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 MAX_RECORD_SIZE_IN_BYTES,
                 clickHouseClientConfig
         );
+
+        Path filePath = new Path("./src/test/resources/epidemiology_top_10000.csv.gz");
+
+        FileSource<String> source = FileSource
+                .forRecordStreamFormat(new TextLineInputFormat(), filePath)
+                .build();
+        // read csv data from file
+        DataStreamSource<String> lines = env.fromSource(
+                source,
+                WatermarkStrategy.noWatermarks(),
+                "GzipCsvSource"
+        );
+
+        // convert to POJO
+        DataStream<CovidPOJO> covidPOJOs = lines.map(new MapFunction<String, CovidPOJO>() {
+            @Override
+            public CovidPOJO map(String value) throws Exception {
+                return new CovidPOJO(value);
+            }
+        });
+        // send to a sink
+        covidPOJOs.sinkTo(covidPOJOSink);
+        int rows = executeAsyncJob(env, tableName, 10, EXPECTED_ROWS);
+        Assertions.assertEquals(EXPECTED_ROWS, rows);
+    }
+
+    @Test
+    void CovidPOJOHeaderDataTest() throws Exception {
+        String tableName = "covid_pojo";
+
+        String dropTable = String.format("DROP TABLE IF EXISTS `%s`.`%s`", getDatabase(), tableName);
+        ClickHouseServerForTests.executeSql(dropTable);
+        // create table
+        String tableSql = "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` (" +
+                "date Date," +
+                "location_key LowCardinality(String)," +
+                "new_confirmed Int32," +
+                "new_deceased Int32," +
+                "new_recovered Int32," +
+                "new_tested Int32," +
+                "cumulative_confirmed Int32," +
+                "cumulative_deceased Int32," +
+                "cumulative_recovered Int32," +
+                "cumulative_tested Int32," +
+                "dummy Int32 null," +
+                "dummy2 String default 'orig'" + 
+                ") " +
+                "ENGINE = MergeTree " +
+                "ORDER BY (location_key, date); ";
+        ClickHouseServerForTests.executeSql(tableSql);
+
+        TableSchema covidTableSchema = ClickHouseServerForTests.getTableSchema(tableName);
+
+        CovidPOJOWithHeaderConvertor covidPOJOConvertor = new CovidPOJOWithHeaderConvertor(); 
+        final StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
+        env.setParallelism(STREAM_PARALLELISM);
+
+        ClickHouseClientConfig clickHouseClientConfig = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        clickHouseClientConfig.setSupportDefault(covidTableSchema.hasDefaults());
+        ElementConverter<CovidPOJO, ClickHousePayload> convertorCovid = new ClickHouseConvertorWithHeader<>(CovidPOJO.class, covidPOJOConvertor);
+
+        ClickHouseAsyncSink<CovidPOJO> covidPOJOSink = new ClickHouseAsyncSink<>(
+                convertorCovid,
+                MAX_BATCH_SIZE,
+                MAX_IN_FLIGHT_REQUESTS,
+                MAX_BUFFERED_REQUESTS,
+                MAX_BATCH_SIZE_IN_BYTES,
+                MAX_TIME_IN_BUFFER_MS,
+                MAX_RECORD_SIZE_IN_BYTES,
+                clickHouseClientConfig
+        );
+        covidPOJOSink.setClickHouseFormat(ClickHouseFormat.RowBinaryWithNames);
 
         Path filePath = new Path("./src/test/resources/epidemiology_top_10000.csv.gz");
 

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -245,7 +245,17 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         covidPOJOs.sinkTo(covidPOJOSink);
         int rows = executeAsyncJob(env, tableName, 10, EXPECTED_ROWS);
         Assertions.assertEquals(EXPECTED_ROWS, rows);
-    }
+
+        // verify that missing columns are left as NULL/default via header-based column mapping  
+        List<GenericRecord> records =  
+                ClickHouseServerForTests.extractData(ClickHouseServerForTests.getDatabase(), tableName, "date");  
+        Assertions.assertFalse(records.isEmpty(), "No records found in ClickHouse table " + tableName);  
+        GenericRecord firstRecord = records.get(0);  
+        // column "dummy" should be NULL when not provided in the header-based mapping  
+        Assertions.assertNull(firstRecord.getValues().get("dummy"));  
+        // column "dummy2" should take its default value (e.g. 'orig') when not provided  
+        Assertions.assertEquals("orig", firstRecord.getString("dummy2"));  
+}
 
     @Test
     void ProductNameTest() throws Exception {

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2026 Aviatrix, Inc.
+ * Copyright (c) 2026 Aviatrix Systems, Inc.
  * 
- * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.connector.clickhouse.sink.convertor;

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/convertor/CovidPOJOWithHeaderConvertor.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Aviatrix, Inc.
+ * 
+ * All rights reserved.
+ */
+
+package org.apache.flink.connector.clickhouse.sink.convertor;
+
+import java.io.IOException;
+
+import org.apache.flink.connector.clickhouse.convertor.SupportsHeader;
+
+import com.clickhouse.utils.writer.DataWriter;
+
+public class CovidPOJOWithHeaderConvertor extends CovidPOJOConvertor implements SupportsHeader {
+    public CovidPOJOWithHeaderConvertor() {
+        super(false); // RowBinaryWithNames is incompatible with defaults
+    }
+
+    @Override
+    public void header(DataWriter dataWriter) throws IOException {  
+        String[] columns = {
+            "date"                ,
+            "location_key"        ,
+            "new_confirmed"       ,
+            "new_deceased"        ,
+            "new_recovered"       ,
+            "new_tested"          ,
+            "cumulative_confirmed",
+            "cumulative_deceased" ,
+            "cumulative_recovered",
+            "cumulative_tested"   
+        };
+
+        dataWriter.writeVarInt(columns.length);
+        for (String col : columns) {
+            dataWriter.writeRawString(col);
+        }
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/test/embedded/clickhouse/ClickHouseTestHelpers.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/test/embedded/clickhouse/ClickHouseTestHelpers.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 public class ClickHouseTestHelpers {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseTestHelpers.class);
 
-    public static final String CLICKHOUSE_VERSION_DEFAULT = "24.3";
+    public static final String CLICKHOUSE_VERSION_DEFAULT = "latest"; //= "24.3";
     public static final String CLICKHOUSE_PROXY_VERSION_DEFAULT = "23.8";
     public static final String CLICKHOUSE_DOCKER_IMAGE = String.format("clickhouse/clickhouse-server:%s", getClickhouseVersion());
     public static final String CLICKHOUSE_FOR_PROXY_DOCKER_IMAGE = String.format("clickhouse/clickhouse-server:%s", CLICKHOUSE_PROXY_VERSION_DEFAULT);

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
@@ -227,4 +227,12 @@ public class DataWriter {
         }
     }
 
+    public void writeVarInt(long value) throws IOException {
+        SerializerUtils.writeVarInt(out, value);
+    }
+
+    public void writeRawString(String value) throws IOException {
+        BinaryStreamUtils.writeString(out,value);
+    }
+
 }

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
@@ -232,7 +232,7 @@ public class DataWriter {
     }
 
     public void writeRawString(String value) throws IOException {
-        BinaryStreamUtils.writeString(out,value);
+        BinaryStreamUtils.writeString(out, Serialize.convertToString(value));
     }
 
 }

--- a/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/convertor/SupportsHeader.java
+++ b/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/convertor/SupportsHeader.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2026 Aviatrix, Inc.
+ * 
+ * All rights reserved.
+ */
+
+package org.apache.flink.connector.clickhouse.convertor;
+
+import java.io.IOException;
+
+import com.clickhouse.utils.writer.DataWriter;
+
+public interface SupportsHeader {
+    void header(DataWriter dataWriter) throws IOException;
+}

--- a/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/convertor/SupportsHeader.java
+++ b/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/convertor/SupportsHeader.java
@@ -1,7 +1,17 @@
 /*
- * Copyright (c) 2026 Aviatrix, Inc.
+ * Copyright (c) 2026 Aviatrix Systems, Inc.
  * 
- * All rights reserved.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 package org.apache.flink.connector.clickhouse.convertor;


### PR DESCRIPTION
## Summary
Adding an interface SupportsHeaders that flags when a Convertor is going to produce a format that requires a header when sending to ClickHouse, and then provides a method to retrieve and incorporate that header as part of the message

Closes #107 
## Checklist
Delete items not relevant to your PR:
- [x] Closes #107
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
