### PR TITLE
Drop internal SerializerUtils.convertToBigInteger from Int128/Int256 writers

### DIFF
--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/Serialize.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/Serialize.java
@@ -186,14 +186,14 @@ public class Serialize {
     // Int128
     public static void writeInt128(OutputStream out, BigInteger value, boolean isNullable, ClickHouseDataType dataType, String column) throws IOException {
         if (writeValuePreamble(out, isNullable, dataType, column, value)) {
-            BinaryStreamUtils.writeInt128(out, SerializerUtils.convertToBigInteger(value));
+            BinaryStreamUtils.writeInt128(out, value);
         }
     }
 
     // Int256
     public static void writeInt256(OutputStream out, BigInteger value, boolean isNullable, ClickHouseDataType dataType, String column) throws IOException {
         if (writeValuePreamble(out, isNullable, dataType, column, value)) {
-            BinaryStreamUtils.writeInt256(out, SerializerUtils.convertToBigInteger(value));
+            BinaryStreamUtils.writeInt256(out, value);
         }
     }
 

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
@@ -124,14 +124,14 @@ public class DataWriter {
     // Int128
     public void writeInt128(BigInteger value, boolean isNullable, ClickHouseDataType dataType, String column) throws IOException {
         if (Serialize.writeValuePreamble(out, isNullable, dataType, column, value)) {
-            BinaryStreamUtils.writeInt128(out, SerializerUtils.convertToBigInteger(value));
+            BinaryStreamUtils.writeInt128(out, value);
         }
     }
 
     // Int256
     public void writeInt256(BigInteger value, boolean isNullable, ClickHouseDataType dataType, String column) throws IOException {
         if (Serialize.writeValuePreamble(out, isNullable, dataType, column, value)) {
-            BinaryStreamUtils.writeInt256(out, SerializerUtils.convertToBigInteger(value));
+            BinaryStreamUtils.writeInt256(out, value);
         }
     }
 


### PR DESCRIPTION
## What

Removes the four calls to `SerializerUtils.convertToBigInteger(...)` wrapping `BinaryStreamUtils.writeInt128/writeInt256` (`DataWriter.java:127,134`, `Serialize.java:189,196`). clickhouse-java removed the method on `main` post-`v0.10.0-rc2`; it lives in `com.clickhouse.client.api.data_formats.internal`, which carries no API stability guarantees.

## Why this is safe

At all four call sites the argument is statically typed `BigInteger`, and the method's `instanceof BigInteger` branch returns the argument unchanged — the call was an identity conversion, so identical bytes are written. Null can never reach it: `writeValuePreamble` either writes the null marker and skips the write, or throws for non-nullable columns.

## Verification

- Compiles and base-module tests pass against pinned 0.9.5.
- Reproduced the nightly locally against clickhouse-java `main` (commit `0b781da`, source-built as `0.10.0-rc1-SNAPSHOT` per the workflow steps): all four compile errors from runs [30802711857](https://github.com/ClickHouse/flink-connector-clickhouse/actions/runs/30802711857) and [33291849394](https://github.com/ClickHouse/flink-connector-clickhouse/actions/runs/33291849394) are gone, and they were the only errors in both logs.
- **Heads-up: this alone does not turn the nightly green.** With compilation unblocked, dependency resolution for the 1.17/2.0.0 modules next hits a Gradle capability conflict — client `main` switched to `at.yawk.lz4:lz4-java:1.11.1`, which declares the `org.lz4:lz4-java` capability that Flink's own `org.lz4:lz4-java:1.8.0` also provides. That needs a separate resolution-strategy fix — tracked in #160.

Fixes #151
