### PR TITLE
Add min/max boundary value type tests (issue #114)

### DIFF
--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
@@ -11,15 +11,15 @@ import java.time.ZonedDateTime;
  * {@link SimplePOJO} with every type set to its supported MAXIMUM (issue #114).
  * longPrimitive = Long.MAX_VALUE (also the ORDER BY key), so it sorts after {@link MinSimplePOJO}.
  *
- * <p>Signed 8/16/32-bit and float/double maxima are inherited from the {@link SimplePOJO}
- * constructor; the fields below are the ones that needed true extremes.
+ * <p>Every numeric and boolean field is set explicitly below; only the non-numeric fields
+ * (string, uuid, collections) are inherited from the {@link SimplePOJO} constructor.
  *
  * <pre>
  * | ClickHouse type | Max                        | How derived                          |
  * |-----------------|----------------------------|--------------------------------------|
- * | Int8            | Byte.MAX_VALUE (127)       | JDK constant (ctor)                  |
- * | Int16           | Short.MAX_VALUE            | JDK constant (ctor)                  |
- * | Int32           | Integer.MAX_VALUE          | JDK constant (ctor)                  |
+ * | Int8            | Byte.MAX_VALUE (127)       | JDK constant                         |
+ * | Int16           | Short.MAX_VALUE            | JDK constant                         |
+ * | Int32           | Integer.MAX_VALUE          | JDK constant                         |
  * | Int64           | Long.MAX_VALUE             | JDK constant; also ORDER BY key      |
  * | Int128          | 2^127 - 1                  | max signed 16-byte int               |
  * | Int256          | 2^255 - 1                  | max signed 32-byte int               |
@@ -29,8 +29,8 @@ import java.time.ZonedDateTime;
  * | UInt64          | 2^64 - 1                   | max unsigned 8-byte int              |
  * | UInt128         | 2^128 - 1                  | max unsigned 16-byte int             |
  * | UInt256         | 2^256 - 1                  | max unsigned 32-byte int             |
- * | Float32         | Float.MAX_VALUE            | JDK constant (ctor)                  |
- * | Float64         | Double.MAX_VALUE           | JDK constant (ctor)                  |
+ * | Float32         | Float.MAX_VALUE            | JDK constant                         |
+ * | Float64         | Double.MAX_VALUE           | JDK constant                         |
  * | Bool            | true                       | the larger of the two values         |
  * | Decimal(10,5)   | 99999.99999                | (10^P - 1) / 10^S, P=10 S=5          |
  * | Decimal32(9)    | 0.999999999                | (10^P - 1) / 10^S, P=9  S=9          |
@@ -43,16 +43,24 @@ import java.time.ZonedDateTime;
  * | DateTime64(6)   | 2299-12-31 23:59:59.999999 | CH DateTime64 max on 24.3            |
  * </pre>
  *
- * <p>Note: Date32 and DateTime64 ranges are ClickHouse-version-dependent. The values above
- * match the 24.3 image the tests run against (DateTime64 clamps to [1900-01-01, 2299-12-31]);
- * newer ClickHouse widens DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
+ * <p>Note: the two long-typed UInt64 fields hold Long.MAX_VALUE (a Java long cannot hold
+ * 2^64-1); the true UInt64 max lives on the BigInteger field. Date32 and DateTime64 ranges
+ * are ClickHouse-version-dependent: the values above match the 24.3 image the tests run
+ * against (DateTime64 clamps to [1900-01-01, 2299-12-31]); newer ClickHouse widens
+ * DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
  */
 public class MaxSimplePOJO extends SimplePOJO {
 
     public MaxSimplePOJO() {
         super(1);
+        setBytePrimitive(Byte.MAX_VALUE);
+        setByteObject(Byte.MAX_VALUE);
+        setShortPrimitive(Short.MAX_VALUE);
+        setShortObject(Short.MAX_VALUE);
+        setIntPrimitive(Integer.MAX_VALUE);
+        setIntegerObject(Integer.MAX_VALUE);
         setLongPrimitive(Long.MAX_VALUE); // Int64 max; also the ORDER BY key (sorts after MinSimplePOJO)
-        // ctor seeds these at signed maxima; override with the true unsigned maxima
+        setLongObject(Long.MAX_VALUE);
         setUint8PrimitiveInt(255);
         setUint8ObjectInt(255);
         setUint8PrimitiveShort((short) 255);
@@ -61,16 +69,24 @@ public class MaxSimplePOJO extends SimplePOJO {
         setUint16Object(65535);
         setUint32Primitive(4294967295L);
         setUint32Object(4294967295L);
-        setUint64ObjectBigInt(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));   // 2^64 - 1
-        setUint128Object(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE));       // 2^128 - 1
-        setUint256Object(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));       // 2^256 - 1
-        setBigInteger128(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE));       // Int128 max
-        setBigInteger256(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE));       // Int256 max
+        setUint64PrimitiveLong(Long.MAX_VALUE);                                        // long can't hold 2^64-1
+        setUint64ObjectLong(Long.MAX_VALUE);                                           // long can't hold 2^64-1
+        setUint64ObjectBigInt(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));  // 2^64 - 1
+        setBigInteger128(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE));      // Int128 max
+        setBigInteger256(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE));      // Int256 max
+        setUint128Object(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE));      // 2^128 - 1
+        setUint256Object(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));      // 2^256 - 1
         setBigDecimal(maxDecimal(10, 5));
         setBigDecimal32(maxDecimal(9, 9));
         setBigDecimal64(maxDecimal(18, 18));
         setBigDecimal128(maxDecimal(38, 38));
         setBigDecimal256(maxDecimal(76, 76));
+        setFloatPrimitive(Float.MAX_VALUE);
+        setFloatObject(Float.MAX_VALUE);
+        setDoublePrimitive(Double.MAX_VALUE);
+        setDoubleObject(Double.MAX_VALUE);
+        setBooleanPrimitive(true);
+        setBooleanObject(true);
         setDateObject(LocalDate.of(2149, 6, 6));
         setDate32Object(LocalDate.of(2299, 12, 31));
         setDateTimeObjectLocal(LocalDateTime.of(2106, 2, 7, 6, 28, 15));

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
@@ -1,0 +1,87 @@
+package org.apache.flink.connector.clickhouse.sink.pojo;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * {@link SimplePOJO} with every type set to its supported MAXIMUM (issue #114).
+ * longPrimitive = Long.MAX_VALUE (also the ORDER BY key), so it sorts after {@link MinSimplePOJO}.
+ *
+ * <p>Signed 8/16/32-bit and float/double maxima are inherited from the {@link SimplePOJO}
+ * constructor; the fields below are the ones that needed true extremes.
+ *
+ * <pre>
+ * | ClickHouse type | Max                        | How derived                          |
+ * |-----------------|----------------------------|--------------------------------------|
+ * | Int8            | Byte.MAX_VALUE (127)       | JDK constant (ctor)                  |
+ * | Int16           | Short.MAX_VALUE            | JDK constant (ctor)                  |
+ * | Int32           | Integer.MAX_VALUE          | JDK constant (ctor)                  |
+ * | Int64           | Long.MAX_VALUE             | JDK constant; also ORDER BY key      |
+ * | Int128          | 2^127 - 1                  | max signed 16-byte int               |
+ * | Int256          | 2^255 - 1                  | max signed 32-byte int               |
+ * | UInt8           | 255                        | max unsigned 1-byte int              |
+ * | UInt16          | 65535                      | max unsigned 2-byte int              |
+ * | UInt32          | 4294967295                 | max unsigned 4-byte int (2^32-1)     |
+ * | UInt64          | 2^64 - 1                   | max unsigned 8-byte int              |
+ * | UInt128         | 2^128 - 1                  | max unsigned 16-byte int             |
+ * | UInt256         | 2^256 - 1                  | max unsigned 32-byte int             |
+ * | Float32         | Float.MAX_VALUE            | JDK constant (ctor)                  |
+ * | Float64         | Double.MAX_VALUE           | JDK constant (ctor)                  |
+ * | Bool            | true                       | the larger of the two values         |
+ * | Decimal(10,5)   | 99999.99999                | (10^P - 1) / 10^S, P=10 S=5          |
+ * | Decimal32(9)    | 0.999999999                | (10^P - 1) / 10^S, P=9  S=9          |
+ * | Decimal64(18)   | 0.(18 nines)               | (10^P - 1) / 10^S, P=18 S=18         |
+ * | Decimal128(38)  | 0.(38 nines)               | (10^P - 1) / 10^S, P=38 S=38         |
+ * | Decimal256(76)  | 0.(76 nines)               | (10^P - 1) / 10^S, P=76 S=76         |
+ * | Date            | 2149-06-06                 | CH Date upper bound (UInt16 days)    |
+ * | Date32          | 2299-12-31                 | CH Date32 upper bound                |
+ * | DateTime        | 2106-02-07 06:28:15        | CH DateTime upper bound (UInt32 sec) |
+ * | DateTime64(6)   | 2299-12-31 23:59:59.999999 | CH DateTime64 max on 24.3            |
+ * </pre>
+ *
+ * <p>Note: Date32 and DateTime64 ranges are ClickHouse-version-dependent. The values above
+ * match the 24.3 image the tests run against (DateTime64 clamps to [1900-01-01, 2299-12-31]);
+ * newer ClickHouse widens DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
+ */
+public class MaxSimplePOJO extends SimplePOJO {
+
+    public MaxSimplePOJO() {
+        super(1);
+        setLongPrimitive(Long.MAX_VALUE); // Int64 max; also the ORDER BY key (sorts after MinSimplePOJO)
+        // ctor seeds these at signed maxima; override with the true unsigned maxima
+        setUint8PrimitiveInt(255);
+        setUint8ObjectInt(255);
+        setUint8PrimitiveShort((short) 255);
+        setUint8ObjectShort((short) 255);
+        setUint16Primitive(65535);
+        setUint16Object(65535);
+        setUint32Primitive(4294967295L);
+        setUint32Object(4294967295L);
+        setUint64ObjectBigInt(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));   // 2^64 - 1
+        setUint128Object(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE));       // 2^128 - 1
+        setUint256Object(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));       // 2^256 - 1
+        setBigInteger128(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE));       // Int128 max
+        setBigInteger256(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE));       // Int256 max
+        setBigDecimal(maxDecimal(10, 5));
+        setBigDecimal32(maxDecimal(9, 9));
+        setBigDecimal64(maxDecimal(18, 18));
+        setBigDecimal128(maxDecimal(38, 38));
+        setBigDecimal256(maxDecimal(76, 76));
+        setDateObject(LocalDate.of(2149, 6, 6));
+        setDate32Object(LocalDate.of(2299, 12, 31));
+        setDateTimeObjectLocal(LocalDateTime.of(2106, 2, 7, 6, 28, 15));
+        setDateTimeObjectZoned(ZonedDateTime.of(2106, 2, 7, 6, 28, 15, 0, ZoneId.of("UTC")));
+        // scale 6 => microseconds; 999_999_000 ns = .999999 us (the exact DateTime64 max on CH 24.3)
+        setDateTime64ObjectLocal(LocalDateTime.of(2299, 12, 31, 23, 59, 59, 999_999_000));
+        setDateTime64ObjectZoned(ZonedDateTime.of(2299, 12, 31, 23, 59, 59, 999_999_000, ZoneId.of("UTC")));
+    }
+
+    /** Largest unscaled value representable at {@code precision}, at the given {@code scale}. */
+    static BigDecimal maxDecimal(int precision, int scale) {
+        return new BigDecimal(BigInteger.TEN.pow(precision).subtract(BigInteger.ONE), scale);
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
@@ -10,16 +10,17 @@ import java.time.ZonedDateTime;
  * {@link SimplePOJO} with every type set to its supported MINIMUM (issue #114).
  * longPrimitive = Long.MIN_VALUE (also the ORDER BY key), so it sorts before {@link MaxSimplePOJO}.
  *
- * <p>Signed 8/16/32-bit minima are inherited from the {@link SimplePOJO} constructor.
- * Note {@code Float/Double.MIN_VALUE} are the smallest POSITIVE values (Java has no
- * most-negative float constant).
+ * <p>Every numeric and boolean field is set explicitly below; only the non-numeric fields
+ * (string, uuid, collections) are inherited from the {@link SimplePOJO} constructor.
+ * Float/Double minima use {@code -MAX_VALUE} (the most-negative value); {@code MIN_VALUE}
+ * would be the smallest POSITIVE value, not a lower bound.
  *
  * <pre>
  * | ClickHouse type | Min                   | How derived                     |
  * |-----------------|-----------------------|---------------------------------|
- * | Int8            | Byte.MIN_VALUE (-128) | JDK constant (ctor)             |
- * | Int16           | Short.MIN_VALUE       | JDK constant (ctor)             |
- * | Int32           | Integer.MIN_VALUE     | JDK constant (ctor)             |
+ * | Int8            | Byte.MIN_VALUE (-128) | JDK constant                    |
+ * | Int16           | Short.MIN_VALUE       | JDK constant                    |
+ * | Int32           | Integer.MIN_VALUE     | JDK constant                    |
  * | Int64           | Long.MIN_VALUE        | JDK constant; also ORDER BY key |
  * | Int128          | -2^127                | min signed 16-byte int          |
  * | Int256          | -2^255                | min signed 32-byte int          |
@@ -29,8 +30,8 @@ import java.time.ZonedDateTime;
  * | UInt64          | 0                     | unsigned min                    |
  * | UInt128         | 0                     | unsigned min                    |
  * | UInt256         | 0                     | unsigned min                    |
- * | Float32         | Float.MIN_VALUE       | smallest POSITIVE float (ctor)  |
- * | Float64         | Double.MIN_VALUE      | smallest POSITIVE double (ctor) |
+ * | Float32         | -Float.MAX_VALUE      | most negative float             |
+ * | Float64         | -Double.MAX_VALUE     | most negative double            |
  * | Bool            | false                 | the smaller of the two values   |
  * | Decimal(10,5)   | -99999.99999          | -(10^P - 1) / 10^S, P=10 S=5    |
  * | Decimal32(9)    | -0.999999999          | -(10^P - 1) / 10^S, P=9  S=9    |
@@ -51,18 +52,40 @@ public class MinSimplePOJO extends SimplePOJO {
 
     public MinSimplePOJO() {
         super(0);
+        setBytePrimitive(Byte.MIN_VALUE);
+        setByteObject(Byte.MIN_VALUE);
+        setShortPrimitive(Short.MIN_VALUE);
+        setShortObject(Short.MIN_VALUE);
+        setIntPrimitive(Integer.MIN_VALUE);
+        setIntegerObject(Integer.MIN_VALUE);
         setLongPrimitive(Long.MIN_VALUE); // Int64 min; also the ORDER BY key (sorts before MaxSimplePOJO)
-        setLongObject(Long.MIN_VALUE);    // Int64 min (ctor seeds this to Long.MAX_VALUE)
+        setLongObject(Long.MIN_VALUE);
+        setUint8PrimitiveInt(0);
+        setUint8ObjectInt(0);
+        setUint8PrimitiveShort((short) 0);
+        setUint8ObjectShort((short) 0);
+        setUint16Primitive(0);
+        setUint16Object(0);
+        setUint32Primitive(0L);
+        setUint32Object(0L);
+        setUint64PrimitiveLong(0L);
+        setUint64ObjectLong(0L);
         setUint64ObjectBigInt(BigInteger.ZERO);
-        setUint128Object(BigInteger.ZERO);
-        setUint256Object(BigInteger.ZERO);
         setBigInteger128(BigInteger.ONE.shiftLeft(127).negate());   // Int128 min = -2^127
         setBigInteger256(BigInteger.ONE.shiftLeft(255).negate());   // Int256 min = -2^255
+        setUint128Object(BigInteger.ZERO);
+        setUint256Object(BigInteger.ZERO);
         setBigDecimal(MaxSimplePOJO.maxDecimal(10, 5).negate());
         setBigDecimal32(MaxSimplePOJO.maxDecimal(9, 9).negate());
         setBigDecimal64(MaxSimplePOJO.maxDecimal(18, 18).negate());
         setBigDecimal128(MaxSimplePOJO.maxDecimal(38, 38).negate());
         setBigDecimal256(MaxSimplePOJO.maxDecimal(76, 76).negate());
+        setFloatPrimitive(-Float.MAX_VALUE);
+        setFloatObject(-Float.MAX_VALUE);
+        setDoublePrimitive(-Double.MAX_VALUE);
+        setDoubleObject(-Double.MAX_VALUE);
+        setBooleanPrimitive(false);
+        setBooleanObject(false);
         setDateObject(LocalDate.of(1970, 1, 1));
         setDate32Object(LocalDate.of(1900, 1, 1));
         setDateTimeObjectLocal(LocalDateTime.of(1970, 1, 1, 0, 0, 0));

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
@@ -1,0 +1,73 @@
+package org.apache.flink.connector.clickhouse.sink.pojo;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * {@link SimplePOJO} with every type set to its supported MINIMUM (issue #114).
+ * longPrimitive = Long.MIN_VALUE (also the ORDER BY key), so it sorts before {@link MaxSimplePOJO}.
+ *
+ * <p>Signed 8/16/32-bit minima are inherited from the {@link SimplePOJO} constructor.
+ * Note {@code Float/Double.MIN_VALUE} are the smallest POSITIVE values (Java has no
+ * most-negative float constant).
+ *
+ * <pre>
+ * | ClickHouse type | Min                   | How derived                     |
+ * |-----------------|-----------------------|---------------------------------|
+ * | Int8            | Byte.MIN_VALUE (-128) | JDK constant (ctor)             |
+ * | Int16           | Short.MIN_VALUE       | JDK constant (ctor)             |
+ * | Int32           | Integer.MIN_VALUE     | JDK constant (ctor)             |
+ * | Int64           | Long.MIN_VALUE        | JDK constant; also ORDER BY key |
+ * | Int128          | -2^127                | min signed 16-byte int          |
+ * | Int256          | -2^255                | min signed 32-byte int          |
+ * | UInt8           | 0                     | unsigned min                    |
+ * | UInt16          | 0                     | unsigned min                    |
+ * | UInt32          | 0                     | unsigned min                    |
+ * | UInt64          | 0                     | unsigned min                    |
+ * | UInt128         | 0                     | unsigned min                    |
+ * | UInt256         | 0                     | unsigned min                    |
+ * | Float32         | Float.MIN_VALUE       | smallest POSITIVE float (ctor)  |
+ * | Float64         | Double.MIN_VALUE      | smallest POSITIVE double (ctor) |
+ * | Bool            | false                 | the smaller of the two values   |
+ * | Decimal(10,5)   | -99999.99999          | -(10^P - 1) / 10^S, P=10 S=5    |
+ * | Decimal32(9)    | -0.999999999          | -(10^P - 1) / 10^S, P=9  S=9    |
+ * | Decimal64(18)   | -0.(18 nines)         | -(10^P - 1) / 10^S, P=18 S=18   |
+ * | Decimal128(38)  | -0.(38 nines)         | -(10^P - 1) / 10^S, P=38 S=38   |
+ * | Decimal256(76)  | -0.(76 nines)         | -(10^P - 1) / 10^S, P=76 S=76   |
+ * | Date            | 1970-01-01            | CH Date lower bound (epoch)     |
+ * | Date32          | 1900-01-01            | CH Date32 lower bound           |
+ * | DateTime        | 1970-01-01 00:00:00   | CH DateTime lower bound (epoch) |
+ * | DateTime64(6)   | 1900-01-01 00:00:00   | CH DateTime64 min on 24.3       |
+ * </pre>
+ *
+ * <p>Note: Date32 and DateTime64 ranges are ClickHouse-version-dependent. The values above
+ * match the 24.3 image the tests run against (DateTime64 clamps to [1900-01-01, 2299-12-31]);
+ * newer ClickHouse widens DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
+ */
+public class MinSimplePOJO extends SimplePOJO {
+
+    public MinSimplePOJO() {
+        super(0);
+        setLongPrimitive(Long.MIN_VALUE); // Int64 min; also the ORDER BY key (sorts before MaxSimplePOJO)
+        setLongObject(Long.MIN_VALUE);    // Int64 min (ctor seeds this to Long.MAX_VALUE)
+        setUint64ObjectBigInt(BigInteger.ZERO);
+        setUint128Object(BigInteger.ZERO);
+        setUint256Object(BigInteger.ZERO);
+        setBigInteger128(BigInteger.ONE.shiftLeft(127).negate());   // Int128 min = -2^127
+        setBigInteger256(BigInteger.ONE.shiftLeft(255).negate());   // Int256 min = -2^255
+        setBigDecimal(MaxSimplePOJO.maxDecimal(10, 5).negate());
+        setBigDecimal32(MaxSimplePOJO.maxDecimal(9, 9).negate());
+        setBigDecimal64(MaxSimplePOJO.maxDecimal(18, 18).negate());
+        setBigDecimal128(MaxSimplePOJO.maxDecimal(38, 38).negate());
+        setBigDecimal256(MaxSimplePOJO.maxDecimal(76, 76).negate());
+        setDateObject(LocalDate.of(1970, 1, 1));
+        setDate32Object(LocalDate.of(1900, 1, 1));
+        setDateTimeObjectLocal(LocalDateTime.of(1970, 1, 1, 0, 0, 0));
+        setDateTimeObjectZoned(ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")));
+        setDateTime64ObjectLocal(LocalDateTime.of(1900, 1, 1, 0, 0, 0));
+        setDateTime64ObjectZoned(ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")));
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
@@ -15,6 +15,8 @@ import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOWithDefaul
 import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOWithJSONDataMapper;
 import org.apache.flink.connector.clickhouse.sink.pojo.DateTimePOJO;
 import org.apache.flink.connector.clickhouse.sink.pojo.SimplePOJO;
+import org.apache.flink.connector.clickhouse.sink.pojo.MaxSimplePOJO;
+import org.apache.flink.connector.clickhouse.sink.pojo.MinSimplePOJO;
 import org.apache.flink.connector.clickhouse.sink.pojo.SimplePOJOWithDefaults;
 import org.apache.flink.connector.clickhouse.sink.pojo.SimplePOJOWithJSON;
 import org.apache.flink.connector.test.FlinkClusterTests;
@@ -115,6 +117,52 @@ public class ClickHouseTypeTests extends FlinkClusterTests {
         // read back the table and validate the rows
         List<SimplePOJO> actualPOJOs = ClickHouseServerForTests.extractAllDataToPOJO(getDatabase(), tableName, "longPrimitive", SimplePOJO.class);
         Assertions.assertEquals(simplePOJOList, actualPOJOs);
+    }
+
+    /** Round-trips the true min/max of every supported type through a real ClickHouse (issue #114). */
+    @Test
+    void testSimplePOJOBoundaryValues() throws Exception {
+        String tableName = "simple_pojo_boundary";
+
+        ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQL(getDatabase(), tableName));
+
+        // read back is ordered by longPrimitive, so keep the expected list in that order (0, 1).
+        List<SimplePOJO> expected = List.of(new MinSimplePOJO(), new MaxSimplePOJO());
+
+        List<SimplePOJO> actual = runSimplePOJORoundTrip(tableName, expected);
+        Assertions.assertEquals(expected, actual);
+    }
+
+    /** Sends {@code pojos} through the async sink and reads them back ordered by longPrimitive. */
+    private List<SimplePOJO> runSimplePOJORoundTrip(String tableName, List<SimplePOJO> pojos) throws Exception {
+        TableSchema tableSchema = ClickHouseServerForTests.getTableSchema(tableName);
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(STREAM_PARALLELISM);
+
+        ClickHouseClientConfig clickHouseClientConfig = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        clickHouseClientConfig.setSupportDefault(tableSchema.hasDefaults());
+
+        ClickHouseConvertor<SimplePOJO> convertor = new ClickHouseConvertor<>(SimplePOJO.class, new SimplePOJODataMapper());
+
+        ClickHouseAsyncSink<SimplePOJO> sink = ClickHouseAsyncSink.<SimplePOJO>builder()
+                .setElementConverter(convertor)
+                .setMaxBatchSize(MAX_BATCH_SIZE)
+                .setMaxInFlightRequests(MAX_IN_FLIGHT_REQUESTS)
+                .setMaxBufferedRequests(MAX_BUFFERED_REQUESTS)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(clickHouseClientConfig)
+                .build();
+
+        // pojos may be a mix of SimplePOJO subclasses (Min/Max), so pin the element type explicitly.
+        DataStream<SimplePOJO> stream = env.fromCollection(pojos, TypeInformation.of(SimplePOJO.class));
+        stream.sinkTo(sink);
+        int rows = executeAsyncJob(env, tableName, 10, pojos.size());
+        Assertions.assertEquals(pojos.size(), rows);
+
+        return ClickHouseServerForTests.extractAllDataToPOJO(getDatabase(), tableName, "longPrimitive", SimplePOJO.class);
     }
 
     @ParameterizedTest

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
@@ -126,7 +126,8 @@ public class ClickHouseTypeTests extends FlinkClusterTests {
 
         ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQL(getDatabase(), tableName));
 
-        // read back is ordered by longPrimitive, so keep the expected list in that order (0, 1).
+        // read back is ordered by longPrimitive (Long.MIN_VALUE < Long.MAX_VALUE),
+        // so keep the expected list min-then-max to match.
         List<SimplePOJO> expected = List.of(new MinSimplePOJO(), new MaxSimplePOJO());
 
         List<SimplePOJO> actual = runSimplePOJORoundTrip(tableName, expected);

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
@@ -11,15 +11,15 @@ import java.time.ZonedDateTime;
  * {@link SimplePOJO} with every type set to its supported MAXIMUM (issue #114).
  * longPrimitive = Long.MAX_VALUE (also the ORDER BY key), so it sorts after {@link MinSimplePOJO}.
  *
- * <p>Signed 8/16/32-bit and float/double maxima are inherited from the {@link SimplePOJO}
- * constructor; the fields below are the ones that needed true extremes.
+ * <p>Every numeric and boolean field is set explicitly below; only the non-numeric fields
+ * (string, uuid, collections) are inherited from the {@link SimplePOJO} constructor.
  *
  * <pre>
  * | ClickHouse type | Max                        | How derived                          |
  * |-----------------|----------------------------|--------------------------------------|
- * | Int8            | Byte.MAX_VALUE (127)       | JDK constant (ctor)                  |
- * | Int16           | Short.MAX_VALUE            | JDK constant (ctor)                  |
- * | Int32           | Integer.MAX_VALUE          | JDK constant (ctor)                  |
+ * | Int8            | Byte.MAX_VALUE (127)       | JDK constant                         |
+ * | Int16           | Short.MAX_VALUE            | JDK constant                         |
+ * | Int32           | Integer.MAX_VALUE          | JDK constant                         |
  * | Int64           | Long.MAX_VALUE             | JDK constant; also ORDER BY key      |
  * | Int128          | 2^127 - 1                  | max signed 16-byte int               |
  * | Int256          | 2^255 - 1                  | max signed 32-byte int               |
@@ -29,8 +29,8 @@ import java.time.ZonedDateTime;
  * | UInt64          | 2^64 - 1                   | max unsigned 8-byte int              |
  * | UInt128         | 2^128 - 1                  | max unsigned 16-byte int             |
  * | UInt256         | 2^256 - 1                  | max unsigned 32-byte int             |
- * | Float32         | Float.MAX_VALUE            | JDK constant (ctor)                  |
- * | Float64         | Double.MAX_VALUE           | JDK constant (ctor)                  |
+ * | Float32         | Float.MAX_VALUE            | JDK constant                         |
+ * | Float64         | Double.MAX_VALUE           | JDK constant                         |
  * | Bool            | true                       | the larger of the two values         |
  * | Decimal(10,5)   | 99999.99999                | (10^P - 1) / 10^S, P=10 S=5          |
  * | Decimal32(9)    | 0.999999999                | (10^P - 1) / 10^S, P=9  S=9          |
@@ -43,16 +43,24 @@ import java.time.ZonedDateTime;
  * | DateTime64(6)   | 2299-12-31 23:59:59.999999 | CH DateTime64 max on 24.3            |
  * </pre>
  *
- * <p>Note: Date32 and DateTime64 ranges are ClickHouse-version-dependent. The values above
- * match the 24.3 image the tests run against (DateTime64 clamps to [1900-01-01, 2299-12-31]);
- * newer ClickHouse widens DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
+ * <p>Note: the two long-typed UInt64 fields hold Long.MAX_VALUE (a Java long cannot hold
+ * 2^64-1); the true UInt64 max lives on the BigInteger field. Date32 and DateTime64 ranges
+ * are ClickHouse-version-dependent: the values above match the 24.3 image the tests run
+ * against (DateTime64 clamps to [1900-01-01, 2299-12-31]); newer ClickHouse widens
+ * DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
  */
 public class MaxSimplePOJO extends SimplePOJO {
 
     public MaxSimplePOJO() {
         super(1);
+        setBytePrimitive(Byte.MAX_VALUE);
+        setByteObject(Byte.MAX_VALUE);
+        setShortPrimitive(Short.MAX_VALUE);
+        setShortObject(Short.MAX_VALUE);
+        setIntPrimitive(Integer.MAX_VALUE);
+        setIntegerObject(Integer.MAX_VALUE);
         setLongPrimitive(Long.MAX_VALUE); // Int64 max; also the ORDER BY key (sorts after MinSimplePOJO)
-        // ctor seeds these at signed maxima; override with the true unsigned maxima
+        setLongObject(Long.MAX_VALUE);
         setUint8PrimitiveInt(255);
         setUint8ObjectInt(255);
         setUint8PrimitiveShort((short) 255);
@@ -61,16 +69,24 @@ public class MaxSimplePOJO extends SimplePOJO {
         setUint16Object(65535);
         setUint32Primitive(4294967295L);
         setUint32Object(4294967295L);
-        setUint64ObjectBigInt(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));   // 2^64 - 1
-        setUint128Object(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE));       // 2^128 - 1
-        setUint256Object(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));       // 2^256 - 1
-        setBigInteger128(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE));       // Int128 max
-        setBigInteger256(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE));       // Int256 max
+        setUint64PrimitiveLong(Long.MAX_VALUE);                                        // long can't hold 2^64-1
+        setUint64ObjectLong(Long.MAX_VALUE);                                           // long can't hold 2^64-1
+        setUint64ObjectBigInt(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));  // 2^64 - 1
+        setBigInteger128(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE));      // Int128 max
+        setBigInteger256(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE));      // Int256 max
+        setUint128Object(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE));      // 2^128 - 1
+        setUint256Object(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));      // 2^256 - 1
         setBigDecimal(maxDecimal(10, 5));
         setBigDecimal32(maxDecimal(9, 9));
         setBigDecimal64(maxDecimal(18, 18));
         setBigDecimal128(maxDecimal(38, 38));
         setBigDecimal256(maxDecimal(76, 76));
+        setFloatPrimitive(Float.MAX_VALUE);
+        setFloatObject(Float.MAX_VALUE);
+        setDoublePrimitive(Double.MAX_VALUE);
+        setDoubleObject(Double.MAX_VALUE);
+        setBooleanPrimitive(true);
+        setBooleanObject(true);
         setDateObject(LocalDate.of(2149, 6, 6));
         setDate32Object(LocalDate.of(2299, 12, 31));
         setDateTimeObjectLocal(LocalDateTime.of(2106, 2, 7, 6, 28, 15));

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MaxSimplePOJO.java
@@ -1,0 +1,87 @@
+package org.apache.flink.connector.clickhouse.sink.pojo;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * {@link SimplePOJO} with every type set to its supported MAXIMUM (issue #114).
+ * longPrimitive = Long.MAX_VALUE (also the ORDER BY key), so it sorts after {@link MinSimplePOJO}.
+ *
+ * <p>Signed 8/16/32-bit and float/double maxima are inherited from the {@link SimplePOJO}
+ * constructor; the fields below are the ones that needed true extremes.
+ *
+ * <pre>
+ * | ClickHouse type | Max                        | How derived                          |
+ * |-----------------|----------------------------|--------------------------------------|
+ * | Int8            | Byte.MAX_VALUE (127)       | JDK constant (ctor)                  |
+ * | Int16           | Short.MAX_VALUE            | JDK constant (ctor)                  |
+ * | Int32           | Integer.MAX_VALUE          | JDK constant (ctor)                  |
+ * | Int64           | Long.MAX_VALUE             | JDK constant; also ORDER BY key      |
+ * | Int128          | 2^127 - 1                  | max signed 16-byte int               |
+ * | Int256          | 2^255 - 1                  | max signed 32-byte int               |
+ * | UInt8           | 255                        | max unsigned 1-byte int              |
+ * | UInt16          | 65535                      | max unsigned 2-byte int              |
+ * | UInt32          | 4294967295                 | max unsigned 4-byte int (2^32-1)     |
+ * | UInt64          | 2^64 - 1                   | max unsigned 8-byte int              |
+ * | UInt128         | 2^128 - 1                  | max unsigned 16-byte int             |
+ * | UInt256         | 2^256 - 1                  | max unsigned 32-byte int             |
+ * | Float32         | Float.MAX_VALUE            | JDK constant (ctor)                  |
+ * | Float64         | Double.MAX_VALUE           | JDK constant (ctor)                  |
+ * | Bool            | true                       | the larger of the two values         |
+ * | Decimal(10,5)   | 99999.99999                | (10^P - 1) / 10^S, P=10 S=5          |
+ * | Decimal32(9)    | 0.999999999                | (10^P - 1) / 10^S, P=9  S=9          |
+ * | Decimal64(18)   | 0.(18 nines)               | (10^P - 1) / 10^S, P=18 S=18         |
+ * | Decimal128(38)  | 0.(38 nines)               | (10^P - 1) / 10^S, P=38 S=38         |
+ * | Decimal256(76)  | 0.(76 nines)               | (10^P - 1) / 10^S, P=76 S=76         |
+ * | Date            | 2149-06-06                 | CH Date upper bound (UInt16 days)    |
+ * | Date32          | 2299-12-31                 | CH Date32 upper bound                |
+ * | DateTime        | 2106-02-07 06:28:15        | CH DateTime upper bound (UInt32 sec) |
+ * | DateTime64(6)   | 2299-12-31 23:59:59.999999 | CH DateTime64 max on 24.3            |
+ * </pre>
+ *
+ * <p>Note: Date32 and DateTime64 ranges are ClickHouse-version-dependent. The values above
+ * match the 24.3 image the tests run against (DateTime64 clamps to [1900-01-01, 2299-12-31]);
+ * newer ClickHouse widens DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
+ */
+public class MaxSimplePOJO extends SimplePOJO {
+
+    public MaxSimplePOJO() {
+        super(1);
+        setLongPrimitive(Long.MAX_VALUE); // Int64 max; also the ORDER BY key (sorts after MinSimplePOJO)
+        // ctor seeds these at signed maxima; override with the true unsigned maxima
+        setUint8PrimitiveInt(255);
+        setUint8ObjectInt(255);
+        setUint8PrimitiveShort((short) 255);
+        setUint8ObjectShort((short) 255);
+        setUint16Primitive(65535);
+        setUint16Object(65535);
+        setUint32Primitive(4294967295L);
+        setUint32Object(4294967295L);
+        setUint64ObjectBigInt(BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE));   // 2^64 - 1
+        setUint128Object(BigInteger.ONE.shiftLeft(128).subtract(BigInteger.ONE));       // 2^128 - 1
+        setUint256Object(BigInteger.ONE.shiftLeft(256).subtract(BigInteger.ONE));       // 2^256 - 1
+        setBigInteger128(BigInteger.ONE.shiftLeft(127).subtract(BigInteger.ONE));       // Int128 max
+        setBigInteger256(BigInteger.ONE.shiftLeft(255).subtract(BigInteger.ONE));       // Int256 max
+        setBigDecimal(maxDecimal(10, 5));
+        setBigDecimal32(maxDecimal(9, 9));
+        setBigDecimal64(maxDecimal(18, 18));
+        setBigDecimal128(maxDecimal(38, 38));
+        setBigDecimal256(maxDecimal(76, 76));
+        setDateObject(LocalDate.of(2149, 6, 6));
+        setDate32Object(LocalDate.of(2299, 12, 31));
+        setDateTimeObjectLocal(LocalDateTime.of(2106, 2, 7, 6, 28, 15));
+        setDateTimeObjectZoned(ZonedDateTime.of(2106, 2, 7, 6, 28, 15, 0, ZoneId.of("UTC")));
+        // scale 6 => microseconds; 999_999_000 ns = .999999 us (the exact DateTime64 max on CH 24.3)
+        setDateTime64ObjectLocal(LocalDateTime.of(2299, 12, 31, 23, 59, 59, 999_999_000));
+        setDateTime64ObjectZoned(ZonedDateTime.of(2299, 12, 31, 23, 59, 59, 999_999_000, ZoneId.of("UTC")));
+    }
+
+    /** Largest unscaled value representable at {@code precision}, at the given {@code scale}. */
+    static BigDecimal maxDecimal(int precision, int scale) {
+        return new BigDecimal(BigInteger.TEN.pow(precision).subtract(BigInteger.ONE), scale);
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
@@ -10,16 +10,17 @@ import java.time.ZonedDateTime;
  * {@link SimplePOJO} with every type set to its supported MINIMUM (issue #114).
  * longPrimitive = Long.MIN_VALUE (also the ORDER BY key), so it sorts before {@link MaxSimplePOJO}.
  *
- * <p>Signed 8/16/32-bit minima are inherited from the {@link SimplePOJO} constructor.
- * Note {@code Float/Double.MIN_VALUE} are the smallest POSITIVE values (Java has no
- * most-negative float constant).
+ * <p>Every numeric and boolean field is set explicitly below; only the non-numeric fields
+ * (string, uuid, collections) are inherited from the {@link SimplePOJO} constructor.
+ * Float/Double minima use {@code -MAX_VALUE} (the most-negative value); {@code MIN_VALUE}
+ * would be the smallest POSITIVE value, not a lower bound.
  *
  * <pre>
  * | ClickHouse type | Min                   | How derived                     |
  * |-----------------|-----------------------|---------------------------------|
- * | Int8            | Byte.MIN_VALUE (-128) | JDK constant (ctor)             |
- * | Int16           | Short.MIN_VALUE       | JDK constant (ctor)             |
- * | Int32           | Integer.MIN_VALUE     | JDK constant (ctor)             |
+ * | Int8            | Byte.MIN_VALUE (-128) | JDK constant                    |
+ * | Int16           | Short.MIN_VALUE       | JDK constant                    |
+ * | Int32           | Integer.MIN_VALUE     | JDK constant                    |
  * | Int64           | Long.MIN_VALUE        | JDK constant; also ORDER BY key |
  * | Int128          | -2^127                | min signed 16-byte int          |
  * | Int256          | -2^255                | min signed 32-byte int          |
@@ -29,8 +30,8 @@ import java.time.ZonedDateTime;
  * | UInt64          | 0                     | unsigned min                    |
  * | UInt128         | 0                     | unsigned min                    |
  * | UInt256         | 0                     | unsigned min                    |
- * | Float32         | Float.MIN_VALUE       | smallest POSITIVE float (ctor)  |
- * | Float64         | Double.MIN_VALUE      | smallest POSITIVE double (ctor) |
+ * | Float32         | -Float.MAX_VALUE      | most negative float             |
+ * | Float64         | -Double.MAX_VALUE     | most negative double            |
  * | Bool            | false                 | the smaller of the two values   |
  * | Decimal(10,5)   | -99999.99999          | -(10^P - 1) / 10^S, P=10 S=5    |
  * | Decimal32(9)    | -0.999999999          | -(10^P - 1) / 10^S, P=9  S=9    |
@@ -51,18 +52,40 @@ public class MinSimplePOJO extends SimplePOJO {
 
     public MinSimplePOJO() {
         super(0);
+        setBytePrimitive(Byte.MIN_VALUE);
+        setByteObject(Byte.MIN_VALUE);
+        setShortPrimitive(Short.MIN_VALUE);
+        setShortObject(Short.MIN_VALUE);
+        setIntPrimitive(Integer.MIN_VALUE);
+        setIntegerObject(Integer.MIN_VALUE);
         setLongPrimitive(Long.MIN_VALUE); // Int64 min; also the ORDER BY key (sorts before MaxSimplePOJO)
-        setLongObject(Long.MIN_VALUE);    // Int64 min (ctor seeds this to Long.MAX_VALUE)
+        setLongObject(Long.MIN_VALUE);
+        setUint8PrimitiveInt(0);
+        setUint8ObjectInt(0);
+        setUint8PrimitiveShort((short) 0);
+        setUint8ObjectShort((short) 0);
+        setUint16Primitive(0);
+        setUint16Object(0);
+        setUint32Primitive(0L);
+        setUint32Object(0L);
+        setUint64PrimitiveLong(0L);
+        setUint64ObjectLong(0L);
         setUint64ObjectBigInt(BigInteger.ZERO);
-        setUint128Object(BigInteger.ZERO);
-        setUint256Object(BigInteger.ZERO);
         setBigInteger128(BigInteger.ONE.shiftLeft(127).negate());   // Int128 min = -2^127
         setBigInteger256(BigInteger.ONE.shiftLeft(255).negate());   // Int256 min = -2^255
+        setUint128Object(BigInteger.ZERO);
+        setUint256Object(BigInteger.ZERO);
         setBigDecimal(MaxSimplePOJO.maxDecimal(10, 5).negate());
         setBigDecimal32(MaxSimplePOJO.maxDecimal(9, 9).negate());
         setBigDecimal64(MaxSimplePOJO.maxDecimal(18, 18).negate());
         setBigDecimal128(MaxSimplePOJO.maxDecimal(38, 38).negate());
         setBigDecimal256(MaxSimplePOJO.maxDecimal(76, 76).negate());
+        setFloatPrimitive(-Float.MAX_VALUE);
+        setFloatObject(-Float.MAX_VALUE);
+        setDoublePrimitive(-Double.MAX_VALUE);
+        setDoubleObject(-Double.MAX_VALUE);
+        setBooleanPrimitive(false);
+        setBooleanObject(false);
         setDateObject(LocalDate.of(1970, 1, 1));
         setDate32Object(LocalDate.of(1900, 1, 1));
         setDateTimeObjectLocal(LocalDateTime.of(1970, 1, 1, 0, 0, 0));

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/pojo/MinSimplePOJO.java
@@ -1,0 +1,73 @@
+package org.apache.flink.connector.clickhouse.sink.pojo;
+
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+/**
+ * {@link SimplePOJO} with every type set to its supported MINIMUM (issue #114).
+ * longPrimitive = Long.MIN_VALUE (also the ORDER BY key), so it sorts before {@link MaxSimplePOJO}.
+ *
+ * <p>Signed 8/16/32-bit minima are inherited from the {@link SimplePOJO} constructor.
+ * Note {@code Float/Double.MIN_VALUE} are the smallest POSITIVE values (Java has no
+ * most-negative float constant).
+ *
+ * <pre>
+ * | ClickHouse type | Min                   | How derived                     |
+ * |-----------------|-----------------------|---------------------------------|
+ * | Int8            | Byte.MIN_VALUE (-128) | JDK constant (ctor)             |
+ * | Int16           | Short.MIN_VALUE       | JDK constant (ctor)             |
+ * | Int32           | Integer.MIN_VALUE     | JDK constant (ctor)             |
+ * | Int64           | Long.MIN_VALUE        | JDK constant; also ORDER BY key |
+ * | Int128          | -2^127                | min signed 16-byte int          |
+ * | Int256          | -2^255                | min signed 32-byte int          |
+ * | UInt8           | 0                     | unsigned min                    |
+ * | UInt16          | 0                     | unsigned min                    |
+ * | UInt32          | 0                     | unsigned min                    |
+ * | UInt64          | 0                     | unsigned min                    |
+ * | UInt128         | 0                     | unsigned min                    |
+ * | UInt256         | 0                     | unsigned min                    |
+ * | Float32         | Float.MIN_VALUE       | smallest POSITIVE float (ctor)  |
+ * | Float64         | Double.MIN_VALUE      | smallest POSITIVE double (ctor) |
+ * | Bool            | false                 | the smaller of the two values   |
+ * | Decimal(10,5)   | -99999.99999          | -(10^P - 1) / 10^S, P=10 S=5    |
+ * | Decimal32(9)    | -0.999999999          | -(10^P - 1) / 10^S, P=9  S=9    |
+ * | Decimal64(18)   | -0.(18 nines)         | -(10^P - 1) / 10^S, P=18 S=18   |
+ * | Decimal128(38)  | -0.(38 nines)         | -(10^P - 1) / 10^S, P=38 S=38   |
+ * | Decimal256(76)  | -0.(76 nines)         | -(10^P - 1) / 10^S, P=76 S=76   |
+ * | Date            | 1970-01-01            | CH Date lower bound (epoch)     |
+ * | Date32          | 1900-01-01            | CH Date32 lower bound           |
+ * | DateTime        | 1970-01-01 00:00:00   | CH DateTime lower bound (epoch) |
+ * | DateTime64(6)   | 1900-01-01 00:00:00   | CH DateTime64 min on 24.3       |
+ * </pre>
+ *
+ * <p>Note: Date32 and DateTime64 ranges are ClickHouse-version-dependent. The values above
+ * match the 24.3 image the tests run against (DateTime64 clamps to [1900-01-01, 2299-12-31]);
+ * newer ClickHouse widens DateTime64 to [0000-01-01, 9999-12-31] for precision &lt;= 7.
+ */
+public class MinSimplePOJO extends SimplePOJO {
+
+    public MinSimplePOJO() {
+        super(0);
+        setLongPrimitive(Long.MIN_VALUE); // Int64 min; also the ORDER BY key (sorts before MaxSimplePOJO)
+        setLongObject(Long.MIN_VALUE);    // Int64 min (ctor seeds this to Long.MAX_VALUE)
+        setUint64ObjectBigInt(BigInteger.ZERO);
+        setUint128Object(BigInteger.ZERO);
+        setUint256Object(BigInteger.ZERO);
+        setBigInteger128(BigInteger.ONE.shiftLeft(127).negate());   // Int128 min = -2^127
+        setBigInteger256(BigInteger.ONE.shiftLeft(255).negate());   // Int256 min = -2^255
+        setBigDecimal(MaxSimplePOJO.maxDecimal(10, 5).negate());
+        setBigDecimal32(MaxSimplePOJO.maxDecimal(9, 9).negate());
+        setBigDecimal64(MaxSimplePOJO.maxDecimal(18, 18).negate());
+        setBigDecimal128(MaxSimplePOJO.maxDecimal(38, 38).negate());
+        setBigDecimal256(MaxSimplePOJO.maxDecimal(76, 76).negate());
+        setDateObject(LocalDate.of(1970, 1, 1));
+        setDate32Object(LocalDate.of(1900, 1, 1));
+        setDateTimeObjectLocal(LocalDateTime.of(1970, 1, 1, 0, 0, 0));
+        setDateTimeObjectZoned(ZonedDateTime.of(1970, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")));
+        setDateTime64ObjectLocal(LocalDateTime.of(1900, 1, 1, 0, 0, 0));
+        setDateTime64ObjectZoned(ZonedDateTime.of(1900, 1, 1, 0, 0, 0, 0, ZoneId.of("UTC")));
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
@@ -15,6 +15,8 @@ import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOWithDefaul
 import org.apache.flink.connector.clickhouse.sink.convertor.SimplePOJOWithJSONDataMapper;
 import org.apache.flink.connector.clickhouse.sink.pojo.DateTimePOJO;
 import org.apache.flink.connector.clickhouse.sink.pojo.SimplePOJO;
+import org.apache.flink.connector.clickhouse.sink.pojo.MaxSimplePOJO;
+import org.apache.flink.connector.clickhouse.sink.pojo.MinSimplePOJO;
 import org.apache.flink.connector.clickhouse.sink.pojo.SimplePOJOWithDefaults;
 import org.apache.flink.connector.clickhouse.sink.pojo.SimplePOJOWithJSON;
 import org.apache.flink.connector.test.FlinkClusterTests;
@@ -115,6 +117,52 @@ public class ClickHouseTypeTests extends FlinkClusterTests {
         // read back the table and validate the rows
         List<SimplePOJO> actualPOJOs = ClickHouseServerForTests.extractAllDataToPOJO(getDatabase(), tableName, "longPrimitive", SimplePOJO.class);
         Assertions.assertEquals(simplePOJOList, actualPOJOs);
+    }
+
+    /** Round-trips the true min/max of every supported type through a real ClickHouse (issue #114). */
+    @Test
+    void testSimplePOJOBoundaryValues() throws Exception {
+        String tableName = "simple_pojo_boundary";
+
+        ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQL(getDatabase(), tableName));
+
+        // read back is ordered by longPrimitive, so keep the expected list in that order (0, 1).
+        List<SimplePOJO> expected = List.of(new MinSimplePOJO(), new MaxSimplePOJO());
+
+        List<SimplePOJO> actual = runSimplePOJORoundTrip(tableName, expected);
+        Assertions.assertEquals(expected, actual);
+    }
+
+    /** Sends {@code pojos} through the async sink and reads them back ordered by longPrimitive. */
+    private List<SimplePOJO> runSimplePOJORoundTrip(String tableName, List<SimplePOJO> pojos) throws Exception {
+        TableSchema tableSchema = ClickHouseServerForTests.getTableSchema(tableName);
+
+        final StreamExecutionEnvironment env = StreamExecutionEnvironment.getExecutionEnvironment();
+        env.setParallelism(STREAM_PARALLELISM);
+
+        ClickHouseClientConfig clickHouseClientConfig = new ClickHouseClientConfig(getServerURL(), getUsername(), getPassword(), getDatabase(), tableName);
+        clickHouseClientConfig.setSupportDefault(tableSchema.hasDefaults());
+
+        ClickHouseConvertor<SimplePOJO> convertor = new ClickHouseConvertor<>(SimplePOJO.class, new SimplePOJODataMapper());
+
+        ClickHouseAsyncSink<SimplePOJO> sink = ClickHouseAsyncSink.<SimplePOJO>builder()
+                .setElementConverter(convertor)
+                .setMaxBatchSize(MAX_BATCH_SIZE)
+                .setMaxInFlightRequests(MAX_IN_FLIGHT_REQUESTS)
+                .setMaxBufferedRequests(MAX_BUFFERED_REQUESTS)
+                .setMaxBatchSizeInBytes(MAX_BATCH_SIZE_IN_BYTES)
+                .setMaxTimeInBufferMS(MAX_TIME_IN_BUFFER_MS)
+                .setMaxRecordSizeInBytes(MAX_RECORD_SIZE_IN_BYTES)
+                .setClickHouseClientConfig(clickHouseClientConfig)
+                .build();
+
+        // pojos may be a mix of SimplePOJO subclasses (Min/Max), so pin the element type explicitly.
+        DataStream<SimplePOJO> stream = env.fromCollection(pojos, TypeInformation.of(SimplePOJO.class));
+        stream.sinkTo(sink);
+        int rows = executeAsyncJob(env, tableName, 10, pojos.size());
+        Assertions.assertEquals(pojos.size(), rows);
+
+        return ClickHouseServerForTests.extractAllDataToPOJO(getDatabase(), tableName, "longPrimitive", SimplePOJO.class);
     }
 
     @ParameterizedTest

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/types/ClickHouseTypeTests.java
@@ -126,7 +126,8 @@ public class ClickHouseTypeTests extends FlinkClusterTests {
 
         ClickHouseServerForTests.executeSql(SimplePOJO.createTableSQL(getDatabase(), tableName));
 
-        // read back is ordered by longPrimitive, so keep the expected list in that order (0, 1).
+        // read back is ordered by longPrimitive (Long.MIN_VALUE < Long.MAX_VALUE),
+        // so keep the expected list min-then-max to match.
         List<SimplePOJO> expected = List.of(new MinSimplePOJO(), new MaxSimplePOJO());
 
         List<SimplePOJO> actual = runSimplePOJORoundTrip(tableName, expected);


### PR DESCRIPTION
Implements ClickHouse/flink-connector-clickhouse#114 — validates ingested data at type boundaries.

Adds `MinSimplePOJO` and `MaxSimplePOJO` (true min/max for every supported type) and `testSimplePOJOBoundaryValues`, which round-trips them through a real ClickHouse (testcontainers) and asserts read-back equality.

Closes the gap where wide/unsigned types were seeded with placeholder values — now tested at true extremes: UInt8–256, Int128/256, Int64 min/max, max-precision decimals, and min/max Date/Date32/DateTime/DateTime64. Each fixture documents its values in a table comment. Mirrored across the 1.17 and 2.0.0 modules; passes on a ClickHouse 24.3 container.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)