### PR TITLE
Extract cloud test to a different workflow

### DIFF
--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -1,12 +1,18 @@
 name: Integration Tests CI (Java, Cloud)
 
-# Cloud counterpart of integration-tests.yaml. Runs on pull_request_target so the
-# ClickHouse Cloud secrets are available; fork PRs are gated behind the
-# `run-cloud-tests` label (see the `gate` job).
+# Cloud counterpart of integration-tests.yaml. Same-repo branch PRs run
+# automatically via `pull_request`; fork PRs run via `pull_request_target` only
+# after the `run-cloud-tests` label is added (see the `gate` job, which keeps
+# the two paths from double-running).
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  pull_request:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -25,10 +31,11 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && (
-        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
-        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
-      ))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'run-cloud-tests')
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -1,0 +1,101 @@
+name: Integration Tests CI (Java, Cloud)
+
+# Cloud counterpart of integration-tests.yaml. Runs on pull_request_target so the
+# ClickHouse Cloud secrets are available; fork PRs are gated behind the
+# `run-cloud-tests` label (see the `gate` job).
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  workflow_dispatch:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && (
+        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+      ))
+    steps:
+      - run: echo "Cloud tests approved for ${{ github.event_name }}"
+
+  test-integration-tests:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "cloud" ]
+        flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2", "2.0.0", "2.1.0" , "latest"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Publish locally flink-connector-clickhouse-1.17
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+      - name: Publish locally flink-connector-clickhouse-2.0.0
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+      - name: Generate Flink Covid App example 2.X
+        working-directory: ./examples/maven/flink-v2/covid
+        run: mvn clean install
+      - name: Generate Flink Covid App example 1.17+
+        working-directory: ./examples/maven/flink-v1.7/covid
+        run: mvn clean install
+      - name: Setup and execute Gradle 'integration-test' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          FLINK_VERSION: ${{ matrix.flink }}
+        with:
+          arguments: :flink-connector-clickhouse-integration:test
+
+  remove-label:
+    needs: [ test-integration-tests ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-cloud-tests')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'run-cloud-tests'
+              });
+            } catch (e) {
+              core.info(`Label removal skipped: ${e.message}`);
+            }

--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -12,11 +12,6 @@ on:
       - '**.md'
       - 'LICENSE'
       - 'examples'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'examples'
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
     paths-ignore:
@@ -28,14 +23,16 @@ on:
 jobs:
   gate:
     runs-on: ubuntu-latest
+    # Run for
+    # - Internal PRs (from repo collaborators): auto-run on open/reopen/sync (NOT on random label additions)
+    # - External PRs (from forks): only when 'run-cloud-tests' label is added (secure, no auto-run on new commits)
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'run-cloud-tests')
+      (github.event_name == 'pull_request_target' && (
+                   (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+                   (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+                 ))
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/integration-tests-scala-cloud.yaml
+++ b/.github/workflows/integration-tests-scala-cloud.yaml
@@ -12,11 +12,6 @@ on:
       - '**.md'
       - 'LICENSE'
       - 'examples/**'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'examples/**'
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
     paths-ignore:
@@ -28,14 +23,16 @@ on:
 jobs:
   gate:
     runs-on: ubuntu-latest
+    # Run for
+    # - Internal PRs (from repo collaborators): auto-run on open/reopen/sync (NOT on random label additions)
+    # - External PRs (from forks): only when 'run-cloud-tests' label is added (secure, no auto-run on new commits)
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'run-cloud-tests')
+      (github.event_name == 'pull_request_target' && (
+                   (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+                   (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+                 ))
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/integration-tests-scala-cloud.yaml
+++ b/.github/workflows/integration-tests-scala-cloud.yaml
@@ -1,12 +1,18 @@
 name: Integration Tests CI (Scala, Cloud)
 
-# Cloud counterpart of integration-tests-scala.yaml. Runs on pull_request_target
-# so the ClickHouse Cloud secrets are available; fork PRs are gated behind the
-# `run-cloud-tests` label (see the `gate` job).
+# Cloud counterpart of integration-tests-scala.yaml. Same-repo branch PRs run
+# automatically via `pull_request`; fork PRs run via `pull_request_target` only
+# after the `run-cloud-tests` label is added (see the `gate` job, which keeps
+# the two paths from double-running).
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples/**'
+  pull_request:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -25,10 +31,11 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && (
-        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
-        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
-      ))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'run-cloud-tests')
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/integration-tests-scala-cloud.yaml
+++ b/.github/workflows/integration-tests-scala-cloud.yaml
@@ -1,0 +1,103 @@
+name: Integration Tests CI (Scala, Cloud)
+
+# Cloud counterpart of integration-tests-scala.yaml. Runs on pull_request_target
+# so the ClickHouse Cloud secrets are available; fork PRs are gated behind the
+# `run-cloud-tests` label (see the `gate` job).
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples/**'
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples/**'
+  workflow_dispatch:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && (
+        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+      ))
+    steps:
+      - run: echo "Cloud tests approved for ${{ github.event_name }}"
+
+  test-integration-tests-scala:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "cloud" ]
+        flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2", "2.0.0", "2.1.0" , "latest"]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Publish locally flink-connector-clickhouse-1.17
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+      - name: Publish locally flink-connector-clickhouse-2.0.0
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+      - name: Set up sbt
+        uses: sbt/setup-sbt@v1
+      - name: Generate Flink Covid App example 2.X (Scala)
+        working-directory: ./examples/sbt/flink-v2/covid
+        run: sbt clean assembly
+      - name: Generate Flink Covid App example 1.17+ (Scala)
+        working-directory: ./examples/sbt/flink-v1.7/covid
+        run: sbt clean assembly
+      - name: Setup and execute Gradle 'integration-test' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          FLINK_VERSION: ${{ matrix.flink }}
+        with:
+          arguments: :flink-connector-clickhouse-integration:test -Dexample.lang=scala
+
+  remove-label:
+    needs: [ test-integration-tests-scala ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-cloud-tests')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'run-cloud-tests'
+              });
+            } catch (e) {
+              core.info(`Label removal skipped: ${e.message}`);
+            }

--- a/.github/workflows/integration-tests-scala.yaml
+++ b/.github/workflows/integration-tests-scala.yaml
@@ -21,55 +21,36 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud" ]
+        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
         flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2", "2.0.0", "2.1.0" , "latest"]
     steps:
-      - name: Check for Cloud Credentials
-        id: check-cloud-credentials
-        run: |
-          if [[ "${{ matrix.clickhouse }}" == "cloud" && (-z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}" || -z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}") ]]; then
-            echo "SKIP_STEP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_STEP=false" >> $GITHUB_ENV
-          fi
-        shell: bash
       - uses: actions/checkout@v3
-        if: env.SKIP_STEP != 'true'
       - name: Set up JDK 17
-        if: env.SKIP_STEP != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
       - name: Publish locally flink-connector-clickhouse-1.17
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Set up sbt
-        if: env.SKIP_STEP != 'true'
         uses: sbt/setup-sbt@v1
       - name: Generate Flink Covid App example 2.X (Scala)
-        if: env.SKIP_STEP != 'true'
         working-directory: ./examples/sbt/flink-v2/covid
         run: sbt clean assembly
       - name: Generate Flink Covid App example 1.17+ (Scala)
-        if: env.SKIP_STEP != 'true'
         working-directory: ./examples/sbt/flink-v1.7/covid
         run: sbt clean assembly
       - name: Setup and execute Gradle 'integration-test' task
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
         with:
           arguments: :flink-connector-clickhouse-integration:test -Dexample.lang=scala

--- a/.github/workflows/integration-tests-schema-evolution-cloud.yaml
+++ b/.github/workflows/integration-tests-schema-evolution-cloud.yaml
@@ -16,15 +16,6 @@ on:
       - 'examples/maven/flink-v1.7/map-evolution/**'
       - 'examples/maven/flink-v2/map-evolution/**'
       - '.github/workflows/integration-tests-schema-evolution-cloud.yaml'
-  pull_request:
-    paths:
-      - 'flink-connector-clickhouse-base/**'
-      - 'flink-connector-clickhouse-1.17/**'
-      - 'flink-connector-clickhouse-2.0.0/**'
-      - 'flink-connector-clickhouse-integration/**'
-      - 'examples/maven/flink-v1.7/map-evolution/**'
-      - 'examples/maven/flink-v2/map-evolution/**'
-      - '.github/workflows/integration-tests-schema-evolution-cloud.yaml'
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
     paths:
@@ -40,14 +31,16 @@ on:
 jobs:
   gate:
     runs-on: ubuntu-latest
+    # Run for
+    # - Internal PRs (from repo collaborators): auto-run on open/reopen/sync (NOT on random label additions)
+    # - External PRs (from forks): only when 'run-cloud-tests' label is added (secure, no auto-run on new commits)
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'run-cloud-tests')
+      (github.event_name == 'pull_request_target' && (
+                   (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+                   (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+                 ))
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/integration-tests-schema-evolution-cloud.yaml
+++ b/.github/workflows/integration-tests-schema-evolution-cloud.yaml
@@ -1,12 +1,22 @@
 name: Integration Tests CI (Schema Evolution, Cloud)
 
-# Cloud counterpart of integration-tests-schema-evolution.yaml. Runs on
-# pull_request_target so the ClickHouse Cloud secrets are available; fork PRs are
-# gated behind the `run-cloud-tests` label (see the `gate` job).
+# Cloud counterpart of integration-tests-schema-evolution.yaml. Same-repo branch
+# PRs run automatically via `pull_request`; fork PRs run via
+# `pull_request_target` only after the `run-cloud-tests` label is added (see the
+# `gate` job, which keeps the two paths from double-running).
 on:
   push:
     branches:
       - main
+    paths:
+      - 'flink-connector-clickhouse-base/**'
+      - 'flink-connector-clickhouse-1.17/**'
+      - 'flink-connector-clickhouse-2.0.0/**'
+      - 'flink-connector-clickhouse-integration/**'
+      - 'examples/maven/flink-v1.7/map-evolution/**'
+      - 'examples/maven/flink-v2/map-evolution/**'
+      - '.github/workflows/integration-tests-schema-evolution-cloud.yaml'
+  pull_request:
     paths:
       - 'flink-connector-clickhouse-base/**'
       - 'flink-connector-clickhouse-1.17/**'
@@ -33,10 +43,11 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && (
-        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
-        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
-      ))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'run-cloud-tests')
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/integration-tests-schema-evolution-cloud.yaml
+++ b/.github/workflows/integration-tests-schema-evolution-cloud.yaml
@@ -1,5 +1,8 @@
-name: Integration Tests CI (Schema Evolution)
+name: Integration Tests CI (Schema Evolution, Cloud)
 
+# Cloud counterpart of integration-tests-schema-evolution.yaml. Runs on
+# pull_request_target so the ClickHouse Cloud secrets are available; fork PRs are
+# gated behind the `run-cloud-tests` label (see the `gate` job).
 on:
   push:
     branches:
@@ -11,8 +14,9 @@ on:
       - 'flink-connector-clickhouse-integration/**'
       - 'examples/maven/flink-v1.7/map-evolution/**'
       - 'examples/maven/flink-v2/map-evolution/**'
-      - '.github/workflows/integration-tests-schema-evolution.yaml'
-  pull_request:
+      - '.github/workflows/integration-tests-schema-evolution-cloud.yaml'
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
     paths:
       - 'flink-connector-clickhouse-base/**'
       - 'flink-connector-clickhouse-1.17/**'
@@ -20,24 +24,38 @@ on:
       - 'flink-connector-clickhouse-integration/**'
       - 'examples/maven/flink-v1.7/map-evolution/**'
       - 'examples/maven/flink-v2/map-evolution/**'
-      - '.github/workflows/integration-tests-schema-evolution.yaml'
+      - '.github/workflows/integration-tests-schema-evolution-cloud.yaml'
+  workflow_dispatch:
 
 jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && (
+        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+      ))
+    steps:
+      - run: echo "Cloud tests approved for ${{ github.event_name }}"
+
   test-schema-evolution:
+    needs: gate
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        # Schema-evolution test exercises connector writer-state migration, not
-        # ClickHouse-version compatibility — a single CH is enough.
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
+        clickhouse: [ "cloud" ]
         # The flink-v1.7 example POM pins Flink 1.17.2 and the flink-v2 example
         # pins 2.0.0. Running them against newer 1.x / 2.x runtimes verifies the
         # same JARs remain forward-compatible on the runtime side.
         flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2", "2.0.0", "2.1.0", "latest" ]
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -62,6 +80,33 @@ jobs:
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
         with:
           arguments: ":flink-connector-clickhouse-integration:test --tests com.clickhouse.flink.integration.FlinkTests.testSchemaEvolution"
+
+  remove-label:
+    needs: [ test-schema-evolution ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-cloud-tests')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'run-cloud-tests'
+              });
+            } catch (e) {
+              core.info(`Label removal skipped: ${e.message}`);
+            }

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -21,56 +21,34 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud" ]
+        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
         flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2", "2.0.0", "2.1.0" , "latest"]
     steps:
-      - name: Check for Cloud Credentials
-        id: check-cloud-credentials
-        run: |
-          if [[ "${{ matrix.clickhouse }}" == "cloud" && (-z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}" || -z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}") ]]; then
-            echo "SKIP_STEP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_STEP=false" >> $GITHUB_ENV
-          fi
-        shell: bash
       - uses: actions/checkout@v3
-        if: env.SKIP_STEP != 'true'
       - name: Set up JDK 17
-        if: env.SKIP_STEP != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
       - name: Publish locally flink-connector-clickhouse-1.17
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Generate Flink Covid App example 2.X
-        if: env.SKIP_STEP != 'true'
         working-directory: ./examples/maven/flink-v2/covid
         run: mvn clean install
       - name: Generate Flink Covid App example 1.17+
-        if: env.SKIP_STEP != 'true'
         working-directory: ./examples/maven/flink-v1.7/covid
         run: mvn clean install
       - name: Setup and execute Gradle 'integration-test' task
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
         with:
           arguments: :flink-connector-clickhouse-integration:test
-
-
-
-

--- a/.github/workflows/tests-cloud.yaml
+++ b/.github/workflows/tests-cloud.yaml
@@ -1,0 +1,123 @@
+name: Apache Flink ClickHouse Connector Tests CI (Java, Cloud)
+
+# Cloud counterpart of tests.yaml. It needs the ClickHouse Cloud secrets, so it
+# runs on pull_request_target (which exposes secrets) instead of pull_request.
+# To stop untrusted fork code from reaching those secrets automatically, fork
+# PRs only run once a maintainer adds the `run-cloud-tests` label (see the
+# `gate` job). Same-repo PRs and pushes to main run without a label.
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  workflow_dispatch:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    # Allow when: not a PR (push / manual), OR a same-repo PR that is not a bare
+    # label event, OR a `run-cloud-tests` label was just added (the only path for
+    # fork PRs). Fork PRs without the label fall through and the job is skipped,
+    # which skips every job that `needs: gate`.
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && (
+        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+      ))
+    steps:
+      - run: echo "Cloud tests approved for ${{ github.event_name }}"
+
+  test-flink-17:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "cloud" ]
+        flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2"]
+    name: Apache Flink ${{ matrix.flink }} ClickHouse Connector tests with ClickHouse ${{ matrix.clickhouse }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Setup and execute Gradle 'test' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          FLINK_VERSION: ${{ matrix.flink }}
+        with:
+          arguments: :flink-connector-clickhouse-1.17:test
+  test-flink-2:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "cloud" ]
+    name: Apache Flink 2.0.0 ClickHouse Connector tests with ClickHouse ${{ matrix.clickhouse }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Setup and execute Gradle 'test' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+        with:
+          arguments: :flink-connector-clickhouse-2.0.0:test
+
+  remove-label:
+    needs: [ test-flink-17, test-flink-2 ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    # Strip the label after each fork-PR run so new commits need re-labeling
+    # (and thus re-review) before they can touch the cloud secrets again.
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-cloud-tests')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'run-cloud-tests'
+              });
+            } catch (e) {
+              core.info(`Label removal skipped: ${e.message}`);
+            }

--- a/.github/workflows/tests-cloud.yaml
+++ b/.github/workflows/tests-cloud.yaml
@@ -1,14 +1,21 @@
 name: Apache Flink ClickHouse Connector Tests CI (Java, Cloud)
 
-# Cloud counterpart of tests.yaml. It needs the ClickHouse Cloud secrets, so it
-# runs on pull_request_target (which exposes secrets) instead of pull_request.
-# To stop untrusted fork code from reaching those secrets automatically, fork
-# PRs only run once a maintainer adds the `run-cloud-tests` label (see the
-# `gate` job). Same-repo PRs and pushes to main run without a label.
+# Cloud counterpart of tests.yaml. These jobs need the ClickHouse Cloud secrets.
+#   - Same-repo branch PRs run automatically via `pull_request` (GitHub grants
+#     secrets to same-repo PRs, and the workflow is read from the PR branch).
+#   - Fork PRs run via `pull_request_target` only after a maintainer adds the
+#     `run-cloud-tests` label, so untrusted fork code never reaches the secrets
+#     automatically.
+# The `gate` job routes each event to exactly one path so they never double-run.
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  pull_request:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -24,17 +31,20 @@ on:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    # Allow when: not a PR (push / manual), OR a same-repo PR that is not a bare
-    # label event, OR a `run-cloud-tests` label was just added (the only path for
-    # fork PRs). Fork PRs without the label fall through and the job is skipped,
-    # which skips every job that `needs: gate`.
+    # Allow when: push / manual dispatch, OR a same-repo PR (auto, no label), OR
+    # a fork PR that just had the `run-cloud-tests` label added. Same-repo PRs
+    # are handled only by the pull_request clause and forks only by the
+    # pull_request_target clause, so a same-repo PR (which fires both events)
+    # runs exactly once. Anything else skips the gate, which skips every job
+    # that `needs: gate`.
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && (
-        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
-        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
-      ))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'run-cloud-tests')
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/tests-cloud.yaml
+++ b/.github/workflows/tests-cloud.yaml
@@ -15,11 +15,6 @@ on:
       - '**.md'
       - 'LICENSE'
       - 'examples'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'examples'
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
     paths-ignore:
@@ -31,20 +26,16 @@ on:
 jobs:
   gate:
     runs-on: ubuntu-latest
-    # Allow when: push / manual dispatch, OR a same-repo PR (auto, no label), OR
-    # a fork PR that just had the `run-cloud-tests` label added. Same-repo PRs
-    # are handled only by the pull_request clause and forks only by the
-    # pull_request_target clause, so a same-repo PR (which fires both events)
-    # runs exactly once. Anything else skips the gate, which skips every job
-    # that `needs: gate`.
+    # Run for
+    # - Internal PRs (from repo collaborators): auto-run on open/reopen/sync (NOT on random label additions)
+    # - External PRs (from forks): only when 'run-cloud-tests' label is added (secure, no auto-run on new commits)
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'run-cloud-tests')
+      (github.event_name == 'pull_request_target' && (
+              (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+              (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+            ))
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/tests-scala-cloud.yaml
+++ b/.github/workflows/tests-scala-cloud.yaml
@@ -1,0 +1,115 @@
+name: Apache Flink ClickHouse Connector Tests CI (Scala, Cloud)
+
+# Cloud counterpart of tests-scala.yaml. Runs on pull_request_target so the
+# ClickHouse Cloud secrets are available; fork PRs are gated behind the
+# `run-cloud-tests` label (see the `gate` job).
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  workflow_dispatch:
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request_target' && (
+        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+      ))
+    steps:
+      - run: echo "Cloud tests approved for ${{ github.event_name }}"
+
+  test-flink-17:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "cloud" ]
+        flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2"]
+    name: Apache Flink ${{ matrix.flink }} ClickHouse Connector scala tests with ClickHouse ${{ matrix.clickhouse }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Setup and execute Gradle 'test' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          FLINK_VERSION: ${{ matrix.flink }}
+        with:
+          arguments: :flink-connector-clickhouse-1.17:runScalaTests
+  test-flink-2:
+    needs: gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        clickhouse: [ "cloud" ]
+    name: Apache Flink 2.0.0 ClickHouse Connector tests with scala ClickHouse ${{ matrix.clickhouse }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.ref }}
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+          architecture: x64
+      - name: Setup and execute Gradle 'test' task
+        uses: gradle/gradle-build-action@v2
+        env:
+          CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+        with:
+          arguments: :flink-connector-clickhouse-2.0.0:runScalaTests
+
+  remove-label:
+    needs: [ test-flink-17, test-flink-2 ]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      github.event.pull_request.head.repo.full_name != github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'run-cloud-tests')
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                name: 'run-cloud-tests'
+              });
+            } catch (e) {
+              core.info(`Label removal skipped: ${e.message}`);
+            }

--- a/.github/workflows/tests-scala-cloud.yaml
+++ b/.github/workflows/tests-scala-cloud.yaml
@@ -12,11 +12,6 @@ on:
       - '**.md'
       - 'LICENSE'
       - 'examples'
-  pull_request:
-    paths-ignore:
-      - '**.md'
-      - 'LICENSE'
-      - 'examples'
   pull_request_target:
     types: [opened, reopened, synchronize, labeled]
     paths-ignore:
@@ -28,14 +23,16 @@ on:
 jobs:
   gate:
     runs-on: ubuntu-latest
+    # Run for
+    # - Internal PRs (from repo collaborators): auto-run on open/reopen/sync (NOT on random label additions)
+    # - External PRs (from forks): only when 'run-cloud-tests' label is added (secure, no auto-run on new commits)
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_target' &&
-        github.event.pull_request.head.repo.full_name != github.repository &&
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'run-cloud-tests')
+      (github.event_name == 'pull_request_target' && (
+                    (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
+                    (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
+                  ))
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/tests-scala-cloud.yaml
+++ b/.github/workflows/tests-scala-cloud.yaml
@@ -1,12 +1,18 @@
 name: Apache Flink ClickHouse Connector Tests CI (Scala, Cloud)
 
-# Cloud counterpart of tests-scala.yaml. Runs on pull_request_target so the
-# ClickHouse Cloud secrets are available; fork PRs are gated behind the
-# `run-cloud-tests` label (see the `gate` job).
+# Cloud counterpart of tests-scala.yaml. Same-repo branch PRs run automatically
+# via `pull_request`; fork PRs run via `pull_request_target` only after the
+# `run-cloud-tests` label is added (see the `gate` job, which keeps the two
+# paths from double-running).
 on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - 'examples'
+  pull_request:
     paths-ignore:
       - '**.md'
       - 'LICENSE'
@@ -25,10 +31,11 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request_target' && (
-        (github.event.pull_request.head.repo.full_name == github.repository && github.event.action != 'labeled') ||
-        (github.event.action == 'labeled' && github.event.label.name == 'run-cloud-tests')
-      ))
+      (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_target' &&
+        github.event.pull_request.head.repo.full_name != github.repository &&
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'run-cloud-tests')
     steps:
       - run: echo "Cloud tests approved for ${{ github.event_name }}"
 

--- a/.github/workflows/tests-scala.yaml
+++ b/.github/workflows/tests-scala.yaml
@@ -21,35 +21,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud"]
+        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest"]
         flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2"]
     name: Apache Flink ${{ matrix.flink }} ClickHouse Connector scala tests with ClickHouse ${{ matrix.clickhouse }}
     steps:
-      - name: Check for Cloud Credentials
-        id: check-cloud-credentials
-        run: |
-          if [[ "${{ matrix.clickhouse }}" == "cloud" && (-z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}" || -z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}") ]]; then
-            echo "SKIP_STEP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_STEP=false" >> $GITHUB_ENV
-          fi
-        shell: bash
       - uses: actions/checkout@v3
-        if: env.SKIP_STEP != 'true'
       - name: Set up JDK 17
-        if: env.SKIP_STEP != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
       - name: Setup and execute Gradle 'test' task
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
         with:
           arguments: :flink-connector-clickhouse-1.17:runScalaTests
@@ -59,33 +45,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ "23.7", "24.3", "latest", "cloud" ]
+        clickhouse: [ "23.7", "24.3", "latest" ]
     name: Apache Flink 2.0.0 ClickHouse Connector tests with scala ClickHouse ${{ matrix.clickhouse }}
     steps:
-      - name: Check for Cloud Credentials
-        id: check-cloud-credentials
-        run: |
-          if [[ "${{ matrix.clickhouse }}" == "cloud" && (-z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}" || -z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}") ]]; then
-            echo "SKIP_STEP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_STEP=false" >> $GITHUB_ENV
-          fi
-        shell: bash
       - uses: actions/checkout@v3
-        if: env.SKIP_STEP != 'true'
       - name: Set up JDK 17
-        if: env.SKIP_STEP != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
       - name: Setup and execute Gradle 'test' task
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
         with:
           arguments: :flink-connector-clickhouse-2.0.0:runScalaTests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,35 +21,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud" ]
+        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
         flink: [ "1.17.2", "1.18.1", "1.19.3", "1.20.2"]
     name: Apache Flink ${{ matrix.flink }} ClickHouse Connector tests with ClickHouse ${{ matrix.clickhouse }}
     steps:
-      - name: Check for Cloud Credentials
-        id: check-cloud-credentials
-        run: |
-          if [[ "${{ matrix.clickhouse }}" == "cloud" && (-z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}" || -z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}") ]]; then
-            echo "SKIP_STEP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_STEP=false" >> $GITHUB_ENV
-          fi
-        shell: bash
       - uses: actions/checkout@v3
-        if: env.SKIP_STEP != 'true'
       - name: Set up JDK 17
-        if: env.SKIP_STEP != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
       - name: Setup and execute Gradle 'test' task
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
         with:
           arguments: :flink-connector-clickhouse-1.17:test
@@ -59,33 +45,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest", "cloud" ]
+        clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
     name: Apache Flink 2.0.0 ClickHouse Connector tests with ClickHouse ${{ matrix.clickhouse }}
     steps:
-      - name: Check for Cloud Credentials
-        id: check-cloud-credentials
-        run: |
-          if [[ "${{ matrix.clickhouse }}" == "cloud" && (-z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}" || -z "${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}") ]]; then
-            echo "SKIP_STEP=true" >> $GITHUB_ENV
-          else
-            echo "SKIP_STEP=false" >> $GITHUB_ENV
-          fi
-        shell: bash
       - uses: actions/checkout@v3
-        if: env.SKIP_STEP != 'true'
       - name: Set up JDK 17
-        if: env.SKIP_STEP != 'true'
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
       - name: Setup and execute Gradle 'test' task
-        if: env.SKIP_STEP != 'true'
         uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
         with:
           arguments: :flink-connector-clickhouse-2.0.0:test


### PR DESCRIPTION
## Summary
Extract cloud test to a different workflow, change to pull_request_target, and enable running cloud tests with the label run-cloud-tests.

Closes <!-- Link to an issue to close on merge. -->
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
