### PR TITLE
Allow users to set BatchFailureStrategy and add handling for additional retryable IOException messages

### DIFF
--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
@@ -45,8 +45,8 @@ public class ClickHouseAsyncWriter<InputT>
     private final ClickHouseClientConfig clickHouseClientConfig;
     private final ClickHouseConvertor<InputT> convertor;
     private final ClickHouseFormat clickHouseFormat;          // for STRING mode only
-    private RetryPolicy retryPolicy = RetryPolicy.forever();
-    private final BatchFailureStrategy batchFailureStrategy = BatchFailureStrategy.STOP_FLINK;
+    private final RetryPolicy retryPolicy;
+    private final BatchFailureStrategy batchFailureStrategy;
 
     private final boolean typedMode;
     private final byte[] namesAndTypesHeader;                 // null in STRING mode
@@ -68,7 +68,6 @@ public class ClickHouseAsyncWriter<InputT>
                                  long maxBatchSizeInBytes,
                                  long maxTimeInBufferMS,
                                  long maxRecordSizeInBytes,
-                                 RetryPolicy retryPolicy,
                                  ClickHouseClientConfig clickHouseClientConfig,
                                  ClickHouseFormat clickHouseFormat,
                                  Collection<BufferedRequestState<ClickHousePayload>> state) {
@@ -92,7 +91,8 @@ public class ClickHouseAsyncWriter<InputT>
         this.convertor = (ClickHouseConvertor<InputT>) elementConverter;
         this.clickHouseClientConfig = clickHouseClientConfig;
         this.clickHouseFormat = clickHouseFormat;
-        this.retryPolicy = retryPolicy;
+        this.retryPolicy = clickHouseClientConfig.getRetryPolicy();
+        this.batchFailureStrategy = clickHouseClientConfig.getBatchFailureStrategy();
         this.typedMode = !this.convertor.isStringMode();
 
         if (typedMode) {
@@ -116,23 +116,6 @@ public class ClickHouseAsyncWriter<InputT>
                 new DescriptiveStatisticsHistogram(1000));
         this.writeFailureLatencyHistogram = metricGroup.histogram("writeFailureLatencyHistogram",
                 new DescriptiveStatisticsHistogram(1000));
-    }
-
-    public ClickHouseAsyncWriter(ElementConverter<InputT, ClickHousePayload> elementConverter,
-                                 Sink.InitContext context,
-                                 int maxBatchSize,
-                                 int maxInFlightRequests,
-                                 int maxBufferedRequests,
-                                 long maxBatchSizeInBytes,
-                                 long maxTimeInBufferMS,
-                                 long maxRecordSizeInBytes,
-                                 ClickHouseClientConfig clickHouseClientConfig,
-                                 ClickHouseFormat clickHouseFormat,
-                                 Collection<BufferedRequestState<ClickHousePayload>> state) {
-        this(elementConverter, context, maxBatchSize, maxInFlightRequests, maxBufferedRequests,
-             maxBatchSizeInBytes, maxTimeInBufferMS, maxRecordSizeInBytes,
-             clickHouseClientConfig.getRetryPolicy(),
-             clickHouseClientConfig, clickHouseFormat, state);
     }
 
     private static byte[] buildHeader(List<ColumnBinding> bindings) {

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
@@ -2,6 +2,7 @@ package org.apache.flink.connector.clickhouse.sink;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.config.BatchFailureStrategy;
 import com.clickhouse.config.RetryPolicy;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.slf4j.Logger;
@@ -30,8 +31,8 @@ public class ClickHouseClientConfig implements Serializable {
     private final Map<String, String> serverSettings;
     private boolean enableJsonSupportAsString = true;
     private transient Client client = null;
-    private int numberOfRetries = DEFAULT_MAX_RETRIES;
     private RetryPolicy retryPolicy = RetryPolicy.forever();
+    private BatchFailureStrategy batchFailureStrategy = BatchFailureStrategy.STOP_FLINK;
 
     public ClickHouseClientConfig(String url, String username, String password, String database, String tableName, Map<String, String> options, Map<String, String> serverSettings, boolean enableJsonSupportAsString) {
         this.url = url;
@@ -47,10 +48,12 @@ public class ClickHouseClientConfig implements Serializable {
         Client clientTmp = initClient(database);
 
         boolean isServerAlive = false;
-        for (int i = 0; i < numberOfRetries && !isServerAlive; i++) {
+        for (int i = 0; i < retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES) && !isServerAlive; i++) {
             isServerAlive = clientTmp.ping();
             if (!isServerAlive) {
-                LOG.warn("Ping failed, number of will {} retry in {} seconds.", numberOfRetries, 1);
+                LOG.warn(
+                    "Ping failed, number of will {} retry in {} seconds.",
+                    retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES), 1);
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException ignored) {
@@ -122,8 +125,17 @@ public class ClickHouseClientConfig implements Serializable {
         }
     }
 
+    public RetryPolicy getRetryPolicy() { return retryPolicy; }
+
     public void setRetryPolicy(RetryPolicy retryPolicy) {
         this.retryPolicy = Objects.requireNonNull(retryPolicy, "retryPolicy must not be null");
+    }
+
+    public BatchFailureStrategy getBatchFailureStrategy() { return batchFailureStrategy; }
+
+    public void setBatchFailureStrategy(BatchFailureStrategy batchFailureStrategy) {
+        this.batchFailureStrategy = Objects.requireNonNull(
+            batchFailureStrategy,"batchFailureStrategy must not be null");
     }
 
     public void setEnableJsonSupportAsString(boolean enableJsonSupportAsString) {
@@ -132,5 +144,4 @@ public class ClickHouseClientConfig implements Serializable {
 
     public Boolean getEnableJsonSupportAsString() { return  enableJsonSupportAsString; }
 
-    public RetryPolicy getRetryPolicy() { return retryPolicy; }
 }

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
@@ -52,7 +52,7 @@ public class ClickHouseClientConfig implements Serializable {
             isServerAlive = clientTmp.ping();
             if (!isServerAlive) {
                 LOG.warn(
-                    "Ping failed, number of will {} retry in {} seconds.",
+                    "Ping failed; will retry up to {} times in {} seconds.",
                     retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES), 1);
                 try {
                     Thread.sleep(1000);

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -1,6 +1,7 @@
 package org.apache.flink.connector.clickhouse.sink;
 
 import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.config.BatchFailureStrategy;
 import com.clickhouse.config.RetryPolicy;
 import com.clickhouse.data.ClickHouseFormat;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -418,6 +419,29 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         Assertions.assertThrows(RuntimeException.class, () -> {
             new ClickHouseClientConfig(getServerURL(), getUsername() + "wrong_username", getPassword(), getDatabase(), "dummy");
         });
+    }
+
+    @Test
+    void BatchFailureStrategyDefaultIsStopFlink() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), "dummy");
+        Assertions.assertEquals(BatchFailureStrategy.STOP_FLINK, config.getBatchFailureStrategy());
+    }
+
+    @Test
+    void BatchFailureStrategyCanBeOverridden() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), "dummy");
+        config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+        Assertions.assertEquals(BatchFailureStrategy.DROP_BATCH, config.getBatchFailureStrategy());
+    }
+
+    @Test
+    void BatchFailureStrategyNullThrowsNpe() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), "dummy");
+        Assertions.assertThrows(NullPointerException.class,
+                () -> config.setBatchFailureStrategy(null));
     }
 
     @Test
@@ -933,6 +957,127 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         Assertions.assertFalse(
                 chainContainsAny(thrown, RetriableException.class, DataCorruptionException.class),
                 "Cause chain should not contain RetriableException or DataCorruptionException");
+    }
+
+    @Test
+    void DropBatchStrategyJobSucceedsOnAllCorruptBatches() throws Exception {
+        String tableName = "drop_batch_all_corrupt";
+        ClickHouseServerForTests.executeSql(
+                "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` " +
+                "(date Date, location_key String, value Int32) " +
+                "ENGINE = MergeTree ORDER BY (location_key, date)");
+
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+
+        ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setMaxBatchSize(10)
+                .setMaxInFlightRequests(1)
+                .setMaxBufferedRequests(200)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(config)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .build();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,100", i));
+        }
+        env.fromElements(records.toArray(new String[0])).sinkTo(sink);
+
+        Assertions.assertDoesNotThrow(() -> env.execute("drop-batch-all-corrupt"));
+        Assertions.assertEquals(0, ClickHouseServerForTests.countRows(tableName),
+                "All batches should have been dropped — 0 rows expected");
+    }
+
+    @Test
+    void StopFlinkStrategyFailsJobOnCorruptBatches() throws Exception {
+        String tableName = "stop_flink_all_corrupt";
+        ClickHouseServerForTests.executeSql(
+                "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` " +
+                "(date Date, location_key String, value Int32) " +
+                "ENGINE = MergeTree ORDER BY (location_key, date)");
+
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        // default: batchFailureStrategy = STOP_FLINK
+
+        ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setMaxBatchSize(10)
+                .setMaxInFlightRequests(1)
+                .setMaxBufferedRequests(200)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(config)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .build();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,100", i));
+        }
+        env.fromElements(records.toArray(new String[0])).sinkTo(sink);
+
+        Exception thrown = Assertions.assertThrows(Exception.class,
+                () -> env.execute("stop-flink-all-corrupt"));
+        Assertions.assertTrue(
+                chainContainsExact(thrown, DataCorruptionException.class),
+                "Expected DataCorruptionException in cause chain, got: " + thrown);
+    }
+
+    @Test
+    void DropBatchPreservesGoodBatchesAndDropsCorruptBatch() throws Exception {
+        String tableName = "drop_batch_mixed";
+        ClickHouseServerForTests.executeSql(
+                "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` " +
+                "(date Date, location_key String, value Int32) " +
+                "ENGINE = MergeTree ORDER BY (location_key, date)");
+
+        int batchSize = 25;
+
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+
+        ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setMaxBatchSize(batchSize)
+                .setMaxInFlightRequests(1)
+                .setMaxBufferedRequests(200)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(config)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .build();
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(1);
+
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < batchSize; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,100", i));
+        }
+        for (int i = 0; i < batchSize; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,not_a_number", i));
+        }
+        env.fromElements(records.toArray(new String[0])).sinkTo(sink);
+
+        Assertions.assertDoesNotThrow(() -> env.execute("drop-batch-mixed"));
+        Assertions.assertEquals(batchSize, ClickHouseServerForTests.countRows(tableName),
+                "Good batch should be preserved; corrupt batch should be dropped");
     }
 
     private static boolean chainContainsExact(Throwable t, Class<? extends Throwable> exactClass) {

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -980,7 +980,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 .setMaxTimeInBufferMS(1000)
                 .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
                 .setClickHouseClientConfig(config)
-                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .setClickHouseFormat(ClickHouseFormat.JSONEachRow)
                 .build();
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -1018,7 +1018,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 .setMaxTimeInBufferMS(1000)
                 .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
                 .setClickHouseClientConfig(config)
-                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .setClickHouseFormat(ClickHouseFormat.JSONEachRow)
                 .build();
 
         final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncWriter.java
@@ -44,8 +44,8 @@ public class ClickHouseAsyncWriter<InputT>
     private final ClickHouseClientConfig clickHouseClientConfig;
     private final ClickHouseConvertor<InputT> convertor;
     private final ClickHouseFormat clickHouseFormat;          // for STRING mode only
-    private RetryPolicy retryPolicy = RetryPolicy.forever();
-    private final BatchFailureStrategy batchFailureStrategy = BatchFailureStrategy.STOP_FLINK;
+    private final RetryPolicy retryPolicy;
+    private final BatchFailureStrategy batchFailureStrategy;
 
     private final boolean typedMode;
     private final byte[] namesAndTypesHeader;                 // null in STRING mode
@@ -67,7 +67,6 @@ public class ClickHouseAsyncWriter<InputT>
                                  long maxBatchSizeInBytes,
                                  long maxTimeInBufferMS,
                                  long maxRecordSizeInBytes,
-                                 RetryPolicy retryPolicy,
                                  ClickHouseClientConfig clickHouseClientConfig,
                                  ClickHouseFormat clickHouseFormat,
                                  Collection<BufferedRequestState<ClickHousePayload>> state) {
@@ -91,7 +90,8 @@ public class ClickHouseAsyncWriter<InputT>
         this.convertor = (ClickHouseConvertor<InputT>) elementConverter;
         this.clickHouseClientConfig = clickHouseClientConfig;
         this.clickHouseFormat = clickHouseFormat;
-        this.retryPolicy = retryPolicy;
+        this.retryPolicy = clickHouseClientConfig.getRetryPolicy();
+        this.batchFailureStrategy = clickHouseClientConfig.getBatchFailureStrategy();
         this.typedMode = !this.convertor.isStringMode();
 
         if (typedMode) {
@@ -115,23 +115,6 @@ public class ClickHouseAsyncWriter<InputT>
                 new DescriptiveStatisticsHistogram(1000));
         this.writeFailureLatencyHistogram = metricGroup.histogram("writeFailureLatencyHistogram",
                 new DescriptiveStatisticsHistogram(1000));
-    }
-
-    public ClickHouseAsyncWriter(ElementConverter<InputT, ClickHousePayload> elementConverter,
-                                 WriterInitContext context,
-                                 int maxBatchSize,
-                                 int maxInFlightRequests,
-                                 int maxBufferedRequests,
-                                 long maxBatchSizeInBytes,
-                                 long maxTimeInBufferMS,
-                                 long maxRecordSizeInBytes,
-                                 ClickHouseClientConfig clickHouseClientConfig,
-                                 ClickHouseFormat clickHouseFormat,
-                                 Collection<BufferedRequestState<ClickHousePayload>> state) {
-        this(elementConverter, context, maxBatchSize, maxInFlightRequests, maxBufferedRequests,
-             maxBatchSizeInBytes, maxTimeInBufferMS, maxRecordSizeInBytes,
-             clickHouseClientConfig.getRetryPolicy(),
-             clickHouseClientConfig, clickHouseFormat, state);
     }
 
     private static byte[] buildHeader(List<ColumnBinding> bindings) {

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
@@ -52,7 +52,7 @@ public class ClickHouseClientConfig implements Serializable {
             isServerAlive = clientTmp.ping();
             if (!isServerAlive) {
                 LOG.warn(
-                        "Ping failed, number of will {} retry in {} seconds.",
+                        "Ping failed; will retry up to {} times in {} seconds.",
                         retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES), 1);
                 try {
                     Thread.sleep(1000);

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
@@ -2,6 +2,7 @@ package org.apache.flink.connector.clickhouse.sink;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.config.BatchFailureStrategy;
 import com.clickhouse.config.RetryPolicy;
 import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.slf4j.Logger;
@@ -30,8 +31,8 @@ public class ClickHouseClientConfig implements Serializable {
     private final Map<String, String> serverSettings;
     private boolean enableJsonSupportAsString = true;
     private transient Client client = null;
-    private int numberOfRetries = DEFAULT_MAX_RETRIES;
     private RetryPolicy retryPolicy = RetryPolicy.forever();
+    private BatchFailureStrategy batchFailureStrategy = BatchFailureStrategy.STOP_FLINK;
 
     public ClickHouseClientConfig(String url, String username, String password, String database, String tableName, Map<String, String> options, Map<String, String> serverSettings, boolean enableJsonSupportAsString) {
         this.url = url;
@@ -47,10 +48,12 @@ public class ClickHouseClientConfig implements Serializable {
         Client clientTmp = initClient(database);
 
         boolean isServerAlive = false;
-        for (int i = 0; i < numberOfRetries && !isServerAlive; i++) {
+        for (int i = 0; i < retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES) && !isServerAlive; i++) {
             isServerAlive = clientTmp.ping();
             if (!isServerAlive) {
-                LOG.warn("Ping failed, number of will {} retry in {} seconds.", numberOfRetries, 1);
+                LOG.warn(
+                        "Ping failed, number of will {} retry in {} seconds.",
+                        retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES), 1);
                 try {
                     Thread.sleep(1000);
                 } catch (InterruptedException ignored) {
@@ -122,10 +125,18 @@ public class ClickHouseClientConfig implements Serializable {
         }
     }
 
+    public RetryPolicy getRetryPolicy() { return retryPolicy; }
+
     public void setRetryPolicy(RetryPolicy retryPolicy) {
         this.retryPolicy = Objects.requireNonNull(retryPolicy, "retryPolicy must not be null");
     }
 
+    public BatchFailureStrategy getBatchFailureStrategy() { return batchFailureStrategy; }
+
+    public void setBatchFailureStrategy(BatchFailureStrategy batchFailureStrategy) {
+        this.batchFailureStrategy = Objects.requireNonNull(
+                batchFailureStrategy,"batchFailureStrategy must not be null");
+    }
 
     public void setEnableJsonSupportAsString(boolean enableJsonSupportAsString) {
         this.enableJsonSupportAsString = enableJsonSupportAsString;
@@ -133,5 +144,4 @@ public class ClickHouseClientConfig implements Serializable {
 
     public Boolean getEnableJsonSupportAsString() { return  enableJsonSupportAsString; }
 
-    public RetryPolicy getRetryPolicy() { return retryPolicy; }
 }

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -274,7 +274,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
                 .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
                 .setClickHouseClientConfig(clickHouseClientConfig)
-                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .setClickHouseFormat(ClickHouseFormat.JSONEachRow)
                 .build();
 
         Path filePath = new Path("./src/test/resources/epidemiology_top_10000.csv.gz");
@@ -994,7 +994,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
         config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
 
-        // TSV format for CSV-formatted data → every INSERT fails with DataCorruptionException
+        // JSONEachRow format for CSV-formatted data → every INSERT fails with DataCorruptionException
         ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
                 .setElementConverter(new ClickHouseConvertor<>(String.class))
                 .setMaxBatchSize(10)
@@ -1004,7 +1004,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 .setMaxTimeInBufferMS(1000)
                 .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
                 .setClickHouseClientConfig(config)
-                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .setClickHouseFormat(ClickHouseFormat.JSONEachRow)
                 .build();
 
         final StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
@@ -1047,7 +1047,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 .setMaxTimeInBufferMS(1000)
                 .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
                 .setClickHouseClientConfig(config)
-                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .setClickHouseFormat(ClickHouseFormat.JSONEachRow)
                 .build();
 
         final StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -1,6 +1,7 @@
 package org.apache.flink.connector.clickhouse.sink;
 
 import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.config.BatchFailureStrategy;
 import com.clickhouse.config.RetryPolicy;
 import com.clickhouse.data.ClickHouseFormat;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -273,7 +274,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
                 .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
                 .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
                 .setClickHouseClientConfig(clickHouseClientConfig)
-                .setClickHouseFormat(ClickHouseFormat.TSV)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
                 .build();
 
         Path filePath = new Path("./src/test/resources/epidemiology_top_10000.csv.gz");
@@ -430,6 +431,29 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         Assertions.assertThrows(RuntimeException.class, () -> {
             new ClickHouseClientConfig(getServerURL(), getUsername() + "wrong_username", getPassword(), getDatabase(), "dummy");
         });
+    }
+
+    @Test
+    void BatchFailureStrategyDefaultIsStopFlink() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), "dummy");
+        Assertions.assertEquals(BatchFailureStrategy.STOP_FLINK, config.getBatchFailureStrategy());
+    }
+
+    @Test
+    void BatchFailureStrategyCanBeOverridden() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), "dummy");
+        config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+        Assertions.assertEquals(BatchFailureStrategy.DROP_BATCH, config.getBatchFailureStrategy());
+    }
+
+    @Test
+    void BatchFailureStrategyNullThrowsNpe() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), "dummy");
+        Assertions.assertThrows(NullPointerException.class,
+                () -> config.setBatchFailureStrategy(null));
     }
 
     @Test
@@ -951,6 +975,149 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         Assertions.assertFalse(
                 chainContainsAny(thrown, RetriableException.class, DataCorruptionException.class),
                 "Cause chain should not contain RetriableException or DataCorruptionException");
+    }
+
+    /*
+        DROP_BATCH: when a batch fails with DataCorruptionException and the strategy
+        is DROP_BATCH, the connector calls resultHandler.complete() (not completeExceptionally),
+        so the Flink job continues and finishes normally. The batch is silently discarded.
+    */
+    @Test
+    void DropBatchStrategyJobSucceedsOnAllCorruptBatches() throws Exception {
+        String tableName = "drop_batch_all_corrupt";
+        ClickHouseServerForTests.executeSql(
+                "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` " +
+                "(date Date, location_key String, value Int32) " +
+                "ENGINE = MergeTree ORDER BY (location_key, date)");
+
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+
+        // TSV format for CSV-formatted data → every INSERT fails with DataCorruptionException
+        ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setMaxBatchSize(10)
+                .setMaxInFlightRequests(1)
+                .setMaxBufferedRequests(200)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(config)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .build();
+
+        final StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
+        env.setParallelism(1);
+
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,100", i));
+        }
+        env.fromData(records.toArray(new String[0])).sinkTo(sink);
+
+        // DROP_BATCH lets the job finish — no exception even though all batches were corrupt
+        Assertions.assertDoesNotThrow(() -> env.execute("drop-batch-all-corrupt"));
+        Assertions.assertEquals(0, ClickHouseServerForTests.countRows(tableName),
+                "All batches should have been dropped — 0 rows expected");
+    }
+
+    /*
+        Contrast to DropBatchStrategyJobSucceedsOnAllCorruptBatches: STOP_FLINK (the
+        default) propagates the DataCorruptionException and fails the job.
+    */
+    @Test
+    void StopFlinkStrategyFailsJobOnCorruptBatches() throws Exception {
+        String tableName = "stop_flink_all_corrupt";
+        ClickHouseServerForTests.executeSql(
+                "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` " +
+                "(date Date, location_key String, value Int32) " +
+                "ENGINE = MergeTree ORDER BY (location_key, date)");
+
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        // default: batchFailureStrategy = STOP_FLINK
+
+        ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setMaxBatchSize(10)
+                .setMaxInFlightRequests(1)
+                .setMaxBufferedRequests(200)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(config)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .build();
+
+        final StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
+        env.setParallelism(1);
+
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,100", i));
+        }
+        env.fromData(records.toArray(new String[0])).sinkTo(sink);
+
+        Exception thrown = Assertions.assertThrows(Exception.class,
+                () -> env.execute("stop-flink-all-corrupt"));
+        Assertions.assertTrue(
+                chainContainsExact(thrown, DataCorruptionException.class),
+                "Expected DataCorruptionException in cause chain, got: " + thrown);
+    }
+
+    /*
+        DROP_BATCH with mixed good and corrupt batches: good batches land in ClickHouse
+        while corrupt batches are silently discarded.  The first batchSize records are
+        valid CSV; the next batchSize have an invalid Int32 field (CANNOT_PARSE_NUMBER,
+        error code 72 → DataCorruptionException).  With maxInFlightRequests=1 and
+        parallelism=1, the good batch is submitted and confirmed before the corrupt one.
+    */
+    @Test
+    void DropBatchPreservesGoodBatchesAndDropsCorruptBatch() throws Exception {
+        String tableName = "drop_batch_mixed";
+        ClickHouseServerForTests.executeSql(
+                "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` " +
+                "(date Date, location_key String, value Int32) " +
+                "ENGINE = MergeTree ORDER BY (location_key, date)");
+
+        int batchSize = 25;
+
+        ClickHouseClientConfig config = new ClickHouseClientConfig(
+                getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        config.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+
+        ClickHouseAsyncSink<String> sink = ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setMaxBatchSize(batchSize)
+                .setMaxInFlightRequests(1)
+                .setMaxBufferedRequests(200)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(1000)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(config)
+                .setClickHouseFormat(ClickHouseFormat.CSV)
+                .build();
+
+        final StreamExecutionEnvironment env = EmbeddedFlinkClusterForTests.getMiniCluster().getTestStreamEnvironment();
+        env.setParallelism(1);
+
+        // First batchSize records: valid CSV  → INSERT succeeds
+        // Next  batchSize records: invalid Int32 field → DataCorruptionException → DROP_BATCH
+        List<String> records = new ArrayList<>();
+        for (int i = 0; i < batchSize; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,100", i));
+        }
+        for (int i = 0; i < batchSize; i++) {
+            records.add(String.format("2020-01-01,loc_%02d,not_a_number", i));
+        }
+        env.fromData(records.toArray(new String[0])).sinkTo(sink);
+
+        // Job completes — DROP_BATCH absorbed the corrupt batch
+        Assertions.assertDoesNotThrow(() -> env.execute("drop-batch-mixed"));
+        // Only the good batch was written
+        Assertions.assertEquals(batchSize, ClickHouseServerForTests.countRows(tableName),
+                "Good batch should be preserved; corrupt batch should be dropped");
     }
 
     private static boolean chainContainsExact(Throwable t, Class<? extends Throwable> exactClass) {

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/Utils.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/Utils.java
@@ -82,7 +82,9 @@ public class Utils {
         } else if (rootCause instanceof IOException) {
             final String msg = rootCause.getMessage();
             LOG.warn("Deciding how to handle IOException thrown with message: {}", msg);
-            if (msg.indexOf(CLICKHOUSE_CLIENT_ERROR_READ_TIMEOUT_MSG) == 0 ||
+            if (msg == null) { 
+                // Do nothing. neccessary check to prevent null pointer exceptions
+            } else if (msg.indexOf(CLICKHOUSE_CLIENT_ERROR_READ_TIMEOUT_MSG) == 0 ||
                 msg.indexOf(CLICKHOUSE_CLIENT_ERROR_WRITE_TIMEOUT_MSG) == 0 ||
                 msg.indexOf(CLICKHOUSE_CLIENT_ERROR_INSERT_MSG) > -1 ||
                 msg.indexOf(CLICKHOUSE_CLIENT_ERROR_RESET_CONNECTION_MSG) > -1 ||

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/Utils.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/Utils.java
@@ -10,13 +10,17 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.SocketTimeoutException;
-import java.net.UnknownHostException;
 
 public class Utils {
 
     private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
     private static final String CLICKHOUSE_CLIENT_ERROR_READ_TIMEOUT_MSG = "Read timed out after";
     private static final String CLICKHOUSE_CLIENT_ERROR_WRITE_TIMEOUT_MSG = "Write timed out after";
+    // occasional IO failures should be retried
+    private static final String CLICKHOUSE_CLIENT_ERROR_INSERT_MSG = "Insert failed";
+    private static final String CLICKHOUSE_CLIENT_ERROR_RESET_CONNECTION_MSG = "Connection reset by peer";
+    private static final String CLICKHOUSE_CLIENT_ERROR_BROKEN_PIPE_MSG = "Broken pipe";
+    private static final String CLICKHOUSE_CLIENT_ERROR_CONNECTION_TIMEOUT_MSG = "Connection timed out";
 
     /**
      * This will drill down to the first ServerException in the exception chain
@@ -77,7 +81,13 @@ public class Utils {
             throw new RetriableException(e);
         } else if (rootCause instanceof IOException) {
             final String msg = rootCause.getMessage();
-            if (msg.indexOf(CLICKHOUSE_CLIENT_ERROR_READ_TIMEOUT_MSG) == 0 || msg.indexOf(CLICKHOUSE_CLIENT_ERROR_WRITE_TIMEOUT_MSG) == 0) {
+            LOG.warn("Deciding how to handle IOException thrown with message: {}", msg);
+            if (msg.indexOf(CLICKHOUSE_CLIENT_ERROR_READ_TIMEOUT_MSG) == 0 ||
+                msg.indexOf(CLICKHOUSE_CLIENT_ERROR_WRITE_TIMEOUT_MSG) == 0 ||
+                msg.indexOf(CLICKHOUSE_CLIENT_ERROR_INSERT_MSG) > -1 ||
+                msg.indexOf(CLICKHOUSE_CLIENT_ERROR_RESET_CONNECTION_MSG) > -1 ||
+                msg.indexOf(CLICKHOUSE_CLIENT_ERROR_BROKEN_PIPE_MSG) > -1 ||
+                msg.indexOf(CLICKHOUSE_CLIENT_ERROR_CONNECTION_TIMEOUT_MSG) > -1) {
                 LOG.warn("IOException thrown, wrapping exception: {}", e.getLocalizedMessage());
                 throw new RetriableException(e);
             }

--- a/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/UtilsTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/UtilsTest.java
@@ -1,0 +1,67 @@
+package com.clickhouse.utils;
+
+import org.apache.flink.connector.clickhouse.exception.FlinkWriteException;
+import org.apache.flink.connector.clickhouse.exception.RetriableException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class UtilsTest {
+
+    private static IOException ioException(String message) {
+        return new IOException(message);
+    }
+
+    @Test void readTimedOutIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Read timed out after 5000ms")));
+    }
+
+    @Test void writeTimedOutIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Write timed out after 5000ms")));
+    }
+
+    @Test void insertFailedIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Insert failed: connection dropped")));
+    }
+
+    @Test void insertFailedAsSuffixIsRetriable() {
+        // "Insert failed" is a substring check (> -1), not a starts-with check
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Batch Insert failed")));
+    }
+
+    @Test void connectionResetByPeerIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Connection reset by peer")));
+    }
+
+    @Test void brokenPipeIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Broken pipe")));
+    }
+
+    @Test void connectionTimedOutIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("Connection timed out")));
+    }
+
+    @Test void connectionTimedOutAsSuffixIsRetriable() {
+        assertThrows(RetriableException.class,
+                () -> Utils.handleException(ioException("java.net.SocketException: Connection timed out")));
+    }
+
+    @Test void unknownIoExceptionMessageThrowsFlinkWriteException() {
+        assertThrows(FlinkWriteException.class,
+                () -> Utils.handleException(ioException("Some unexpected IO error")));
+    }
+
+    @Test void wrappedInsertFailedIsRetriable() {
+        RuntimeException wrapper = new RuntimeException(ioException("Insert failed: timeout"));
+        assertThrows(RetriableException.class, () -> Utils.handleException(wrapper));
+    }
+}


### PR DESCRIPTION
* Allow users to set batchRetryStrategy
* Set defaults in clickhouseClientConfig class instead of within the sink
* Extends list of known IOException messages which should be retried

## Summary
<!-- A short description of the changes with a link to an open issue. -->

Closes <!-- Link to an issue to close on merge. -->
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
