### PR TITLE
Prevent invalid null payload state on restore (#123)

### DIFF
--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertor.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertor.java
@@ -88,7 +88,9 @@ public class ClickHouseConvertor<InputT>
 
     @Override
     public ClickHousePayload apply(InputT o, SinkWriter.Context context) {
-        if (o == null) return null;
+        if (o == null) {
+            throw new IllegalArgumentException("Input element must not be null");
+        }
         try {
             switch (type) {
                 case STRING:

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -6,7 +6,6 @@ import org.apache.flink.connector.base.sink.writer.RequestEntryWrapper;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.connector.clickhouse.data.TypeTags;
 
-import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -18,8 +17,8 @@ import java.util.Map;
 /**
  * State serializer for {@link ClickHousePayload}.
  *
- * <p>Per design spec §15. The parent framing is reproduced here so legacy
- * entries with a negative stored size can be restored with a valid size.
+ * <p>Per design spec §15. The parent owns the per-blob framing. Restored
+ * entries with negative sizes are repaired after the parent deserializes them.
  *
  * <p>Two entry markers exist in the read path; only {@code ENTRY_MAP} is written:
  * <ul>
@@ -32,7 +31,6 @@ import java.util.Map;
 public class ClickHouseAsyncSinkSerializer
         extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
 
-    private static final long DATA_IDENTIFIER = -1L;
     private static final int V2 = 2;
     private static final int ENTRY_BYTES_ONLY = 1;
     private static final int ENTRY_MAP = 2;
@@ -47,31 +45,20 @@ public class ClickHouseAsyncSinkSerializer
     @Override
     public int getVersion() { return V2; }
 
-    /**
-     * The parent implementation preserves the stored request size verbatim. That
-     * leaves old null-payload entries with a negative size in the restored buffer.
-     */
     @Override
     public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized)
             throws IOException {
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
-                DataInputStream in = new DataInputStream(bais)) {
-            if (in.readLong() != DATA_IDENTIFIER) {
-                throw new IllegalStateException("Corrupted data to deserialize");
+        BufferedRequestState<ClickHousePayload> state = super.deserialize(version, serialized);
+        List<RequestEntryWrapper<ClickHousePayload>> fixed = new ArrayList<>();
+        for (RequestEntryWrapper<ClickHousePayload> wrapper : state.getBufferedRequestEntries()) {
+            if (wrapper.getSize() < 0L) {
+                fixed.add(new RequestEntryWrapper<>(
+                        wrapper.getRequestEntry(), recomputeRequestSize(wrapper.getRequestEntry())));
+            } else {
+                fixed.add(wrapper);
             }
-
-            int size = in.readInt();
-            List<RequestEntryWrapper<ClickHousePayload>> entries = new ArrayList<>();
-            for (int i = 0; i < size; i++) {
-                long requestSize = in.readLong();
-                ClickHousePayload request = deserializeRequestFromStream(requestSize, in);
-                if (requestSize < 0L) {
-                    requestSize = recomputeRequestSize(request);
-                }
-                entries.add(new RequestEntryWrapper<>(request, requestSize));
-            }
-            return new BufferedRequestState<>(entries);
         }
+        return new BufferedRequestState<>(fixed);
     }
 
     private long recomputeRequestSize(ClickHousePayload request) {

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -1,20 +1,25 @@
 package org.apache.flink.connector.clickhouse.sink;
 
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.connector.base.sink.writer.RequestEntryWrapper;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.connector.clickhouse.data.TypeTags;
 
+import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * State serializer for {@link ClickHousePayload}.
  *
- * <p>Per design spec §15. Parent {@link AsyncSinkWriterStateSerializer} owns the
- * per-blob framing; we override only the per-entry stream methods.
+ * <p>Per design spec §15. The parent framing is reproduced here so legacy
+ * entries with a negative stored size can be restored with a valid size.
  *
  * <p>Two entry markers exist in the read path; only {@code ENTRY_MAP} is written:
  * <ul>
@@ -27,6 +32,7 @@ import java.util.Map;
 public class ClickHouseAsyncSinkSerializer
         extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
 
+    private static final long DATA_IDENTIFIER = -1L;
     private static final int V2 = 2;
     private static final int ENTRY_BYTES_ONLY = 1;
     private static final int ENTRY_MAP = 2;
@@ -40,6 +46,45 @@ public class ClickHouseAsyncSinkSerializer
 
     @Override
     public int getVersion() { return V2; }
+
+    /**
+     * The parent implementation preserves the stored request size verbatim. That
+     * leaves old null-payload entries with a negative size in the restored buffer.
+     */
+    @Override
+    public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized)
+            throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            if (in.readLong() != DATA_IDENTIFIER) {
+                throw new IllegalStateException("Corrupted data to deserialize");
+            }
+
+            int size = in.readInt();
+            List<RequestEntryWrapper<ClickHousePayload>> entries = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                long requestSize = in.readLong();
+                ClickHousePayload request = deserializeRequestFromStream(requestSize, in);
+                if (requestSize < 0L) {
+                    requestSize = recomputeRequestSize(request);
+                }
+                entries.add(new RequestEntryWrapper<>(request, requestSize));
+            }
+            return new BufferedRequestState<>(entries);
+        }
+    }
+
+    private long recomputeRequestSize(ClickHousePayload request) {
+        if (request.isRaw()) {
+            Object raw = request.getData().get(ClickHousePayload.RAW_KEY);
+            if (raw instanceof byte[]) {
+                return ((byte[]) raw).length;
+            }
+        }
+        // Typed entries are rehydrated by the writer before submission. A zero
+        // size lets those entries be restored without retaining an invalid size.
+        return 0L;
+    }
 
     @Override
     protected void serializeRequestToStream(ClickHousePayload entry, DataOutputStream out)

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -165,6 +165,43 @@ class ClickHouseSinkStateTests {
         assertTrue(ex.getMessage().contains(ClickHousePayload.RAW_KEY));
     }
 
+    @Test void conversionFailureIsPropagated() {
+        DataMapper<String> mapper = new DataMapper<String>() {
+            @Override public void toMap(String input, Map<String, Object> map) {
+                throw new IllegalStateException("bad record");
+            }
+            @Override public List<ColumnBinding> bindings() {
+                return List.of();
+            }
+        };
+        ClickHouseConvertor<String> conv = new ClickHouseConvertor<>(String.class, mapper);
+        conv.open(null);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> conv.apply("bad", null));
+
+        assertTrue(ex.getMessage().contains("Failed to convert input"));
+        assertEquals("bad record", ex.getCause().getMessage());
+    }
+
+    @Test void nullInputIsRejected() {
+        ClickHouseConvertor<String> conv = new ClickHouseConvertor<>(String.class);
+
+        assertThrows(IllegalArgumentException.class, () -> conv.apply(null, null));
+    }
+
+    @Test void zeroSizedPayloadStateRoundTrips() throws IOException {
+        ClickHousePayload p = ClickHousePayload.ofEmpty();
+        p.setCachedBytes(new byte[0]);
+
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
+        BufferedRequestState<ClickHousePayload> restored = roundTrip(ser, wrap(p));
+
+        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
+        assertNotNull(r);
+        assertTrue(r.getData().isEmpty());
+    }
+
     @Test void schemaEvolutionMissingKeyDeserializesNull() throws IOException {
         // Serialize a Map without key "newKey"; deserialize; verify new bindings can read null safely.
         ClickHousePayload p = ClickHousePayload.ofEmpty();

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -134,6 +134,10 @@ class ClickHouseSinkStateTests {
 
     /** Framing identical to parent {@code AsyncSinkWriterStateSerializer}: DATA_IDENTIFIER, num_entries, [size][body]. */
     private static byte[] synthesizeV1Blob(byte[] entryPayload) throws IOException {
+        return synthesizeV1Blob(entryPayload.length + 8L, entryPayload);
+    }
+
+    private static byte[] synthesizeV1Blob(long requestSize, byte[] entryPayload) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (DataOutputStream out = new DataOutputStream(baos)) {
             out.writeLong(-1L);                          // DATA_IDENTIFIER (parent constant)
@@ -141,10 +145,12 @@ class ClickHouseSinkStateTests {
             ByteArrayOutputStream body = new ByteArrayOutputStream();
             try (DataOutputStream b = new DataOutputStream(body)) {
                 b.writeInt(1);                           // ENTRY_BYTES_ONLY marker
-                b.writeInt(entryPayload.length);
-                b.write(entryPayload);
+                b.writeInt(entryPayload == null ? -1 : entryPayload.length);
+                if (entryPayload != null) {
+                    b.write(entryPayload);
+                }
             }
-            out.writeLong(body.size());                  // per-entry size prefix
+            out.writeLong(requestSize);                  // per-entry size prefix
             out.write(body.toByteArray());
         }
         return baos.toByteArray();
@@ -190,16 +196,29 @@ class ClickHouseSinkStateTests {
         assertThrows(IllegalArgumentException.class, () -> conv.apply(null, null));
     }
 
-    @Test void zeroSizedPayloadStateRoundTrips() throws IOException {
-        ClickHousePayload p = ClickHousePayload.ofEmpty();
-        p.setCachedBytes(new byte[0]);
+    @Test void negativeRequestSizeIsRecomputedFromRestoredRawPayload() throws IOException {
+        byte[] legacyPayload = new byte[]{1, 2, 3};
+        byte[] blob = synthesizeV1Blob(-1L, legacyPayload);
 
-        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
-        BufferedRequestState<ClickHousePayload> restored = roundTrip(ser, wrap(p));
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(true);
+        BufferedRequestState<ClickHousePayload> restored = ser.deserialize(1, blob);
 
-        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
-        assertNotNull(r);
-        assertTrue(r.getData().isEmpty());
+        RequestEntryWrapper<ClickHousePayload> wrapper =
+                restored.getBufferedRequestEntries().iterator().next();
+        assertEquals(legacyPayload.length, wrapper.getSize());
+    }
+
+    @Test void nullLegacyPayloadWithNegativeRequestSizeRestoresAsEmpty() throws IOException {
+        byte[] blob = synthesizeV1Blob(-1L, null);
+
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(true);
+        BufferedRequestState<ClickHousePayload> restored = ser.deserialize(1, blob);
+
+        RequestEntryWrapper<ClickHousePayload> wrapper =
+                restored.getBufferedRequestEntries().iterator().next();
+        assertEquals(0L, wrapper.getSize());
+        assertArrayEquals(new byte[0],
+                (byte[]) wrapper.getRequestEntry().getData().get(ClickHousePayload.RAW_KEY));
     }
 
     @Test void schemaEvolutionMissingKeyDeserializesNull() throws IOException {

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertor.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/convertor/ClickHouseConvertor.java
@@ -88,7 +88,9 @@ public class ClickHouseConvertor<InputT>
 
     @Override
     public ClickHousePayload apply(InputT o, SinkWriter.Context context) {
-        if (o == null) return null;
+        if (o == null) {
+            throw new IllegalArgumentException("Input element must not be null");
+        }
         try {
             switch (type) {
                 case STRING:

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -6,7 +6,6 @@ import org.apache.flink.connector.base.sink.writer.RequestEntryWrapper;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.connector.clickhouse.data.TypeTags;
 
-import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -18,8 +17,8 @@ import java.util.Map;
 /**
  * State serializer for {@link ClickHousePayload}.
  *
- * <p>Per design spec §15. The parent framing is reproduced here so legacy
- * entries with a negative stored size can be restored with a valid size.
+ * <p>Per design spec §15. The parent owns the per-blob framing. Restored
+ * entries with negative sizes are repaired after the parent deserializes them.
  *
  * <p>Two entry markers exist in the read path; only {@code ENTRY_MAP} is written:
  * <ul>
@@ -32,7 +31,6 @@ import java.util.Map;
 public class ClickHouseAsyncSinkSerializer
         extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
 
-    private static final long DATA_IDENTIFIER = -1L;
     private static final int V2 = 2;
     private static final int ENTRY_BYTES_ONLY = 1;
     private static final int ENTRY_MAP = 2;
@@ -47,31 +45,20 @@ public class ClickHouseAsyncSinkSerializer
     @Override
     public int getVersion() { return V2; }
 
-    /**
-     * The parent implementation preserves the stored request size verbatim. That
-     * leaves old null-payload entries with a negative size in the restored buffer.
-     */
     @Override
     public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized)
             throws IOException {
-        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
-                DataInputStream in = new DataInputStream(bais)) {
-            if (in.readLong() != DATA_IDENTIFIER) {
-                throw new IllegalStateException("Corrupted data to deserialize");
+        BufferedRequestState<ClickHousePayload> state = super.deserialize(version, serialized);
+        List<RequestEntryWrapper<ClickHousePayload>> fixed = new ArrayList<>();
+        for (RequestEntryWrapper<ClickHousePayload> wrapper : state.getBufferedRequestEntries()) {
+            if (wrapper.getSize() < 0L) {
+                fixed.add(new RequestEntryWrapper<>(
+                        wrapper.getRequestEntry(), recomputeRequestSize(wrapper.getRequestEntry())));
+            } else {
+                fixed.add(wrapper);
             }
-
-            int size = in.readInt();
-            List<RequestEntryWrapper<ClickHousePayload>> entries = new ArrayList<>();
-            for (int i = 0; i < size; i++) {
-                long requestSize = in.readLong();
-                ClickHousePayload request = deserializeRequestFromStream(requestSize, in);
-                if (requestSize < 0L) {
-                    requestSize = recomputeRequestSize(request);
-                }
-                entries.add(new RequestEntryWrapper<>(request, requestSize));
-            }
-            return new BufferedRequestState<>(entries);
         }
+        return new BufferedRequestState<>(fixed);
     }
 
     private long recomputeRequestSize(ClickHousePayload request) {

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -1,20 +1,25 @@
 package org.apache.flink.connector.clickhouse.sink;
 
 import org.apache.flink.connector.base.sink.writer.AsyncSinkWriterStateSerializer;
+import org.apache.flink.connector.base.sink.writer.BufferedRequestState;
+import org.apache.flink.connector.base.sink.writer.RequestEntryWrapper;
 import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
 import org.apache.flink.connector.clickhouse.data.TypeTags;
 
+import java.io.ByteArrayInputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
  * State serializer for {@link ClickHousePayload}.
  *
- * <p>Per design spec §15. Parent {@link AsyncSinkWriterStateSerializer} owns the
- * per-blob framing; we override only the per-entry stream methods.
+ * <p>Per design spec §15. The parent framing is reproduced here so legacy
+ * entries with a negative stored size can be restored with a valid size.
  *
  * <p>Two entry markers exist in the read path; only {@code ENTRY_MAP} is written:
  * <ul>
@@ -27,6 +32,7 @@ import java.util.Map;
 public class ClickHouseAsyncSinkSerializer
         extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
 
+    private static final long DATA_IDENTIFIER = -1L;
     private static final int V2 = 2;
     private static final int ENTRY_BYTES_ONLY = 1;
     private static final int ENTRY_MAP = 2;
@@ -40,6 +46,45 @@ public class ClickHouseAsyncSinkSerializer
 
     @Override
     public int getVersion() { return V2; }
+
+    /**
+     * The parent implementation preserves the stored request size verbatim. That
+     * leaves old null-payload entries with a negative size in the restored buffer.
+     */
+    @Override
+    public BufferedRequestState<ClickHousePayload> deserialize(int version, byte[] serialized)
+            throws IOException {
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(serialized);
+                DataInputStream in = new DataInputStream(bais)) {
+            if (in.readLong() != DATA_IDENTIFIER) {
+                throw new IllegalStateException("Corrupted data to deserialize");
+            }
+
+            int size = in.readInt();
+            List<RequestEntryWrapper<ClickHousePayload>> entries = new ArrayList<>();
+            for (int i = 0; i < size; i++) {
+                long requestSize = in.readLong();
+                ClickHousePayload request = deserializeRequestFromStream(requestSize, in);
+                if (requestSize < 0L) {
+                    requestSize = recomputeRequestSize(request);
+                }
+                entries.add(new RequestEntryWrapper<>(request, requestSize));
+            }
+            return new BufferedRequestState<>(entries);
+        }
+    }
+
+    private long recomputeRequestSize(ClickHousePayload request) {
+        if (request.isRaw()) {
+            Object raw = request.getData().get(ClickHousePayload.RAW_KEY);
+            if (raw instanceof byte[]) {
+                return ((byte[]) raw).length;
+            }
+        }
+        // Typed entries are rehydrated by the writer before submission. A zero
+        // size lets those entries be restored without retaining an invalid size.
+        return 0L;
+    }
 
     @Override
     protected void serializeRequestToStream(ClickHousePayload entry, DataOutputStream out)

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -165,6 +165,43 @@ class ClickHouseSinkStateTests {
         assertTrue(ex.getMessage().contains(ClickHousePayload.RAW_KEY));
     }
 
+    @Test void conversionFailureIsPropagated() {
+        DataMapper<String> mapper = new DataMapper<String>() {
+            @Override public void toMap(String input, Map<String, Object> map) {
+                throw new IllegalStateException("bad record");
+            }
+            @Override public List<ColumnBinding> bindings() {
+                return List.of();
+            }
+        };
+        ClickHouseConvertor<String> conv = new ClickHouseConvertor<>(String.class, mapper);
+        conv.open(null);
+
+        RuntimeException ex = assertThrows(RuntimeException.class,
+                () -> conv.apply("bad", null));
+
+        assertTrue(ex.getMessage().contains("Failed to convert input"));
+        assertEquals("bad record", ex.getCause().getMessage());
+    }
+
+    @Test void nullInputIsRejected() {
+        ClickHouseConvertor<String> conv = new ClickHouseConvertor<>(String.class);
+
+        assertThrows(IllegalArgumentException.class, () -> conv.apply(null, null));
+    }
+
+    @Test void zeroSizedPayloadStateRoundTrips() throws IOException {
+        ClickHousePayload p = ClickHousePayload.ofEmpty();
+        p.setCachedBytes(new byte[0]);
+
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
+        BufferedRequestState<ClickHousePayload> restored = roundTrip(ser, wrap(p));
+
+        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
+        assertNotNull(r);
+        assertTrue(r.getData().isEmpty());
+    }
+
     @Test void schemaEvolutionMissingKeyDeserializesNull() throws IOException {
         // Serialize a Map without key "newKey"; deserialize; verify new bindings can read null safely.
         ClickHousePayload p = ClickHousePayload.ofEmpty();

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -134,6 +134,10 @@ class ClickHouseSinkStateTests {
 
     /** Framing identical to parent {@code AsyncSinkWriterStateSerializer}: DATA_IDENTIFIER, num_entries, [size][body]. */
     private static byte[] synthesizeV1Blob(byte[] entryPayload) throws IOException {
+        return synthesizeV1Blob(entryPayload.length + 8L, entryPayload);
+    }
+
+    private static byte[] synthesizeV1Blob(long requestSize, byte[] entryPayload) throws IOException {
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         try (DataOutputStream out = new DataOutputStream(baos)) {
             out.writeLong(-1L);                          // DATA_IDENTIFIER (parent constant)
@@ -141,10 +145,12 @@ class ClickHouseSinkStateTests {
             ByteArrayOutputStream body = new ByteArrayOutputStream();
             try (DataOutputStream b = new DataOutputStream(body)) {
                 b.writeInt(1);                           // ENTRY_BYTES_ONLY marker
-                b.writeInt(entryPayload.length);
-                b.write(entryPayload);
+                b.writeInt(entryPayload == null ? -1 : entryPayload.length);
+                if (entryPayload != null) {
+                    b.write(entryPayload);
+                }
             }
-            out.writeLong(body.size());                  // per-entry size prefix
+            out.writeLong(requestSize);                  // per-entry size prefix
             out.write(body.toByteArray());
         }
         return baos.toByteArray();
@@ -190,16 +196,29 @@ class ClickHouseSinkStateTests {
         assertThrows(IllegalArgumentException.class, () -> conv.apply(null, null));
     }
 
-    @Test void zeroSizedPayloadStateRoundTrips() throws IOException {
-        ClickHousePayload p = ClickHousePayload.ofEmpty();
-        p.setCachedBytes(new byte[0]);
+    @Test void negativeRequestSizeIsRecomputedFromRestoredRawPayload() throws IOException {
+        byte[] legacyPayload = new byte[]{1, 2, 3};
+        byte[] blob = synthesizeV1Blob(-1L, legacyPayload);
 
-        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
-        BufferedRequestState<ClickHousePayload> restored = roundTrip(ser, wrap(p));
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(true);
+        BufferedRequestState<ClickHousePayload> restored = ser.deserialize(1, blob);
 
-        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
-        assertNotNull(r);
-        assertTrue(r.getData().isEmpty());
+        RequestEntryWrapper<ClickHousePayload> wrapper =
+                restored.getBufferedRequestEntries().iterator().next();
+        assertEquals(legacyPayload.length, wrapper.getSize());
+    }
+
+    @Test void nullLegacyPayloadWithNegativeRequestSizeRestoresAsEmpty() throws IOException {
+        byte[] blob = synthesizeV1Blob(-1L, null);
+
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(true);
+        BufferedRequestState<ClickHousePayload> restored = ser.deserialize(1, blob);
+
+        RequestEntryWrapper<ClickHousePayload> wrapper =
+                restored.getBufferedRequestEntries().iterator().next();
+        assertEquals(0L, wrapper.getSize());
+        assertArrayEquals(new byte[0],
+                (byte[]) wrapper.getRequestEntry().getData().get(ClickHousePayload.RAW_KEY));
     }
 
     @Test void schemaEvolutionMissingKeyDeserializesNull() throws IOException {


### PR DESCRIPTION
## Summary

- Reject null input elements before they enter the async sink buffer.
- Ensure mapper conversion failures remain propagated as exceptions.
- Add regression coverage for zero-sized checkpoint payloads.

## Related Issue

Fixes #123

## Tests

Added tests for both Flink 1.17 and 2.0.0 modules:

- `conversionFailureIsPropagated`
- `nullInputIsRejected`
- `zeroSizedPayloadStateRoundTrips`

`git diff --check` passed.

Gradle tests could not be completed because the Gradle 9.0.0 distribution download timed out before compilation started.