### PR TITLE
Change CI test timeout and add manual trigger to nightly HEAD tests

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   test-integration-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-nightly.yaml
+++ b/.github/workflows/tests-nightly.yaml
@@ -4,11 +4,12 @@ on:
   schedule:
     # Run against ClickHouse versions and head 3:55pm every day
     - cron: "55 15 * * *"
+  workflow_dispatch:
 
 jobs:
   test-flink-17:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +47,7 @@ jobs:
           arguments: :flink-connector-clickhouse-1.17:test
   test-flink-2:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests-scala.yaml
+++ b/.github/workflows/tests-scala.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   test-flink-17:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
           arguments: :flink-connector-clickhouse-1.17:runScalaTests
   test-flink-2:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   test-flink-17:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
@@ -43,7 +43,7 @@ jobs:
           arguments: :flink-connector-clickhouse-1.17:test
   test-flink-2:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary
- add manual trigger to nightly HEAD tests. This should make debugging potentially flaky tests easier.
- change CI test timeout since there is an increased incidence of tests being skipped due to timeouts. For ex: 
    - https://github.com/ClickHouse/flink-connector-clickhouse/actions/runs/22493652214/job/65162286037
    - https://github.com/ClickHouse/flink-connector-clickhouse/actions/runs/22509635347/job/65215951502