### PR TITLE
Validate retry deduplication when writing to a non-replicated MergeTree

### DIFF
--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutionException;
 
 import static org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests.*;
 import static org.apache.flink.connector.clickhouse.sink.ClickHouseSinkTestUtils.*;
@@ -388,6 +387,74 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         Assertions.assertEquals(EXPECTED_ROWS, rows);
 //        ClickHouseServerForTests.showData("simple_too_many_parts_pojo");
         //ClickHouseServerForTests.executeSql(String.format("SYSTEM START MERGES `%s.%s`", getDatabase(), tableName));
+    }
+
+    /*
+        In this test, we try sending an identical batch to ClickHouse twice under two different configurations:
+        1. non_replicated_deduplication_window=0 (default): block-level retry deduplication is disabled
+        2. non_replicated_deduplication_window=1: block-level retry deduplication is enabled
+
+        The goal of sending the same batch twice is to simulate a retry, which would happen in response to a retryable exception.
+        We intentionally set the maxBatchSize to be greater than the number of rows being sent to ensure all rows fit in a single batch.
+        On the server side, this batch becomes a single block and its hash is flushed to the dedup log before the server responds.
+        We assert that if deduplication is disabled, the rows should appear twice when retried, and that if its enabled, the rows should appear only once.
+    */
+    @Test
+    void testDeduplicateOnRetryNonReplicated() throws Exception {
+        if (isCloud()) return; // non_replicated_deduplication_window only for non-replicated MergeTree
+
+        int numRows = 10;
+        // maxBatchSize > numRows ensures all rows are sent as one block (required for block-hash dedup)
+        int maxBatchSize = numRows * 2;
+
+        List<SimplePOJO> data = new ArrayList<>();
+        for (int i = 0; i < numRows; i++) data.add(new SimplePOJO(i));
+        SimplePOJO[] dataArray = data.toArray(new SimplePOJO[0]);
+
+        // scenario A: no dedup window (default=0) — inserting the same data twice produces duplicates
+        {
+            String tableName = "dedup_no_window_pojo";
+            ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQL(getDatabase(), tableName));
+            TableSchema schema = ClickHouseServerForTests.getTableSchema(tableName);
+            ClickHouseClientConfig config = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+            config.setSupportDefault(schema.hasDefaults());
+            ElementConverter<SimplePOJO, ClickHousePayload> converter = new ClickHouseConvertor<>(SimplePOJO.class, new SimplePOJOConvertor(schema.hasDefaults()));
+
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setParallelism(1);
+
+            // first insert; executeAsync clears transformations after compiling the graph
+            env.fromElements(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            executeAsyncJob(env, tableName, 30, numRows);
+
+            // second insert of identical data (simulates a retry) — no dedup, expect duplicates
+            env.fromElements(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            int rows = executeAsyncJob(env, tableName, 30, numRows * 2);
+            Assertions.assertEquals(numRows * 2, rows, "Without dedup window, inserting the same data twice should produce duplicates");
+        }
+
+        // scenario B: dedup window=100 — inserting the same data twice is deduplicated
+        {
+            String tableName = "dedup_with_window_pojo";
+            ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQLWithDedupWindow(getDatabase(), tableName, 100));
+            TableSchema schema = ClickHouseServerForTests.getTableSchema(tableName);
+            ClickHouseClientConfig config = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+            config.setSupportDefault(schema.hasDefaults());
+            ElementConverter<SimplePOJO, ClickHousePayload> converter = new ClickHouseConvertor<>(SimplePOJO.class, new SimplePOJOConvertor(schema.hasDefaults()));
+
+            StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+            env.setParallelism(1);
+
+            // first insert
+            env.fromElements(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            executeAsyncJob(env, tableName, 30, numRows);
+
+            // second insert of identical data (simulates a retry) — CH recognizes the same block hash, ignores it
+            env.fromElements(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            env.execute("dedup second insert");
+            int rows = ClickHouseServerForTests.countRows(tableName);
+            Assertions.assertEquals(numRows, rows, "With dedup window, inserting the same data twice should be deduplicated");
+        }
     }
 
     @Test

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -391,8 +391,8 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
 
     /*
         In this test, we try sending an identical batch to ClickHouse twice under two different configurations:
-        1. non_replicated_deduplication_window=0 (default): block-level retry deduplication is disabled
-        2. non_replicated_deduplication_window=1: block-level retry deduplication is enabled
+        1. non_replicated_deduplication_window = 0 (default): block-level retry deduplication is disabled - this is a potential source of duplicates in the connector
+        2. non_replicated_deduplication_window > 0: block-level retry deduplication is enabled
 
         The goal of sending the same batch twice is to simulate a retry, which would happen in response to a retryable exception.
         We intentionally set the maxBatchSize to be greater than the number of rows being sent to ensure all rows fit in a single batch.

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/SimplePOJO.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/SimplePOJO.java
@@ -581,6 +581,12 @@ public class SimplePOJO {
         return createTable.trim().substring(0, createTable.trim().length() - 1) + " " + String.format("SETTINGS parts_to_throw_insert = %d;", partsToThrowInsert);
     }
 
+    public static String createTableSQLWithDedupWindow(String database, String tableName, int dedupWindow) {
+        String createTable = createTableSQL(database, tableName);
+        return createTable.trim().substring(0, createTable.trim().length() - 1)
+                + " " + String.format("SETTINGS non_replicated_deduplication_window = %d;", dedupWindow);
+    }
+
     public static String createTableSQL(String database, String tableName) {
         return "CREATE TABLE `" + database + "`.`" + tableName + "` (" +
                 "bytePrimitive Int8," +

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -403,8 +403,8 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
 
     /*
         In this test, we try sending an identical batch to ClickHouse twice under two different configurations:
-        1. non_replicated_deduplication_window=0 (default): block-level retry deduplication is disabled
-        2. non_replicated_deduplication_window=1: block-level retry deduplication is enabled
+        1. non_replicated_deduplication_window = 0 (default): block-level retry deduplication is disabled - this is a potential source of duplicates in the connector
+        2. non_replicated_deduplication_window > 0: block-level retry deduplication is enabled
 
         The goal of sending the same batch twice is to simulate a retry, which would happen in response to a retryable exception.
         We intentionally set the maxBatchSize to be greater than the number of rows being sent to ensure all rows fit in a single batch.

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -401,6 +401,74 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         //ClickHouseServerForTests.executeSql(String.format("SYSTEM START MERGES `%s.%s`", getDatabase(), tableName));
     }
 
+    /*
+        In this test, we try sending an identical batch to ClickHouse twice under two different configurations:
+            1. non_replicated_deduplication_window=0 (default): block-level retry deduplication is disabled
+            2. non_replicated_deduplication_window=1: block-level retry deduplication is enabled
+
+        The goal of sending the same batch twice is to simulate a retry, which would happen in response to a retryable exception.
+        We intentionally set the maxBatchSize to be greater than the number of rows being sent to ensure all rows fit in a single batch.
+        On the server side, this batch becomes a single block and its hash is flushed before the server responds. TODO: VERIFY THIS
+        We assert that if deduplication is disabled, the rows should appear twice when retried, and that if its enabled, the rows should appear only once.
+    */
+    @Test
+    void testDeduplicateOnRetry() throws Exception {
+        if (isCloud()) return; // non_replicated_deduplication_window only for non-replicated MergeTree
+
+        int numRows = 10;
+        // maxBatchSize > numRows ensures all rows are sent as one block (required for block-hash dedup)
+        int maxBatchSize = numRows * 2;
+
+        List<SimplePOJO> data = new ArrayList<>();
+        for (int i = 0; i < numRows; i++) data.add(new SimplePOJO(i));
+        SimplePOJO[] dataArray = data.toArray(new SimplePOJO[0]);
+
+        // scenario A: no dedup window (default=0) — inserting the same data twice produces duplicates
+        {
+            String tableName = "dedup_no_window_pojo";
+            ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQL(getDatabase(), tableName));
+            TableSchema schema = ClickHouseServerForTests.getTableSchema(tableName);
+            ClickHouseClientConfig config = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+            config.setSupportDefault(schema.hasDefaults());
+            ElementConverter<SimplePOJO, ClickHousePayload> converter = new ClickHouseConvertor<>(SimplePOJO.class, new SimplePOJOConvertor(schema.hasDefaults()));
+
+            StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
+            env.setParallelism(1);
+
+            // first insert; executeAsync clears transformations after compiling the graph
+            env.fromData(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            executeAsyncJob(env, tableName, 30, numRows);
+
+            // second insert of identical data (simulates a retry) — no dedup, expect duplicates
+            env.fromData(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            int rows = executeAsyncJob(env, tableName, 30, numRows * 2);
+            Assertions.assertEquals(numRows * 2, rows, "Without dedup window, inserting the same data twice should produce duplicates");
+        }
+
+        // scenario B: dedup window=100 — inserting the same data twice is deduplicated
+        {
+            String tableName = "dedup_with_window_pojo";
+            ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQLWithDedupWindow(getDatabase(), tableName, 100));
+            TableSchema schema = ClickHouseServerForTests.getTableSchema(tableName);
+            ClickHouseClientConfig config = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+            config.setSupportDefault(schema.hasDefaults());
+            ElementConverter<SimplePOJO, ClickHousePayload> converter = new ClickHouseConvertor<>(SimplePOJO.class, new SimplePOJOConvertor(schema.hasDefaults()));
+
+            StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
+            env.setParallelism(1);
+
+            // first insert
+            env.fromData(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            executeAsyncJob(env, tableName, 30, numRows);
+
+            // second insert of identical data (simulates a retry) — CH recognizes the same block hash, ignores it
+            env.fromData(dataArray).sinkTo(new ClickHouseAsyncSink<>(converter, maxBatchSize, MAX_IN_FLIGHT_REQUESTS, MAX_BUFFERED_REQUESTS, MAX_BATCH_SIZE_IN_BYTES, MAX_TIME_IN_BUFFER_MS, MAX_RECORD_SIZE_IN_BYTES, config));
+            env.execute("dedup second insert");
+            int rows = ClickHouseServerForTests.countRows(tableName);
+            Assertions.assertEquals(numRows, rows, "With dedup window, inserting the same data twice should be deduplicated");
+        }
+    }
+
     @Test
     void CheckClickHouseAlive() {
         Assertions.assertThrows(RuntimeException.class, () -> {

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -403,16 +403,16 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
 
     /*
         In this test, we try sending an identical batch to ClickHouse twice under two different configurations:
-            1. non_replicated_deduplication_window=0 (default): block-level retry deduplication is disabled
-            2. non_replicated_deduplication_window=1: block-level retry deduplication is enabled
+        1. non_replicated_deduplication_window=0 (default): block-level retry deduplication is disabled
+        2. non_replicated_deduplication_window=1: block-level retry deduplication is enabled
 
         The goal of sending the same batch twice is to simulate a retry, which would happen in response to a retryable exception.
         We intentionally set the maxBatchSize to be greater than the number of rows being sent to ensure all rows fit in a single batch.
-        On the server side, this batch becomes a single block and its hash is flushed before the server responds. TODO: VERIFY THIS
+        On the server side, this batch becomes a single block and its hash is flushed to the dedup log before the server responds.
         We assert that if deduplication is disabled, the rows should appear twice when retried, and that if its enabled, the rows should appear only once.
     */
     @Test
-    void testDeduplicateOnRetry() throws Exception {
+    void testDeduplicateOnRetryNonReplicated() throws Exception {
         if (isCloud()) return; // non_replicated_deduplication_window only for non-replicated MergeTree
 
         int numRows = 10;

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/SimplePOJO.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/SimplePOJO.java
@@ -581,6 +581,12 @@ public class SimplePOJO {
         return createTable.trim().substring(0, createTable.trim().length() - 1) + " " + String.format("SETTINGS parts_to_throw_insert = %d;", partsToThrowInsert);
     }
 
+    public static String createTableSQLWithDedupWindow(String database, String tableName, int dedupWindow) {
+        String createTable = createTableSQL(database, tableName);
+        return createTable.trim().substring(0, createTable.trim().length() - 1)
+                + " " + String.format("SETTINGS non_replicated_deduplication_window = %d;", dedupWindow);
+    }
+
     public static String createTableSQL(String database, String tableName) {
         return "CREATE TABLE `" + database + "`.`" + tableName + "` (" +
                 "bytePrimitive Int8," +


### PR DESCRIPTION
## Summary
Validate that retry deduplication occurs when `non_replicated_deduplication_window` > 0. By default, `non_replicated_deduplication_window=0`, which is a potential source of duplicates.

Closes https://github.com/ClickHouse/flink-connector-clickhouse/issues/121

## Checklist
Delete items not relevant to your PR:
- [x] Closes #121 
- [x] Unit and integration tests covering the common scenarios were added
