### PR TITLE
Fix state serializer size mismatch causing checkpoint restore failures

### DIFF
--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -1,6 +1,7 @@
 package org.apache.flink.connector.clickhouse.sink;
 
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,49 +9,60 @@ import org.slf4j.LoggerFactory;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 
 public class ClickHouseAsyncSinkSerializer extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseAsyncSinkSerializer.class);
+
     private static final int V1 = 1;
-    @Override
-    protected void serializeRequestToStream(ClickHousePayload clickHousePayload, DataOutputStream dataOutputStream) throws IOException {
-        byte[] bytes = clickHousePayload.getPayload();
-        if (bytes != null) {
-            dataOutputStream.writeInt(V1);
-            dataOutputStream.writeInt(bytes.length);
-            dataOutputStream.write(bytes);
-        } else {
-            dataOutputStream.writeInt(V1);
-            dataOutputStream.writeInt(-1);
-        }
-
-    }
-
-    private ClickHousePayload deserializeV1(DataInputStream dataInputStream) throws IOException {
-        int len = dataInputStream.readInt();
-        if (len == -1) {
-            return new ClickHousePayload(null);
-        }
-        byte[] payload = dataInputStream.readNBytes(len);
-        return new ClickHousePayload(payload);
-    }
-
-    @Override
-    protected ClickHousePayload deserializeRequestFromStream(long requestSize, DataInputStream dataInputStream) throws IOException {
-        if  (requestSize > 0) {
-            int version = dataInputStream.readInt();
-            if (version == V1) {
-                return deserializeV1(dataInputStream);
-            } else {
-                throw new IOException("Unsupported serialization version: " + version);
-            }
-        } else {
-            throw new IOException("Invalid request size: " + requestSize);
-        }
-    }
+    private static final int V2 = 2;
+    private static final int NULL_PAYLOAD_LENGTH = -1;
 
     @Override
     public int getVersion() {
-        return V1;
+        return V2;
+    }
+
+    @Override
+    protected void serializeRequestToStream(ClickHousePayload payload, DataOutputStream out) throws IOException {
+        byte[] bytes = payload.getPayload();
+        if (bytes == null) {
+            out.writeInt(NULL_PAYLOAD_LENGTH);
+            return;
+        }
+        out.writeInt(bytes.length);
+        out.write(bytes);
+    }
+
+    @Override
+    protected ClickHousePayload deserializeRequestFromStream(long requestSize, DataInputStream in) throws IOException {
+        int length = in.readInt();
+        if (length == NULL_PAYLOAD_LENGTH) {
+            return new ClickHousePayload(null);
+        }
+        if (length < 0) {
+            throw new IOException("Invalid ClickHouse payload length: " + length);
+        }
+        byte[] bytes = in.readNBytes(length);
+        if (bytes.length != length) {
+            throw new IOException(
+                    "Truncated ClickHouse payload: expected " + length + " bytes, got " + bytes.length);
+        }
+        return new ClickHousePayload(bytes);
+    }
+
+    /**
+     * Discards checkpoints written by the broken V1 serializer to prevent
+     * restore loops. Everything else delegates to the base implementation.
+     */
+    @Override
+    public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized) throws IOException {
+        if (version == V1) {
+            LOG.warn("Discarding ClickHouse sink state from version {} ({} bytes). "
+                            + "Records will be re-emitted from the source.",
+                    V1, serialized.length);
+            return new BufferedRequestState<>(Collections.emptyList());
+        }
+        return super.deserialize(version, serialized);
     }
 }

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -51,10 +51,6 @@ public class ClickHouseAsyncSinkSerializer extends AsyncSinkWriterStateSerialize
         return new ClickHousePayload(bytes);
     }
 
-    /**
-     * Discards checkpoints written by the broken V1 serializer to prevent
-     * restore loops. Everything else delegates to the base implementation.
-     */
     @Override
     public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized) throws IOException {
         if (version == V1) {

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -1,5 +1,6 @@
 package org.apache.flink.connector.clickhouse.sink;
 
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,41 +19,87 @@ public class ClickHouseSinkStateTests {
         ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
         serializer.serializeRequestToStream(clickHousePayload, dos);
         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-
-        ClickHousePayload clickHousePayload1 = serializer.deserializeRequestFromStream(dos.size(), dis);
-        Assertions.assertEquals(clickHousePayload.getPayloadLength(), clickHousePayload1.getPayloadLength());
-        Assertions.assertArrayEquals(clickHousePayload.getPayload(), clickHousePayload1.getPayload());
+        ClickHousePayload deserialized = serializer.deserializeRequestFromStream(dos.size(), dis);
+        Assertions.assertEquals(clickHousePayload.getPayloadLength(), deserialized.getPayloadLength());
+        Assertions.assertArrayEquals(clickHousePayload.getPayload(), deserialized.getPayload());
     }
 
     @Test
-    void testSerializeAndDeserializeEmptyPayload() throws Exception {
+    void testSerializeAndDeserializeNullPayload() throws Exception {
         ClickHousePayload clickHousePayload = new ClickHousePayload(null);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
         ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
         serializer.serializeRequestToStream(clickHousePayload, dos);
         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-        ClickHousePayload clickHousePayload1 = serializer.deserializeRequestFromStream(dos.size(), dis);
-        Assertions.assertEquals(clickHousePayload.getPayloadLength(), clickHousePayload1.getPayloadLength());
-        Assertions.assertArrayEquals(clickHousePayload.getPayload(), clickHousePayload1.getPayload());
+        ClickHousePayload deserialized = serializer.deserializeRequestFromStream(dos.size(), dis);
+        Assertions.assertEquals(clickHousePayload.getPayloadLength(), deserialized.getPayloadLength());
+        Assertions.assertArrayEquals(clickHousePayload.getPayload(), deserialized.getPayload());
     }
 
     @Test
-    void testDeserializePayloadWithUnsuportedVersion() throws IOException {
-        byte[] data = {'H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd'};
+    void testSerializedSizeMatchesGetPayloadLength() throws Exception {
+        byte[] data = "test-payload".getBytes();
+        ClickHousePayload payload = new ClickHousePayload(data);
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
-        DataOutputStream dataOutputStream = new DataOutputStream(baos);
-        int V2 = 2;
-        dataOutputStream.writeInt(V2);
-        dataOutputStream.writeInt(data.length);
-        dataOutputStream.write(data);
-        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+        serializer.serializeRequestToStream(payload, dos);
+
+        Assertions.assertEquals(4 + data.length, baos.size());
+    }
+
+    @Test
+    void testMultipleEntriesDeserializeCorrectly() throws Exception {
+        byte[] data1 = "first".getBytes();
+        byte[] data2 = "second-longer-payload".getBytes();
+        byte[] data3 = "third".getBytes();
 
         ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+
+        ClickHousePayload p1 = new ClickHousePayload(data1);
+        ClickHousePayload p2 = new ClickHousePayload(data2);
+        ClickHousePayload p3 = new ClickHousePayload(data3);
+
+        serializer.serializeRequestToStream(p1, dos);
+        serializer.serializeRequestToStream(p2, dos);
+        serializer.serializeRequestToStream(p3, dos);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+
+        ClickHousePayload r1 = serializer.deserializeRequestFromStream(p1.getPayloadLength(), dis);
+        ClickHousePayload r2 = serializer.deserializeRequestFromStream(p2.getPayloadLength(), dis);
+        ClickHousePayload r3 = serializer.deserializeRequestFromStream(p3.getPayloadLength(), dis);
+
+        Assertions.assertArrayEquals(data1, r1.getPayload());
+        Assertions.assertArrayEquals(data2, r2.getPayload());
+        Assertions.assertArrayEquals(data3, r3.getPayload());
+    }
+
+    @Test
+    void testV1StateIsDiscardedOnDeserialize() throws Exception {
+        byte[] fakeV1State = new byte[]{0, 1, 2, 3, 4, 5};
+        ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+
+        BufferedRequestState<ClickHousePayload> result = serializer.deserialize(1, fakeV1State);
+        Assertions.assertTrue(result.getBufferedRequestEntries().isEmpty());
+    }
+
+    @Test
+    void testDeserializeWithNegativeLength() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeInt(-2); // invalid negative length (not -1 which means null)
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+
         Exception exception = Assertions.assertThrows(IOException.class, () -> {
-            serializer.deserializeRequestFromStream(dataOutputStream.size(), dis);
+            serializer.deserializeRequestFromStream(4, dis);
         });
-        Assertions.assertEquals("Unsupported serialization version: 2", exception.getMessage());
+        Assertions.assertTrue(exception.getMessage().contains("Invalid ClickHouse payload length"));
     }
 }

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -1,6 +1,7 @@
 package org.apache.flink.connector.clickhouse.sink;
 
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -8,49 +9,60 @@ import org.slf4j.LoggerFactory;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.Collections;
 
 public class ClickHouseAsyncSinkSerializer extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseAsyncSinkSerializer.class);
+
     private static final int V1 = 1;
-    @Override
-    protected void serializeRequestToStream(ClickHousePayload clickHousePayload, DataOutputStream dataOutputStream) throws IOException {
-        byte[] bytes = clickHousePayload.getPayload();
-        if (bytes != null) {
-            dataOutputStream.writeInt(V1);
-            dataOutputStream.writeInt(bytes.length);
-            dataOutputStream.write(bytes);
-        } else {
-            dataOutputStream.writeInt(V1);
-            dataOutputStream.writeInt(-1);
-        }
-
-    }
-
-    private ClickHousePayload deserializeV1(DataInputStream dataInputStream) throws IOException {
-        int len = dataInputStream.readInt();
-        if (len == -1) {
-            return new ClickHousePayload(null);
-        }
-        byte[] payload = dataInputStream.readNBytes(len);
-        return new ClickHousePayload(payload);
-    }
-
-    @Override
-    protected ClickHousePayload deserializeRequestFromStream(long requestSize, DataInputStream dataInputStream) throws IOException {
-        if  (requestSize > 0) {
-            int version = dataInputStream.readInt();
-            if (version == V1) {
-                return deserializeV1(dataInputStream);
-            } else {
-                throw new IOException("Unsupported serialization version: " + version);
-            }
-        } else {
-            throw new IOException("Invalid request size: " + requestSize);
-        }
-    }
+    private static final int V2 = 2;
+    private static final int NULL_PAYLOAD_LENGTH = -1;
 
     @Override
     public int getVersion() {
-        return V1;
+        return V2;
+    }
+
+    @Override
+    protected void serializeRequestToStream(ClickHousePayload payload, DataOutputStream out) throws IOException {
+        byte[] bytes = payload.getPayload();
+        if (bytes == null) {
+            out.writeInt(NULL_PAYLOAD_LENGTH);
+            return;
+        }
+        out.writeInt(bytes.length);
+        out.write(bytes);
+    }
+
+    @Override
+    protected ClickHousePayload deserializeRequestFromStream(long requestSize, DataInputStream in) throws IOException {
+        int length = in.readInt();
+        if (length == NULL_PAYLOAD_LENGTH) {
+            return new ClickHousePayload(null);
+        }
+        if (length < 0) {
+            throw new IOException("Invalid ClickHouse payload length: " + length);
+        }
+        byte[] bytes = in.readNBytes(length);
+        if (bytes.length != length) {
+            throw new IOException(
+                    "Truncated ClickHouse payload: expected " + length + " bytes, got " + bytes.length);
+        }
+        return new ClickHousePayload(bytes);
+    }
+
+    /**
+     * Discards checkpoints written by the broken V1 serializer to prevent
+     * restore loops. Everything else delegates to the base implementation.
+     */
+    @Override
+    public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized) throws IOException {
+        if (version == V1) {
+            LOG.warn("Discarding ClickHouse sink state from version {} ({} bytes). "
+                            + "Records will be re-emitted from the source.",
+                    V1, serialized.length);
+            return new BufferedRequestState<>(Collections.emptyList());
+        }
+        return super.deserialize(version, serialized);
     }
 }

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -51,10 +51,6 @@ public class ClickHouseAsyncSinkSerializer extends AsyncSinkWriterStateSerialize
         return new ClickHousePayload(bytes);
     }
 
-    /**
-     * Discards checkpoints written by the broken V1 serializer to prevent
-     * restore loops. Everything else delegates to the base implementation.
-     */
     @Override
     public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized) throws IOException {
         if (version == V1) {

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -1,5 +1,6 @@
 package org.apache.flink.connector.clickhouse.sink;
 
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -18,40 +19,87 @@ public class ClickHouseSinkStateTests {
         ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
         serializer.serializeRequestToStream(clickHousePayload, dos);
         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-        ClickHousePayload clickHousePayload1 = serializer.deserializeRequestFromStream(dos.size(), dis);
-        Assertions.assertEquals(clickHousePayload.getPayloadLength(), clickHousePayload1.getPayloadLength());
-        Assertions.assertArrayEquals(clickHousePayload.getPayload(), clickHousePayload1.getPayload());
+        ClickHousePayload deserialized = serializer.deserializeRequestFromStream(dos.size(), dis);
+        Assertions.assertEquals(clickHousePayload.getPayloadLength(), deserialized.getPayloadLength());
+        Assertions.assertArrayEquals(clickHousePayload.getPayload(), deserialized.getPayload());
     }
 
     @Test
-    void testSerializeAndDeserializeEmptyPayload() throws Exception {
+    void testSerializeAndDeserializeNullPayload() throws Exception {
         ClickHousePayload clickHousePayload = new ClickHousePayload(null);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
         ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
         serializer.serializeRequestToStream(clickHousePayload, dos);
         DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
-        ClickHousePayload clickHousePayload1 = serializer.deserializeRequestFromStream(dos.size(), dis);
-        Assertions.assertEquals(clickHousePayload.getPayloadLength(), clickHousePayload1.getPayloadLength());
-        Assertions.assertArrayEquals(clickHousePayload.getPayload(), clickHousePayload1.getPayload());
+        ClickHousePayload deserialized = serializer.deserializeRequestFromStream(dos.size(), dis);
+        Assertions.assertEquals(clickHousePayload.getPayloadLength(), deserialized.getPayloadLength());
+        Assertions.assertArrayEquals(clickHousePayload.getPayload(), deserialized.getPayload());
     }
 
     @Test
-    void testDeserializePayloadWithUnsuportedVersion() throws IOException {
-        byte[] data = {'H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd'};
+    void testSerializedSizeMatchesGetPayloadLength() throws Exception {
+        byte[] data = "test-payload".getBytes();
+        ClickHousePayload payload = new ClickHousePayload(data);
+
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         DataOutputStream dos = new DataOutputStream(baos);
-        DataOutputStream dataOutputStream = new DataOutputStream(baos);
-        int V2 = 2;
-        dataOutputStream.writeInt(V2);
-        dataOutputStream.writeInt(data.length);
-        dataOutputStream.write(data);
-        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+        serializer.serializeRequestToStream(payload, dos);
+
+        Assertions.assertEquals(4 + data.length, baos.size());
+    }
+
+    @Test
+    void testMultipleEntriesDeserializeCorrectly() throws Exception {
+        byte[] data1 = "first".getBytes();
+        byte[] data2 = "second-longer-payload".getBytes();
+        byte[] data3 = "third".getBytes();
 
         ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+
+        ClickHousePayload p1 = new ClickHousePayload(data1);
+        ClickHousePayload p2 = new ClickHousePayload(data2);
+        ClickHousePayload p3 = new ClickHousePayload(data3);
+
+        serializer.serializeRequestToStream(p1, dos);
+        serializer.serializeRequestToStream(p2, dos);
+        serializer.serializeRequestToStream(p3, dos);
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+
+        ClickHousePayload r1 = serializer.deserializeRequestFromStream(p1.getPayloadLength(), dis);
+        ClickHousePayload r2 = serializer.deserializeRequestFromStream(p2.getPayloadLength(), dis);
+        ClickHousePayload r3 = serializer.deserializeRequestFromStream(p3.getPayloadLength(), dis);
+
+        Assertions.assertArrayEquals(data1, r1.getPayload());
+        Assertions.assertArrayEquals(data2, r2.getPayload());
+        Assertions.assertArrayEquals(data3, r3.getPayload());
+    }
+
+    @Test
+    void testV1StateIsDiscardedOnDeserialize() throws Exception {
+        byte[] fakeV1State = new byte[]{0, 1, 2, 3, 4, 5};
+        ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+
+        BufferedRequestState<ClickHousePayload> result = serializer.deserialize(1, fakeV1State);
+        Assertions.assertTrue(result.getBufferedRequestEntries().isEmpty());
+    }
+
+    @Test
+    void testDeserializeWithNegativeLength() throws Exception {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        DataOutputStream dos = new DataOutputStream(baos);
+        dos.writeInt(-2); // invalid negative length (not -1 which means null)
+
+        DataInputStream dis = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()));
+        ClickHouseAsyncSinkSerializer serializer = new ClickHouseAsyncSinkSerializer();
+
         Exception exception = Assertions.assertThrows(IOException.class, () -> {
-            serializer.deserializeRequestFromStream(dataOutputStream.size(), dis);
+            serializer.deserializeRequestFromStream(4, dis);
         });
-        Assertions.assertEquals("Unsupported serialization version: 2", exception.getMessage());
+        Assertions.assertTrue(exception.getMessage().contains("Invalid ClickHouse payload length"));
     }
 }


### PR DESCRIPTION
## Summary

`ClickHouseAsyncSinkSerializer` writes 8 extra bytes per buffered entry (a redundant version int + length int) that are not accounted for in `ClickHousePayload.getPayloadLength()`. This causes stream desynchronization when the framework restores checkpoints with multiple buffered entries, resulting in `IOException: Unsupported version: <random int>`.

## Root Cause

The Flink `AsyncSinkWriterStateSerializer` framework uses `getSizeInBytes(payload)` to track each entry's serialized size. For `ClickHousePayload`, this returns `getPayloadLength()` — the raw byte array length.

However, `serializeRequestToStream` writes:
```
int version (4 bytes) + int length (4 bytes) + byte[] payload
```

This means each entry occupies `payloadLength + 8` bytes in the stream, but the framework believes it occupies only `payloadLength` bytes.

When deserializing multiple entries, the framework passes the recorded `requestSize` to `deserializeRequestFromStream`. After reading the first entry (which consumed 8 extra bytes), the stream cursor is misaligned. The second entry's "version int" reads garbage from the middle of the previous payload, throwing `IOException: Unsupported version: <random int>`.

**The bug only manifests when a checkpoint contains more than one buffered entry** — single-entry checkpoints restore correctly because there's no subsequent entry to misalign.

## Fix

Remove the redundant per-entry version marker. The framework already handles versioning via `getVersion()` and `deserialize(int version, byte[] serialized)` at the outer level. The new wire format is simply:

```
int length      // payload length in bytes, or -1 for null
byte[] payload  // absent when length == -1
```

Serialized size per entry = `4 + payloadLength`, which correctly matches `getPayloadLength() + 4` bytes read by `deserializeRequestFromStream`.

## Backward Compatibility

- Version bumped from 1 → 2
- V1 state encountered during restore is **safely discarded** (returns empty `BufferedRequestState`), with a WARN log
- This is safe because `ClickHouseAsyncSink` provides at-least-once semantics — dropped entries are re-emitted by the source from the last committed offset
- V1 state is inherently corrupt (the bug), so attempting to deserialize it would fail anyway

## Testing

- Added test for multiple entries serialization/deserialization (proves the fix)
- Added test for serialized size invariant
- Added test for V1 state discard on restore
- Added test for invalid negative length handling
- Applied fix to both `flink-connector-clickhouse-2.0.0` and `flink-connector-clickhouse-1.17` modules

## Reproduction

1. Configure `ClickHouseAsyncSink` with `maxBufferedRequests > 1`
2. Send enough records to buffer multiple entries before a checkpoint
3. Trigger checkpoint
4. Restore from checkpoint → `IOException: Unsupported version: <random int>`
