### PR TITLE
reduce likelihood of SimplePOJODataTooManyPartsTest flakiness

### DIFF
--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -347,6 +347,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         if (isCloud())
             return;
         String tableName = "simple_too_many_parts_pojo";
+        int expectedRows = 1000;
 
         // create table
         String tableSql = SimplePOJO.createTableSQL(getDatabase(), tableName, 10);
@@ -377,15 +378,15 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         );
 
         List<SimplePOJO> simplePOJOList = new ArrayList<>();
-        for (int i = 0; i < EXPECTED_ROWS; i++) {
+        for (int i = 0; i < expectedRows; i++) {
             simplePOJOList.add(new SimplePOJO(i));
         }
         // create from list
         DataStream<SimplePOJO> simplePOJOs = env.fromElements(simplePOJOList.toArray(new SimplePOJO[0]));
         // send to a sink
         simplePOJOs.sinkTo(simplePOJOSink);
-        int rows = executeAsyncJob(env, tableName, 500, EXPECTED_ROWS);
-        Assertions.assertEquals(EXPECTED_ROWS, rows);
+        int rows = executeAsyncJob(env, tableName, 500, expectedRows);
+        Assertions.assertEquals(expectedRows, rows);
 //        ClickHouseServerForTests.showData("simple_too_many_parts_pojo");
         //ClickHouseServerForTests.executeSql(String.format("SYSTEM START MERGES `%s.%s`", getDatabase(), tableName));
     }

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -359,6 +359,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         if (isCloud())
             return;
         String tableName = "simple_too_many_parts_pojo";
+        int expectedRows = 1000;
 
         // create table
         String tableSql = SimplePOJO.createTableSQL(getDatabase(), tableName, 10);
@@ -389,15 +390,15 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         );
 
         List<SimplePOJO> simplePOJOList = new ArrayList<>();
-        for (int i = 0; i < EXPECTED_ROWS; i++) {
+        for (int i = 0; i < expectedRows; i++) {
             simplePOJOList.add(new SimplePOJO(i));
         }
         // create from list
         DataStream<SimplePOJO> simplePOJOs = env.fromData(simplePOJOList.toArray(new SimplePOJO[0]));
         // send to a sink
         simplePOJOs.sinkTo(simplePOJOSink);
-        int rows = executeAsyncJob(env, tableName, 500, EXPECTED_ROWS);
-        Assertions.assertEquals(EXPECTED_ROWS, rows);
+        int rows = executeAsyncJob(env, tableName, 1000, expectedRows);
+        Assertions.assertEquals(expectedRows, rows);
         //ClickHouseServerForTests.executeSql(String.format("SYSTEM START MERGES `%s.%s`", getDatabase(), tableName));
     }
 


### PR DESCRIPTION
## Summary
Issue: `SimplePOJODataTooManyPartsTest` is flaky because the expected row count (10000) is not consistently being reached in 100 iterations. This results in an `AssertionFailedError` - [example](https://github.com/ClickHouse/flink-connector-clickhouse/actions/runs/22546995700/job/65310871042). **So far, failures happen regardless of flink and CH version and only in Github CI.**

Proposed fix: increase iterations from 100 to 500 and decrease row count from 10000 to 1000. This will increase the likelihood that the count query result matches the expected row count in the lifetime of the test. 

### NOTE: this is a bandaid fix - it addresses the flakiness in the short term. This test may require re-architecture to make it more stable.