### PR TITLE
Fix DataWriter throwing on SimpleAggregateFunction columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,10 +180,12 @@ Planned for a future release — a complete end-to-end example will be added onc
 | Map<K,V>        | Map<K,V>        | ✅         | DataWriter.writeMap         |
 | Tuple<Type,..>  | Tuple<T1,T2,..> | ✅         | DataWriter.writeTuple       |
 | Object          | Variant         | ❌         | N/A                         |
+| (inner type T)  | SimpleAggregateFunction(f, T) | ✅ | writer for inner type T |
 
 * A ZoneId must also be provided when performing date operations. 
 * Precision and scale must also be provided when performing decimal operations. 
 * To use JSON type as a string, you need to enable `enableJsonSupportAsString` in `ClickHouseClientConfig` . 
+* `SimpleAggregateFunction(f, T)` is wire-encoded exactly as its inner type `T`, so bind the Java value for `T` and ignore the aggregate function `f`. Any `T` supported above works, including `Nullable`, `LowCardinality`, `Decimal`, `Array`, `Map` and `Tuple`. 
 
 ## Configuration Options
 

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTestUtils.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTestUtils.java
@@ -1,5 +1,15 @@
 package org.apache.flink.connector.clickhouse.sink;
 
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+import static org.apache.flink.connector.test.embedded.flink.EmbeddedFlinkClusterForTests.executeAsyncJob;
+
 public class ClickHouseSinkTestUtils {
     public static final int MAX_BATCH_SIZE = 5000;
     public static final int MIN_BATCH_SIZE = 1;
@@ -8,4 +18,36 @@ public class ClickHouseSinkTestUtils {
     public static final long MAX_BATCH_SIZE_IN_BYTES = 1024 * 1024;
     public static final long MAX_TIME_IN_BUFFER_MS = 5 * 1000;
     public static final long MAX_RECORD_SIZE_IN_BYTES = 1000;
+    public static final int STREAM_PARALLELISM = 1;
+
+    /** Construct a sink with the standard test-batch tuning + a typed converter. */
+    public static <T> ClickHouseAsyncSink<T> buildSink(ClickHouseConvertor<T> convertor, String tableName) {
+        ClickHouseClientConfig clientConfig = new ClickHouseClientConfig(
+            ClickHouseServerForTests.getURL(),
+            ClickHouseServerForTests.getUsername(),
+            ClickHouseServerForTests.getPassword(),
+            ClickHouseServerForTests.getDatabase(),
+            tableName);
+        return ClickHouseAsyncSink.<T>builder()
+            .setElementConverter(convertor)
+            .setMaxBatchSize(MAX_BATCH_SIZE)
+            .setMaxInFlightRequests(MAX_IN_FLIGHT_REQUESTS)
+            .setMaxBufferedRequests(MAX_BUFFERED_REQUESTS)
+            .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+            .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
+            .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+            .setClickHouseClientConfig(clientConfig)
+            .build();
+    }
+
+    /** Run a small Flink mini-cluster job that ships a list through the sink. */
+    public static <T> void runJob(ClickHouseAsyncSink<T> sink, List<T> rows, String tableName,
+                                  int expectedRows) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(STREAM_PARALLELISM);
+        DataStream<T> stream = env.fromCollection(rows);
+        stream.sinkTo(sink);
+        int inserted = executeAsyncJob(env, tableName, 10, expectedRows);
+        Assertions.assertEquals(expectedRows, inserted);
+    }
 }

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -127,6 +129,102 @@ public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
             "Null on SimpleAggregateFunction(anyLast, Nullable(String)) should be stored as NULL");
         Assertions.assertEquals(0, new BigDecimal("2.2500").compareTo(second.getBigDecimal("total")));
         Assertions.assertEquals("y", second.getString("tag"));
+    }
+
+    // Inner types whose encoding is multi-part or length/scale-dependent, so only a
+    // server can confirm the body still matches the wrapper named in the header.
+
+    /** Flink-POJO conformant, so the composite fields avoid Kryo. */
+    public static class CompositeRow implements Serializable {
+        public int id;
+        public ArrayList<String> arr;
+        public HashMap<String, Long> kv;
+        public ArrayList<Object> tup;
+        public String code;
+        public LocalDateTime ts;
+
+        public CompositeRow() {}
+
+        CompositeRow(int id) {
+            this.id = id;
+            this.arr = new ArrayList<>(List.of("a" + id, "b" + id));
+            this.kv = new HashMap<>(Map.of("k" + id, (long) id));
+            this.tup = new ArrayList<>(List.of(id, "t" + id));
+            this.code = "cd0" + id;
+            this.ts = LocalDateTime.of(2024, 3, 10, 8, 45, id, 123_000_000);
+        }
+    }
+
+    public static final class CompositeRowMapper extends DataMapper<CompositeRow> {
+        @Override
+        public void toMap(CompositeRow r, Map<String, Object> map) {
+            map.put("id", r.id);
+            map.put("arr", r.arr);
+            map.put("kv", r.kv);
+            map.put("tup", r.tup);
+            map.put("code", r.code);
+            map.put("ts", r.ts);
+        }
+
+        @Override
+        public List<ColumnBinding> bindings() {
+            return List.of(
+                ColumnBinding.scalar("id", "id", ClickHouseDataType.Int32),
+                saf("arr", "groupArrayArray", "Array(String)"),
+                saf("kv", "sumMap", "Map(String, UInt64)"),
+                saf("tup", "anyLast", "Tuple(Int32, String)"),
+                saf("code", "anyLast", "FixedString(4)"),
+                saf("ts", "anyLast", "DateTime64(3, 'UTC')")
+            );
+        }
+
+        private static ColumnBinding saf(String column, String function, String innerType) {
+            return ColumnBinding.of(column, column, ClickHouseColumn.of(
+                column, "SimpleAggregateFunction(" + function + ", " + innerType + ")"));
+        }
+    }
+
+    @Test
+    void compositeInnerTypesRoundTrip() throws Exception {
+        String tableName = "simple_aggregate_function_composite_test";
+
+        ClickHouseServerForTests.executeSql(
+            "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` ("
+                + "  id Int32, "
+                + "  arr SimpleAggregateFunction(groupArrayArray, Array(String)), "
+                + "  kv SimpleAggregateFunction(sumMap, Map(String, UInt64)), "
+                + "  tup SimpleAggregateFunction(anyLast, Tuple(Int32, String)), "
+                + "  code SimpleAggregateFunction(anyLast, FixedString(4)), "
+                + "  ts SimpleAggregateFunction(anyLast, DateTime64(3, 'UTC'))"
+                + ") ENGINE=AggregatingMergeTree ORDER BY id");
+
+        ClickHouseAsyncSink<CompositeRow> sink = buildSink(
+            new ClickHouseConvertor<>(CompositeRow.class, new CompositeRowMapper()),
+            tableName);
+
+        List<CompositeRow> rows = new ArrayList<>();
+        rows.add(new CompositeRow(1));
+        rows.add(new CompositeRow(2));
+
+        runJob(sink, rows, tableName, 2);
+
+        // toString pins the rendered value, incl. the forwarded DateTime64 scale.
+        List<GenericRecord> records = ClickHouseServerForTests.extractData(
+            "id, code, toString(arr) AS arr_s, toString(kv) AS kv_s, "
+                + "toString(tup) AS tup_s, toString(ts) AS ts_s",
+            getDatabase(), tableName, "id");
+        Assertions.assertEquals(2, records.size());
+
+        for (int i = 0; i < 2; i++) {
+            int id = i + 1;
+            GenericRecord rec = records.get(i);
+            Assertions.assertEquals(id, rec.getInteger("id"));
+            Assertions.assertEquals("['a" + id + "','b" + id + "']", rec.getString("arr_s"));
+            Assertions.assertEquals("{'k" + id + "':" + id + "}", rec.getString("kv_s"));
+            Assertions.assertEquals("(" + id + ",'t" + id + "')", rec.getString("tup_s"));
+            Assertions.assertEquals("cd0" + id, rec.getString("code"));
+            Assertions.assertEquals("2024-03-10 08:45:0" + id + ".123", rec.getString("ts_s"));
+        }
     }
 
 }

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
@@ -1,0 +1,132 @@
+package org.apache.flink.connector.clickhouse.sink.types;
+
+import com.clickhouse.client.api.query.GenericRecord;
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.clickhouse.convertor.ColumnBinding;
+import org.apache.flink.connector.clickhouse.convertor.DataMapper;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseAsyncSink;
+import org.apache.flink.connector.test.FlinkClusterTests;
+import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.clickhouse.sink.ClickHouseSinkTestUtils.*;
+
+/**
+ * End-to-end coverage for {@code SimpleAggregateFunction(f, T)} columns (issue #143).
+ *
+ * <p>{@code SimpleAggregateFunction} is wire-encoded exactly as its inner type T,
+ * while the {@code RowBinaryWithNamesAndTypes} header names the wrapper type. Only a
+ * real server enforces that the two agree, which is what these tests add on top of the
+ * byte-level assertions in {@code DataWriterDispatchTest}: they ingest through the
+ * production sink and read the values back.
+ *
+ * <p>The inner types are chosen to cover each property the wrapper has to forward from
+ * its nested column — nullability, precision/scale, and the LowCardinality prefix —
+ * since the outer column reports none of them.
+ */
+public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
+
+
+    public static final class AggRow implements Serializable {
+        public final int id;
+        public final long maxVal;
+        public final String lastName;
+        public final BigDecimal total;
+        public final String tag;
+
+        public AggRow(int id, long maxVal, String lastName, BigDecimal total, String tag) {
+            this.id = id;
+            this.maxVal = maxVal;
+            this.lastName = lastName;
+            this.total = total;
+            this.tag = tag;
+        }
+    }
+
+    public static final class AggRowMapper extends DataMapper<AggRow> {
+        @Override
+        public void toMap(AggRow r, Map<String, Object> map) {
+            map.put("id", r.id);
+            map.put("max_val", r.maxVal);
+            map.put("last_name", r.lastName);
+            map.put("total", r.total);
+            map.put("tag", r.tag);
+        }
+
+        @Override
+        public List<ColumnBinding> bindings() {
+            return List.of(
+                ColumnBinding.scalar("id", "id", ClickHouseDataType.Int32),
+                saf("max_val", "max", "Int64"),
+                saf("last_name", "anyLast", "Nullable(String)"),
+                saf("total", "sum", "Decimal(38, 4)"),
+                saf("tag", "anyLast", "LowCardinality(String)")
+            );
+        }
+
+        /** How a user expresses a SimpleAggregateFunction column: a raw type expression. */
+        private static ColumnBinding saf(String column, String function, String innerType) {
+            return ColumnBinding.of(column, column, ClickHouseColumn.of(
+                column, "SimpleAggregateFunction(" + function + ", " + innerType + ")"));
+        }
+    }
+
+    @Test
+    void simpleAggregateFunctionColumnsRoundTrip() throws Exception {
+        String tableName = "simple_aggregate_function_test";
+
+        // Decimal storage type is Decimal(38, 4), not Decimal(18, 4): ClickHouse requires
+        // the column type to equal the aggregate's return type, and sum widens to 38 digits.
+        ClickHouseServerForTests.executeSql(
+            "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` ("
+                + "  id Int32, "
+                + "  max_val SimpleAggregateFunction(max, Int64), "
+                + "  last_name SimpleAggregateFunction(anyLast, Nullable(String)), "
+                + "  total SimpleAggregateFunction(sum, Decimal(38, 4)), "
+                + "  tag SimpleAggregateFunction(anyLast, LowCardinality(String))"
+                + ") ENGINE=AggregatingMergeTree ORDER BY id");
+
+        ClickHouseAsyncSink<AggRow> sink = buildSink(
+            new ClickHouseConvertor<>(AggRow.class, new AggRowMapper()),
+            tableName);
+
+        // Distinct ids: anyLast is nondeterministic across parts, so rows must not
+        // collide on the sorting key for the read-back to be stable.
+        List<AggRow> rows = new ArrayList<>();
+        rows.add(new AggRow(1, 10L, "alpha", new BigDecimal("1.5000"), "x"));
+        // Null on the Nullable inner type: the outer wrapper reports non-nullable,
+        // so nullability has to be taken from the nested column.
+        rows.add(new AggRow(2, 20L, null, new BigDecimal("2.2500"), "y"));
+
+        runJob(sink, rows, tableName, 2);
+
+        List<GenericRecord> records = ClickHouseServerForTests.extractAllData(
+            getDatabase(), tableName, "id");
+        Assertions.assertEquals(2, records.size());
+
+        GenericRecord first = records.get(0);
+        Assertions.assertEquals(1, first.getInteger("id"));
+        Assertions.assertEquals(10L, first.getLong("max_val"));
+        Assertions.assertEquals("alpha", first.getString("last_name"));
+        Assertions.assertEquals(0, new BigDecimal("1.5000").compareTo(first.getBigDecimal("total")));
+        Assertions.assertEquals("x", first.getString("tag"));
+
+        GenericRecord second = records.get(1);
+        Assertions.assertEquals(2, second.getInteger("id"));
+        Assertions.assertEquals(20L, second.getLong("max_val"));
+        Assertions.assertFalse(second.hasValue("last_name"),
+            "Null on SimpleAggregateFunction(anyLast, Nullable(String)) should be stored as NULL");
+        Assertions.assertEquals(0, new BigDecimal("2.2500").compareTo(second.getBigDecimal("total")));
+        Assertions.assertEquals("y", second.getString("tag"));
+    }
+
+}

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
@@ -208,10 +208,7 @@ public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
 
         runJob(sink, rows, tableName, 2);
 
-        // toString pins the rendered value, incl. the forwarded DateTime64 scale.
-        List<GenericRecord> records = ClickHouseServerForTests.extractData(
-            "id, code, toString(arr) AS arr_s, toString(kv) AS kv_s, "
-                + "toString(tup) AS tup_s, toString(ts) AS ts_s",
+        List<GenericRecord> records = ClickHouseServerForTests.extractAllData(
             getDatabase(), tableName, "id");
         Assertions.assertEquals(2, records.size());
 
@@ -219,11 +216,16 @@ public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
             int id = i + 1;
             GenericRecord rec = records.get(i);
             Assertions.assertEquals(id, rec.getInteger("id"));
-            Assertions.assertEquals("['a" + id + "','b" + id + "']", rec.getString("arr_s"));
-            Assertions.assertEquals("{'k" + id + "':" + id + "}", rec.getString("kv_s"));
-            Assertions.assertEquals("(" + id + ",'t" + id + "')", rec.getString("tup_s"));
+            Assertions.assertEquals(List.of("a" + id, "b" + id), rec.getList("arr"));
+            Assertions.assertArrayEquals(new Object[]{id, "t" + id}, rec.getTuple("tup"));
             Assertions.assertEquals("cd0" + id, rec.getString("code"));
-            Assertions.assertEquals("2024-03-10 08:45:0" + id + ".123", rec.getString("ts_s"));
+            // Milliseconds prove the DateTime64 scale reached the writer.
+            Assertions.assertEquals(LocalDateTime.of(2024, 3, 10, 8, 45, id, 123_000_000),
+                rec.getLocalDateTime("ts"));
+            // Map has no typed accessor on GenericRecord.
+            Map<?, ?> kv = (Map<?, ?>) rec.getObject("kv");
+            Assertions.assertEquals(1, kv.size());
+            Assertions.assertEquals(id, ((Number) kv.get("k" + id)).intValue());
         }
     }
 

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/WireFormatIntegrationTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/WireFormatIntegrationTests.java
@@ -17,8 +17,6 @@ import org.apache.flink.connector.clickhouse.sink.ClickHouseAsyncSinkSerializer;
 import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
 import org.apache.flink.connector.test.FlinkClusterTests;
 import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +30,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.connector.clickhouse.sink.ClickHouseSinkTestUtils.*;
-import static org.apache.flink.connector.test.embedded.flink.EmbeddedFlinkClusterForTests.executeAsyncJob;
 
 /**
  * Wire-format integration tests for the v0.2.0 Map-based payload design.
@@ -57,7 +54,6 @@ import static org.apache.flink.connector.test.embedded.flink.EmbeddedFlinkCluste
  */
 public class WireFormatIntegrationTests extends FlinkClusterTests {
 
-    static final int STREAM_PARALLELISM = 1;
 
     // ====================================================================
     // Test 1: reordered bindings → columns match by name
@@ -354,36 +350,6 @@ public class WireFormatIntegrationTests extends FlinkClusterTests {
             "Expected drain-first message; got: " + ex.getMessage());
     }
 
-    // ====================================================================
-    // Helpers
-    // ====================================================================
-
-    /** Construct a sink with the standard test-batch tuning + a typed converter. */
-    private <T> ClickHouseAsyncSink<T> buildSink(ClickHouseConvertor<T> convertor, String tableName) {
-        ClickHouseClientConfig clientConfig = new ClickHouseClientConfig(
-            getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
-        return ClickHouseAsyncSink.<T>builder()
-            .setElementConverter(convertor)
-            .setMaxBatchSize(MAX_BATCH_SIZE)
-            .setMaxInFlightRequests(MAX_IN_FLIGHT_REQUESTS)
-            .setMaxBufferedRequests(MAX_BUFFERED_REQUESTS)
-            .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
-            .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
-            .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
-            .setClickHouseClientConfig(clientConfig)
-            .build();
-    }
-
-    /** Run a small Flink mini-cluster job that ships a list through the sink. */
-    private <T> void runJob(ClickHouseAsyncSink<T> sink, List<T> rows,
-                            String tableName, int expectedRows) throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(STREAM_PARALLELISM);
-        DataStream<T> stream = env.fromCollection(rows);
-        stream.sinkTo(sink);
-        int inserted = executeAsyncJob(env, tableName, 10, expectedRows);
-        Assertions.assertEquals(expectedRows, inserted);
-    }
 
     /** V1 framing identical to parent {@code AsyncSinkWriterStateSerializer}. */
     private static byte[] synthesizeV1Blob(byte[]... entryPayloads) throws IOException {

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTestUtils.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTestUtils.java
@@ -1,5 +1,15 @@
 package org.apache.flink.connector.clickhouse.sink;
 
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.junit.jupiter.api.Assertions;
+
+import java.util.List;
+
+import static org.apache.flink.connector.test.embedded.flink.EmbeddedFlinkClusterForTests.executeAsyncJob;
+
 public class ClickHouseSinkTestUtils {
     public static final int MAX_BATCH_SIZE = 5000;
     public static final int MIN_BATCH_SIZE = 1;
@@ -8,4 +18,36 @@ public class ClickHouseSinkTestUtils {
     public static final long MAX_BATCH_SIZE_IN_BYTES = 1024 * 1024;
     public static final long MAX_TIME_IN_BUFFER_MS = 5 * 1000;
     public static final long MAX_RECORD_SIZE_IN_BYTES = 1000;
+    public static final int STREAM_PARALLELISM = 1;
+
+    /** Construct a sink with the standard test-batch tuning + a typed converter. */
+    public static <T> ClickHouseAsyncSink<T> buildSink(ClickHouseConvertor<T> convertor, String tableName) {
+        ClickHouseClientConfig clientConfig = new ClickHouseClientConfig(
+            ClickHouseServerForTests.getURL(),
+            ClickHouseServerForTests.getUsername(),
+            ClickHouseServerForTests.getPassword(),
+            ClickHouseServerForTests.getDatabase(),
+            tableName);
+        return ClickHouseAsyncSink.<T>builder()
+            .setElementConverter(convertor)
+            .setMaxBatchSize(MAX_BATCH_SIZE)
+            .setMaxInFlightRequests(MAX_IN_FLIGHT_REQUESTS)
+            .setMaxBufferedRequests(MAX_BUFFERED_REQUESTS)
+            .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+            .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
+            .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+            .setClickHouseClientConfig(clientConfig)
+            .build();
+    }
+
+    /** Run a small Flink mini-cluster job that ships a list through the sink. */
+    public static <T> void runJob(ClickHouseAsyncSink<T> sink, List<T> rows, String tableName,
+                                  int expectedRows) throws Exception {
+        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(STREAM_PARALLELISM);
+        DataStream<T> stream = env.fromCollection(rows);
+        stream.sinkTo(sink);
+        int inserted = executeAsyncJob(env, tableName, 10, expectedRows);
+        Assertions.assertEquals(expectedRows, inserted);
+    }
 }

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
@@ -14,7 +14,9 @@ import org.junit.jupiter.api.Test;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -127,6 +129,102 @@ public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
             "Null on SimpleAggregateFunction(anyLast, Nullable(String)) should be stored as NULL");
         Assertions.assertEquals(0, new BigDecimal("2.2500").compareTo(second.getBigDecimal("total")));
         Assertions.assertEquals("y", second.getString("tag"));
+    }
+
+    // Inner types whose encoding is multi-part or length/scale-dependent, so only a
+    // server can confirm the body still matches the wrapper named in the header.
+
+    /** Flink-POJO conformant, so the composite fields avoid Kryo. */
+    public static class CompositeRow implements Serializable {
+        public int id;
+        public ArrayList<String> arr;
+        public HashMap<String, Long> kv;
+        public ArrayList<Object> tup;
+        public String code;
+        public LocalDateTime ts;
+
+        public CompositeRow() {}
+
+        CompositeRow(int id) {
+            this.id = id;
+            this.arr = new ArrayList<>(List.of("a" + id, "b" + id));
+            this.kv = new HashMap<>(Map.of("k" + id, (long) id));
+            this.tup = new ArrayList<>(List.of(id, "t" + id));
+            this.code = "cd0" + id;
+            this.ts = LocalDateTime.of(2024, 3, 10, 8, 45, id, 123_000_000);
+        }
+    }
+
+    public static final class CompositeRowMapper extends DataMapper<CompositeRow> {
+        @Override
+        public void toMap(CompositeRow r, Map<String, Object> map) {
+            map.put("id", r.id);
+            map.put("arr", r.arr);
+            map.put("kv", r.kv);
+            map.put("tup", r.tup);
+            map.put("code", r.code);
+            map.put("ts", r.ts);
+        }
+
+        @Override
+        public List<ColumnBinding> bindings() {
+            return List.of(
+                ColumnBinding.scalar("id", "id", ClickHouseDataType.Int32),
+                saf("arr", "groupArrayArray", "Array(String)"),
+                saf("kv", "sumMap", "Map(String, UInt64)"),
+                saf("tup", "anyLast", "Tuple(Int32, String)"),
+                saf("code", "anyLast", "FixedString(4)"),
+                saf("ts", "anyLast", "DateTime64(3, 'UTC')")
+            );
+        }
+
+        private static ColumnBinding saf(String column, String function, String innerType) {
+            return ColumnBinding.of(column, column, ClickHouseColumn.of(
+                column, "SimpleAggregateFunction(" + function + ", " + innerType + ")"));
+        }
+    }
+
+    @Test
+    void compositeInnerTypesRoundTrip() throws Exception {
+        String tableName = "simple_aggregate_function_composite_test";
+
+        ClickHouseServerForTests.executeSql(
+            "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` ("
+                + "  id Int32, "
+                + "  arr SimpleAggregateFunction(groupArrayArray, Array(String)), "
+                + "  kv SimpleAggregateFunction(sumMap, Map(String, UInt64)), "
+                + "  tup SimpleAggregateFunction(anyLast, Tuple(Int32, String)), "
+                + "  code SimpleAggregateFunction(anyLast, FixedString(4)), "
+                + "  ts SimpleAggregateFunction(anyLast, DateTime64(3, 'UTC'))"
+                + ") ENGINE=AggregatingMergeTree ORDER BY id");
+
+        ClickHouseAsyncSink<CompositeRow> sink = buildSink(
+            new ClickHouseConvertor<>(CompositeRow.class, new CompositeRowMapper()),
+            tableName);
+
+        List<CompositeRow> rows = new ArrayList<>();
+        rows.add(new CompositeRow(1));
+        rows.add(new CompositeRow(2));
+
+        runJob(sink, rows, tableName, 2);
+
+        // toString pins the rendered value, incl. the forwarded DateTime64 scale.
+        List<GenericRecord> records = ClickHouseServerForTests.extractData(
+            "id, code, toString(arr) AS arr_s, toString(kv) AS kv_s, "
+                + "toString(tup) AS tup_s, toString(ts) AS ts_s",
+            getDatabase(), tableName, "id");
+        Assertions.assertEquals(2, records.size());
+
+        for (int i = 0; i < 2; i++) {
+            int id = i + 1;
+            GenericRecord rec = records.get(i);
+            Assertions.assertEquals(id, rec.getInteger("id"));
+            Assertions.assertEquals("['a" + id + "','b" + id + "']", rec.getString("arr_s"));
+            Assertions.assertEquals("{'k" + id + "':" + id + "}", rec.getString("kv_s"));
+            Assertions.assertEquals("(" + id + ",'t" + id + "')", rec.getString("tup_s"));
+            Assertions.assertEquals("cd0" + id, rec.getString("code"));
+            Assertions.assertEquals("2024-03-10 08:45:0" + id + ".123", rec.getString("ts_s"));
+        }
     }
 
 }

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
@@ -1,0 +1,132 @@
+package org.apache.flink.connector.clickhouse.sink.types;
+
+import com.clickhouse.client.api.query.GenericRecord;
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.clickhouse.convertor.ColumnBinding;
+import org.apache.flink.connector.clickhouse.convertor.DataMapper;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseAsyncSink;
+import org.apache.flink.connector.test.FlinkClusterTests;
+import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.apache.flink.connector.clickhouse.sink.ClickHouseSinkTestUtils.*;
+
+/**
+ * End-to-end coverage for {@code SimpleAggregateFunction(f, T)} columns (issue #143).
+ *
+ * <p>{@code SimpleAggregateFunction} is wire-encoded exactly as its inner type T,
+ * while the {@code RowBinaryWithNamesAndTypes} header names the wrapper type. Only a
+ * real server enforces that the two agree, which is what these tests add on top of the
+ * byte-level assertions in {@code DataWriterDispatchTest}: they ingest through the
+ * production sink and read the values back.
+ *
+ * <p>The inner types are chosen to cover each property the wrapper has to forward from
+ * its nested column — nullability, precision/scale, and the LowCardinality prefix —
+ * since the outer column reports none of them.
+ */
+public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
+
+
+    public static final class AggRow implements Serializable {
+        public final int id;
+        public final long maxVal;
+        public final String lastName;
+        public final BigDecimal total;
+        public final String tag;
+
+        public AggRow(int id, long maxVal, String lastName, BigDecimal total, String tag) {
+            this.id = id;
+            this.maxVal = maxVal;
+            this.lastName = lastName;
+            this.total = total;
+            this.tag = tag;
+        }
+    }
+
+    public static final class AggRowMapper extends DataMapper<AggRow> {
+        @Override
+        public void toMap(AggRow r, Map<String, Object> map) {
+            map.put("id", r.id);
+            map.put("max_val", r.maxVal);
+            map.put("last_name", r.lastName);
+            map.put("total", r.total);
+            map.put("tag", r.tag);
+        }
+
+        @Override
+        public List<ColumnBinding> bindings() {
+            return List.of(
+                ColumnBinding.scalar("id", "id", ClickHouseDataType.Int32),
+                saf("max_val", "max", "Int64"),
+                saf("last_name", "anyLast", "Nullable(String)"),
+                saf("total", "sum", "Decimal(38, 4)"),
+                saf("tag", "anyLast", "LowCardinality(String)")
+            );
+        }
+
+        /** How a user expresses a SimpleAggregateFunction column: a raw type expression. */
+        private static ColumnBinding saf(String column, String function, String innerType) {
+            return ColumnBinding.of(column, column, ClickHouseColumn.of(
+                column, "SimpleAggregateFunction(" + function + ", " + innerType + ")"));
+        }
+    }
+
+    @Test
+    void simpleAggregateFunctionColumnsRoundTrip() throws Exception {
+        String tableName = "simple_aggregate_function_test";
+
+        // Decimal storage type is Decimal(38, 4), not Decimal(18, 4): ClickHouse requires
+        // the column type to equal the aggregate's return type, and sum widens to 38 digits.
+        ClickHouseServerForTests.executeSql(
+            "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` ("
+                + "  id Int32, "
+                + "  max_val SimpleAggregateFunction(max, Int64), "
+                + "  last_name SimpleAggregateFunction(anyLast, Nullable(String)), "
+                + "  total SimpleAggregateFunction(sum, Decimal(38, 4)), "
+                + "  tag SimpleAggregateFunction(anyLast, LowCardinality(String))"
+                + ") ENGINE=AggregatingMergeTree ORDER BY id");
+
+        ClickHouseAsyncSink<AggRow> sink = buildSink(
+            new ClickHouseConvertor<>(AggRow.class, new AggRowMapper()),
+            tableName);
+
+        // Distinct ids: anyLast is nondeterministic across parts, so rows must not
+        // collide on the sorting key for the read-back to be stable.
+        List<AggRow> rows = new ArrayList<>();
+        rows.add(new AggRow(1, 10L, "alpha", new BigDecimal("1.5000"), "x"));
+        // Null on the Nullable inner type: the outer wrapper reports non-nullable,
+        // so nullability has to be taken from the nested column.
+        rows.add(new AggRow(2, 20L, null, new BigDecimal("2.2500"), "y"));
+
+        runJob(sink, rows, tableName, 2);
+
+        List<GenericRecord> records = ClickHouseServerForTests.extractAllData(
+            getDatabase(), tableName, "id");
+        Assertions.assertEquals(2, records.size());
+
+        GenericRecord first = records.get(0);
+        Assertions.assertEquals(1, first.getInteger("id"));
+        Assertions.assertEquals(10L, first.getLong("max_val"));
+        Assertions.assertEquals("alpha", first.getString("last_name"));
+        Assertions.assertEquals(0, new BigDecimal("1.5000").compareTo(first.getBigDecimal("total")));
+        Assertions.assertEquals("x", first.getString("tag"));
+
+        GenericRecord second = records.get(1);
+        Assertions.assertEquals(2, second.getInteger("id"));
+        Assertions.assertEquals(20L, second.getLong("max_val"));
+        Assertions.assertFalse(second.hasValue("last_name"),
+            "Null on SimpleAggregateFunction(anyLast, Nullable(String)) should be stored as NULL");
+        Assertions.assertEquals(0, new BigDecimal("2.2500").compareTo(second.getBigDecimal("total")));
+        Assertions.assertEquals("y", second.getString("tag"));
+    }
+
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/SimpleAggregateFunctionIntegrationTests.java
@@ -208,10 +208,7 @@ public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
 
         runJob(sink, rows, tableName, 2);
 
-        // toString pins the rendered value, incl. the forwarded DateTime64 scale.
-        List<GenericRecord> records = ClickHouseServerForTests.extractData(
-            "id, code, toString(arr) AS arr_s, toString(kv) AS kv_s, "
-                + "toString(tup) AS tup_s, toString(ts) AS ts_s",
+        List<GenericRecord> records = ClickHouseServerForTests.extractAllData(
             getDatabase(), tableName, "id");
         Assertions.assertEquals(2, records.size());
 
@@ -219,11 +216,16 @@ public class SimpleAggregateFunctionIntegrationTests extends FlinkClusterTests {
             int id = i + 1;
             GenericRecord rec = records.get(i);
             Assertions.assertEquals(id, rec.getInteger("id"));
-            Assertions.assertEquals("['a" + id + "','b" + id + "']", rec.getString("arr_s"));
-            Assertions.assertEquals("{'k" + id + "':" + id + "}", rec.getString("kv_s"));
-            Assertions.assertEquals("(" + id + ",'t" + id + "')", rec.getString("tup_s"));
+            Assertions.assertEquals(List.of("a" + id, "b" + id), rec.getList("arr"));
+            Assertions.assertArrayEquals(new Object[]{id, "t" + id}, rec.getTuple("tup"));
             Assertions.assertEquals("cd0" + id, rec.getString("code"));
-            Assertions.assertEquals("2024-03-10 08:45:0" + id + ".123", rec.getString("ts_s"));
+            // Milliseconds prove the DateTime64 scale reached the writer.
+            Assertions.assertEquals(LocalDateTime.of(2024, 3, 10, 8, 45, id, 123_000_000),
+                rec.getLocalDateTime("ts"));
+            // Map has no typed accessor on GenericRecord.
+            Map<?, ?> kv = (Map<?, ?>) rec.getObject("kv");
+            Assertions.assertEquals(1, kv.size());
+            Assertions.assertEquals(id, ((Number) kv.get("k" + id)).intValue());
         }
     }
 

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/WireFormatIntegrationTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/WireFormatIntegrationTests.java
@@ -17,8 +17,6 @@ import org.apache.flink.connector.clickhouse.sink.ClickHouseAsyncSinkSerializer;
 import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
 import org.apache.flink.connector.test.FlinkClusterTests;
 import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
-import org.apache.flink.streaming.api.datastream.DataStream;
-import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +30,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 import static org.apache.flink.connector.clickhouse.sink.ClickHouseSinkTestUtils.*;
-import static org.apache.flink.connector.test.embedded.flink.EmbeddedFlinkClusterForTests.executeAsyncJob;
 
 /**
  * Wire-format integration tests for the v0.2.0 Map-based payload design.
@@ -57,7 +54,6 @@ import static org.apache.flink.connector.test.embedded.flink.EmbeddedFlinkCluste
  */
 public class WireFormatIntegrationTests extends FlinkClusterTests {
 
-    static final int STREAM_PARALLELISM = 1;
 
     // ====================================================================
     // Test 1: reordered bindings → columns match by name
@@ -354,36 +350,6 @@ public class WireFormatIntegrationTests extends FlinkClusterTests {
             "Expected drain-first message; got: " + ex.getMessage());
     }
 
-    // ====================================================================
-    // Helpers
-    // ====================================================================
-
-    /** Construct a sink with the standard test-batch tuning + a typed converter. */
-    private <T> ClickHouseAsyncSink<T> buildSink(ClickHouseConvertor<T> convertor, String tableName) {
-        ClickHouseClientConfig clientConfig = new ClickHouseClientConfig(
-            getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
-        return ClickHouseAsyncSink.<T>builder()
-            .setElementConverter(convertor)
-            .setMaxBatchSize(MAX_BATCH_SIZE)
-            .setMaxInFlightRequests(MAX_IN_FLIGHT_REQUESTS)
-            .setMaxBufferedRequests(MAX_BUFFERED_REQUESTS)
-            .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
-            .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
-            .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
-            .setClickHouseClientConfig(clientConfig)
-            .build();
-    }
-
-    /** Run a small Flink mini-cluster job that ships a list through the sink. */
-    private <T> void runJob(ClickHouseAsyncSink<T> sink, List<T> rows,
-                            String tableName, int expectedRows) throws Exception {
-        StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
-        env.setParallelism(STREAM_PARALLELISM);
-        DataStream<T> stream = env.fromCollection(rows);
-        stream.sinkTo(sink);
-        int inserted = executeAsyncJob(env, tableName, 10, expectedRows);
-        Assertions.assertEquals(expectedRows, inserted);
-    }
 
     /** V1 framing identical to parent {@code AsyncSinkWriterStateSerializer}. */
     private static byte[] synthesizeV1Blob(byte[]... entryPayloads) throws IOException {

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
@@ -239,6 +239,7 @@ public class DataWriter {
     public void writeValue(Object value, ClickHouseColumn column) throws IOException {
         // SimpleAggregateFunction(f, T) is wire-encoded identically to its inner type T; recurse on the nested column. See issue #143.
         if (column.getDataType() == ClickHouseDataType.SimpleAggregateFunction) {
+            // A valid SimpleAggregateFunction has exactly one storage type (ClickHouse rejects more), so nested holds that single inner type.
             writeValue(value, column.getNestedColumns().get(0));
             return;
         }

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
@@ -237,6 +237,12 @@ public class DataWriter {
      * {@code column.getDataType()}. Per design spec §8a.
      */
     public void writeValue(Object value, ClickHouseColumn column) throws IOException {
+        // SimpleAggregateFunction(f, T) is wire-encoded identically to its inner type T; recurse on the nested column. See issue #143.
+        if (column.getDataType() == ClickHouseDataType.SimpleAggregateFunction) {
+            writeValue(value, column.getNestedColumns().get(0));
+            return;
+        }
+
         ClickHouseDataType type = column.getDataType();
         boolean nullable = column.isNullable();
         boolean lowCard  = column.isLowCardinality();

--- a/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
@@ -99,7 +99,7 @@ class DataWriterDispatchTest {
         assertTrue(r.length >= 1);
     }
 
-    // Regression: SimpleAggregateFunction serializes as its inner type (wire encoding == inner type; only the header differs). See issue #143.
+    // SimpleAggregateFunction serializes as its inner type (wire encoding == inner type; only the header differs). See issue #143.
     @Test void dispatchSimpleAggregateFunctionString() throws IOException {
         byte[] r = serialize("abc",
                 ClickHouseColumn.of("c", "SimpleAggregateFunction(max, String)"));

--- a/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
@@ -99,9 +99,7 @@ class DataWriterDispatchTest {
         assertTrue(r.length >= 1);
     }
 
-    // Regression: SimpleAggregateFunction should serialize as its inner type — the
-    // aggregate wrapper only affects the header declaration, not the wire encoding.
-    // See https://github.com/ClickHouse/flink-connector-clickhouse/issues/143
+    // Regression: SimpleAggregateFunction serializes as its inner type (wire encoding == inner type; only the header differs). See issue #143.
     @Test void dispatchSimpleAggregateFunctionString() throws IOException {
         byte[] r = serialize("abc",
                 ClickHouseColumn.of("c", "SimpleAggregateFunction(max, String)"));
@@ -119,5 +117,38 @@ class DataWriterDispatchTest {
                 ClickHouseColumn.of("c", "SimpleAggregateFunction(max, String)"));
         byte[] plain = serialize("abc", ClickHouseColumn.of("c", "String"));
         assertArrayEquals(plain, agg);
+    }
+
+    // LowCardinality inner: getDataType() collapses to String; the SAF wrapper must too.
+    @Test void simpleAggregateFunctionLowCardinalityMatchesInner() throws IOException {
+        byte[] agg = serialize("abc",
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(max, LowCardinality(String))"));
+        byte[] inner = serialize("abc", ClickHouseColumn.of("c", "LowCardinality(String)"));
+        assertArrayEquals(inner, agg);
+    }
+
+    // Nullable inner, non-null value: nullability must come from the nested column.
+    @Test void simpleAggregateFunctionNullableNonNullMatchesInner() throws IOException {
+        byte[] agg = serialize("abc",
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(anyLast, Nullable(String))"));
+        byte[] inner = serialize("abc", ClickHouseColumn.of("c", "Nullable(String)"));
+        assertArrayEquals(inner, agg);
+    }
+
+    // Nullable inner, null value: must write the null marker (nullability from the nested column), not throw.
+    @Test void simpleAggregateFunctionNullableNullMatchesInner() throws IOException {
+        byte[] agg = serialize(null,
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(anyLast, Nullable(String))"));
+        byte[] inner = serialize(null, ClickHouseColumn.of("c", "Nullable(String)"));
+        assertArrayEquals(inner, agg);
+        assertTrue(agg.length >= 1);
+    }
+
+    // Decimal inner: precision/scale must be read from the nested column, not the outer one.
+    @Test void simpleAggregateFunctionDecimalMatchesInner() throws IOException {
+        byte[] agg = serialize(new BigDecimal("123.4567"),
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(sum, Decimal(18, 4))"));
+        byte[] inner = serialize(new BigDecimal("123.4567"), ClickHouseColumn.of("c", "Decimal(18, 4)"));
+        assertArrayEquals(inner, agg);
     }
 }

--- a/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
@@ -15,6 +15,7 @@ import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.UUID;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DataWriterDispatchTest {
@@ -96,5 +97,27 @@ class DataWriterDispatchTest {
     @Test void dispatchBoolean() throws IOException {
         byte[] r = serialize(true, ClickHouseColumn.of("c", "Bool"));
         assertTrue(r.length >= 1);
+    }
+
+    // Regression: SimpleAggregateFunction should serialize as its inner type — the
+    // aggregate wrapper only affects the header declaration, not the wire encoding.
+    // See https://github.com/ClickHouse/flink-connector-clickhouse/issues/143
+    @Test void dispatchSimpleAggregateFunctionString() throws IOException {
+        byte[] r = serialize("abc",
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(max, String)"));
+        assertTrue(r.length > 0);
+    }
+
+    @Test void dispatchSimpleAggregateFunctionInt64() throws IOException {
+        byte[] r = serialize(1234567890123L,
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(sum, Int64)"));
+        assertTrue(r.length >= 8);
+    }
+
+    @Test void simpleAggregateFunctionMatchesInnerTypeEncoding() throws IOException {
+        byte[] agg = serialize("abc",
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(max, String)"));
+        byte[] plain = serialize("abc", ClickHouseColumn.of("c", "String"));
+        assertArrayEquals(plain, agg);
     }
 }

--- a/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
@@ -3,6 +3,9 @@ package com.clickhouse.utils.writer;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -13,7 +16,10 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -150,5 +156,28 @@ class DataWriterDispatchTest {
                 ClickHouseColumn.of("c", "SimpleAggregateFunction(sum, Decimal(18, 4))"));
         byte[] inner = serialize(new BigDecimal("123.4567"), ClickHouseColumn.of("c", "Decimal(18, 4)"));
         assertArrayEquals(inner, agg);
+    }
+
+    /** Inner types carrying detail (length, scale, element types) the outer column does not report. */
+    private static Stream<Arguments> wrappedInnerTypes() {
+        return Stream.of(
+            Arguments.of("FixedString(4)", "anyLast", "abcd"),
+            Arguments.of("DateTime64(3)", "anyLast", LocalDateTime.of(2024, 3, 10, 8, 45, 12, 123_000_000)),
+            Arguments.of("LowCardinality(Nullable(String))", "anyLast", "lc"),
+            Arguments.of("Array(String)", "groupArrayArray", List.of("a", "b")),
+            Arguments.of("Map(String, UInt64)", "sumMap", Map.of("k", 7L)),
+            Arguments.of("Tuple(Int32, String)", "anyLast", List.of(1, "t"))
+        );
+    }
+
+    @ParameterizedTest(name = "SimpleAggregateFunction({1}, {0})")
+    @MethodSource("wrappedInnerTypes")
+    void wrappedInnerTypeMatchesPlainInnerType(String innerType, String function, Object value)
+            throws IOException {
+        byte[] agg = serialize(value,
+                ClickHouseColumn.of("c", "SimpleAggregateFunction(" + function + ", " + innerType + ")"));
+        byte[] inner = serialize(value, ClickHouseColumn.of("c", innerType));
+        assertArrayEquals(inner, agg);
+        assertTrue(agg.length > 0);
     }
 }


### PR DESCRIPTION
Fixes ClickHouse/flink-connector-clickhouse#143.

`DataWriter.writeValue` switched on `column.getDataType()`, which returns `SimpleAggregateFunction` for a `SimpleAggregateFunction(f, T)` column → default case → `IOException: Unsupported ClickHouseDataType`.

**Fix:** `SimpleAggregateFunction`'s wire encoding is identical to its inner type `T`, and the header already uses `getOriginalTypeName()`, so unwrap to the nested column and recurse. Carries full inner-type detail (precision/scale/length/nullability/elements) and is function-agnostic.

Adds dispatch tests + a byte-equality check against the plain inner type.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)