### PR TITLE
CI: migrate to gradle/actions/setup-gradle@v4 to restore the Gradle cache

### DIFF
--- a/.github/workflows/build-and-publish-connector.yaml
+++ b/.github/workflows/build-and-publish-connector.yaml
@@ -21,18 +21,17 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        if: env.SKIP_STEP != 'true'
+        uses: gradle/actions/setup-gradle@v4
       - name: Build shadowJar
         if: env.SKIP_STEP != 'true'
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: shadowJar shadowSourcesJar
+        run: ./gradlew shadowJar shadowSourcesJar
       - name: Deploy ClickHouse Flink Connector
         if: env.SKIP_STEP != 'true'
-        uses: gradle/gradle-build-action@v2
         env:
           NMCP_USERNAME: ${{ secrets.NMCP_USERNAME }}
           NMCP_PASSWORD: ${{ secrets.NMCP_PASSWORD }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
-        with:
-          arguments: publishMavenPublicationToCentralPortal
+        run: ./gradlew publishMavenPublicationToCentralPortal

--- a/.github/workflows/integration-tests-cloud.yaml
+++ b/.github/workflows/integration-tests-cloud.yaml
@@ -55,29 +55,25 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish locally flink-connector-clickhouse-1.17
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Generate Flink Covid App example 2.X
         working-directory: ./examples/maven/flink-v2/covid
         run: mvn clean install
       - name: Generate Flink Covid App example 1.17+
         working-directory: ./examples/maven/flink-v1.7/covid
         run: mvn clean install
-      - name: Setup and execute Gradle 'integration-test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Execute Gradle 'integration-test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-integration:test
+        run: ./gradlew :flink-connector-clickhouse-integration:test
 
   remove-label:
     needs: [ test-integration-tests ]

--- a/.github/workflows/integration-tests-scala-cloud.yaml
+++ b/.github/workflows/integration-tests-scala-cloud.yaml
@@ -55,14 +55,12 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish locally flink-connector-clickhouse-1.17
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Set up sbt
         uses: sbt/setup-sbt@v1
       - name: Generate Flink Covid App example 2.X (Scala)
@@ -71,15 +69,13 @@ jobs:
       - name: Generate Flink Covid App example 1.17+ (Scala)
         working-directory: ./examples/sbt/flink-v1.7/covid
         run: sbt clean assembly
-      - name: Setup and execute Gradle 'integration-test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Execute Gradle 'integration-test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-integration:test -Dexample.lang=scala
+        run: ./gradlew :flink-connector-clickhouse-integration:test -Dexample.lang=scala
 
   remove-label:
     needs: [ test-integration-tests-scala ]

--- a/.github/workflows/integration-tests-scala.yaml
+++ b/.github/workflows/integration-tests-scala.yaml
@@ -31,14 +31,12 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish locally flink-connector-clickhouse-1.17
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Set up sbt
         uses: sbt/setup-sbt@v1
       - name: Generate Flink Covid App example 2.X (Scala)
@@ -47,10 +45,8 @@ jobs:
       - name: Generate Flink Covid App example 1.17+ (Scala)
         working-directory: ./examples/sbt/flink-v1.7/covid
         run: sbt clean assembly
-      - name: Setup and execute Gradle 'integration-test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Execute Gradle 'integration-test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-integration:test -Dexample.lang=scala
+        run: ./gradlew :flink-connector-clickhouse-integration:test -Dexample.lang=scala

--- a/.github/workflows/integration-tests-schema-evolution-cloud.yaml
+++ b/.github/workflows/integration-tests-schema-evolution-cloud.yaml
@@ -66,14 +66,12 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish locally flink-connector-clickhouse-1.17
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Build map-evolution example (Flink 1.17)
         working-directory: ./examples/maven/flink-v1.7/map-evolution
         run: mvn -q clean package
@@ -81,14 +79,12 @@ jobs:
         working-directory: ./examples/maven/flink-v2/map-evolution
         run: mvn -q clean package
       - name: Run testSchemaEvolution
-        uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: ":flink-connector-clickhouse-integration:test --tests com.clickhouse.flink.integration.FlinkTests.testSchemaEvolution"
+        run: ./gradlew :flink-connector-clickhouse-integration:test --tests com.clickhouse.flink.integration.FlinkTests.testSchemaEvolution
 
   remove-label:
     needs: [ test-schema-evolution ]

--- a/.github/workflows/integration-tests-schema-evolution.yaml
+++ b/.github/workflows/integration-tests-schema-evolution.yaml
@@ -44,14 +44,12 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish locally flink-connector-clickhouse-1.17
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Build map-evolution example (Flink 1.17)
         working-directory: ./examples/maven/flink-v1.7/map-evolution
         run: mvn -q clean package
@@ -59,9 +57,7 @@ jobs:
         working-directory: ./examples/maven/flink-v2/map-evolution
         run: mvn -q clean package
       - name: Run testSchemaEvolution
-        uses: gradle/gradle-build-action@v2
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: ":flink-connector-clickhouse-integration:test --tests com.clickhouse.flink.integration.FlinkTests.testSchemaEvolution"
+        run: ./gradlew :flink-connector-clickhouse-integration:test --tests com.clickhouse.flink.integration.FlinkTests.testSchemaEvolution

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -31,24 +31,20 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: Publish locally flink-connector-clickhouse-1.17
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-1.17:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-1.17:publishToMavenLocal
       - name: Publish locally flink-connector-clickhouse-2.0.0
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:publishToMavenLocal
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:publishToMavenLocal
       - name: Generate Flink Covid App example 2.X
         working-directory: ./examples/maven/flink-v2/covid
         run: mvn clean install
       - name: Generate Flink Covid App example 1.17+
         working-directory: ./examples/maven/flink-v1.7/covid
         run: mvn clean install
-      - name: Setup and execute Gradle 'integration-test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Execute Gradle 'integration-test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-integration:test
+        run: ./gradlew :flink-connector-clickhouse-integration:test

--- a/.github/workflows/tests-cloud.yaml
+++ b/.github/workflows/tests-cloud.yaml
@@ -59,15 +59,15 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-1.17:test
+        run: ./gradlew :flink-connector-clickhouse-1.17:test
   test-flink-2:
     needs: gate
     runs-on: ubuntu-latest
@@ -87,14 +87,14 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:test
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:test
 
   remove-label:
     needs: [ test-flink-17, test-flink-2 ]

--- a/.github/workflows/tests-nightly.yaml
+++ b/.github/workflows/tests-nightly.yaml
@@ -35,16 +35,17 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
+      - name: Set up Gradle
         if: env.SKIP_STEP != 'true'
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
+        if: env.SKIP_STEP != 'true'
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-1.17:test
+        run: ./gradlew :flink-connector-clickhouse-1.17:test
   test-flink-2:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -72,12 +73,13 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
+      - name: Set up Gradle
         if: env.SKIP_STEP != 'true'
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
+        if: env.SKIP_STEP != 'true'
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:test
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:test

--- a/.github/workflows/tests-scala-cloud.yaml
+++ b/.github/workflows/tests-scala-cloud.yaml
@@ -56,15 +56,15 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-1.17:runScalaTests
+        run: ./gradlew :flink-connector-clickhouse-1.17:runScalaTests
   test-flink-2:
     needs: gate
     runs-on: ubuntu-latest
@@ -84,14 +84,14 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:runScalaTests
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:runScalaTests
 
   remove-label:
     needs: [ test-flink-17, test-flink-2 ]

--- a/.github/workflows/tests-scala.yaml
+++ b/.github/workflows/tests-scala.yaml
@@ -32,13 +32,13 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-1.17:runScalaTests
+        run: ./gradlew :flink-connector-clickhouse-1.17:runScalaTests
   test-flink-2:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -55,9 +55,9 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:runScalaTests
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:runScalaTests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,13 +32,13 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           FLINK_VERSION: ${{ matrix.flink }}
-        with:
-          arguments: :flink-connector-clickhouse-1.17:test
+        run: ./gradlew :flink-connector-clickhouse-1.17:test
   test-flink-2:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -55,9 +55,9 @@ jobs:
           java-version: '17'
           distribution: 'adopt'
           architecture: x64
-      - name: Setup and execute Gradle 'test' task
-        uses: gradle/gradle-build-action@v2
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
-        with:
-          arguments: :flink-connector-clickhouse-2.0.0:test
+        run: ./gradlew :flink-connector-clickhouse-2.0.0:test


### PR DESCRIPTION
Every workflow used the deprecated `gradle/gradle-build-action@v2`, whose caching silently broke (`Cache service responded with 400`, 100% miss rate) — so all ~219 CI jobs redownload Gradle and all dependencies every run. This swaps it for `gradle/actions/setup-gradle@v4`: one setup step per job, and each old action step becomes a plain `./gradlew ...` run step (v4 dropped the `arguments:` input). Same builds, working cache.

Part of #147.