### PR TITLE
Exclude the client's external lz4 dependency at every client-v2 edge

### DIFF
--- a/flink-connector-clickhouse-1.17/build.gradle.kts
+++ b/flink-connector-clickhouse-1.17/build.gradle.kts
@@ -55,7 +55,12 @@ dependencies {
 
     implementation(project(":flink-connector-clickhouse-base"))
     // ClickHouse Client Libraries
-    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all")
+    // Exclude the client's external lz4: the ':all' jar embeds it, and from client 0.10 the
+    // at.yawk.lz4 fork capability-clashes with Flink's org.lz4:lz4-java (#160).
+    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all") {
+        exclude(group = "org.lz4", module = "lz4-java")
+        exclude(group = "at.yawk.lz4", module = "lz4-java")
+    }
     // Apache Flink Libraries
     implementation("org.apache.flink:flink-connector-base:${project.extra["flinkVersion"]}")
     implementation("org.apache.flink:flink-streaming-java:${project.extra["flinkVersion"]}")

--- a/flink-connector-clickhouse-2.0.0/build.gradle.kts
+++ b/flink-connector-clickhouse-2.0.0/build.gradle.kts
@@ -51,7 +51,12 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${project.extra["log4jVersion"]}")
 
     // ClickHouse Client Libraries
-    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all")
+    // Exclude the client's external lz4: the ':all' jar embeds it, and from client 0.10 the
+    // at.yawk.lz4 fork capability-clashes with Flink's org.lz4:lz4-java (#160).
+    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all") {
+        exclude(group = "org.lz4", module = "lz4-java")
+        exclude(group = "at.yawk.lz4", module = "lz4-java")
+    }
     // Apache Flink Libraries
     implementation("org.apache.flink:flink-connector-base:${project.extra["flinkVersion"]}")
     implementation("org.apache.flink:flink-streaming-java:${project.extra["flinkVersion"]}")

--- a/flink-connector-clickhouse-base/build.gradle.kts
+++ b/flink-connector-clickhouse-base/build.gradle.kts
@@ -39,10 +39,18 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${project.extra["log4jVersion"]}")
 
     // ClickHouse Client Libraries
-    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all")
+    // Exclude the client's external lz4: the ':all' jar embeds it, and from client 0.10 the
+    // at.yawk.lz4 fork capability-clashes with Flink's org.lz4:lz4-java (#160).
+    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all") {
+        exclude(group = "org.lz4", module = "lz4-java")
+        exclude(group = "at.yawk.lz4", module = "lz4-java")
+    }
 
     // For testing
-    testFixturesImplementation("com.clickhouse:client-v2:${clickhouseVersion}:all")
+    testFixturesImplementation("com.clickhouse:client-v2:${clickhouseVersion}:all") {
+        exclude(group = "org.lz4", module = "lz4-java")
+        exclude(group = "at.yawk.lz4", module = "lz4-java")
+    }
     testFixturesImplementation("org.testcontainers:testcontainers:${project.extra["testContainersVersion"]}")
     testFixturesImplementation("org.testcontainers:clickhouse:${project.extra["testContainersVersion"]}")
     testFixturesImplementation("com.squareup.okhttp3:okhttp:5.1.0")

--- a/flink-connector-clickhouse-integration/build.gradle.kts
+++ b/flink-connector-clickhouse-integration/build.gradle.kts
@@ -37,7 +37,12 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:${project.extra["log4jVersion"]}")
 
     // ClickHouse Client Libraries
-    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all")
+    // Exclude the client's external lz4: the ':all' jar embeds it, and from client 0.10 the
+    // at.yawk.lz4 fork capability-clashes with Flink's org.lz4:lz4-java (#160).
+    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all") {
+        exclude(group = "org.lz4", module = "lz4-java")
+        exclude(group = "at.yawk.lz4", module = "lz4-java")
+    }
 
     // For testing
     testImplementation(testFixtures(project(":flink-connector-clickhouse-base")))


### PR DESCRIPTION
## What

Excludes both lz4 coordinates (`org.lz4:lz4-java` and `at.yawk.lz4:lz4-java`) on the five `com.clickhouse:client-v2:${clickhouseVersion}:all` declarations (base ×2 incl. test fixtures, 1.17, 2.0.0, integration). The shadow-jar `include(...)` filters are unaffected.

## Why exclusion rather than the capability rule suggested in #160

The `:all` shaded jar already embeds the lz4 classes (`net.jpountz`, ~110 class files in both 0.9.5 and current client `main`), so the external transitive lz4 artifact was always redundant on the connector's classpaths. Excluding it at the source keeps the `at.yawk.lz4` fork out of the dependency graph entirely — no conflict to arbitrate, no global resolution strategy, and no effect on Flink's own `org.lz4:lz4-java`, which remains exactly as before.

## Verification

- **Against client `main`** (source-built `0.10.0-rc1-SNAPSHOT`, commit `0b781da`, per the nightly workflow steps): `:flink-connector-clickhouse-1.17` classpath resolution — which previously failed with the capability conflict — now succeeds; `dependencyInsight` shows the fork absent and `org.lz4:lz4-java:1.8.0` via `flink-runtime` as the only lz4 module.
- **Against pinned 0.9.5**: the selected graph is unchanged (`org.lz4:1.8.0` via Flink, same as before — previously the client edge lost conflict resolution to it anyway); all modules compile.
- Running the full nightly suite (base + 1.17 + 2.0.0, ClickHouse `latest`) against client `main` with this plus #159 locally now — result to follow as a comment. The same combination already passed end to end (162 tests, 43m) with the equivalent init-script capability rule.

Independent of #159; the nightly needs both to go green.

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)