### PR TITLE
Upgrade log4j verstion to 2.25.4

### DIFF
--- a/flink-connector-clickhouse-1.17/build.gradle.kts
+++ b/flink-connector-clickhouse-1.17/build.gradle.kts
@@ -29,7 +29,7 @@ val flinkVersion = System.getenv("FLINK_VERSION") ?: "1.17.2"
 
 extra.apply {
     set("flinkVersion", flinkVersion)
-    set("log4jVersion","2.17.2")
+    set("log4jVersion","2.25.4")
     set("testContainersVersion", "2.0.2")
     set("testContainersClickHouseVersion", "1.21.3")
     set("byteBuddyVersion", "1.17.5")

--- a/flink-connector-clickhouse-2.0.0/build.gradle.kts
+++ b/flink-connector-clickhouse-2.0.0/build.gradle.kts
@@ -26,7 +26,7 @@ repositories {
 
 extra.apply {
     set("flinkVersion", "2.0.0") // the default still will be 2.0.0 since it is more popular currently
-    set("log4jVersion","2.17.2")
+    set("log4jVersion","2.25.4")
     set("testContainersVersion", "2.0.2")
     set("testContainersClickHouseVersion", "1.21.3")
     set("byteBuddyVersion", "1.17.5")

--- a/flink-connector-clickhouse-base/build.gradle.kts
+++ b/flink-connector-clickhouse-base/build.gradle.kts
@@ -22,7 +22,7 @@ repositories {
 }
 
 extra.apply {
-    set("log4jVersion","2.17.2")
+    set("log4jVersion","2.25.4")
     set("testContainersVersion", "1.21.0")
     set("byteBuddyVersion", "1.17.5")
 }

--- a/flink-connector-clickhouse-integration/build.gradle.kts
+++ b/flink-connector-clickhouse-integration/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
 }
 
 extra.apply {
-    set("log4jVersion","2.17.2")
+    set("log4jVersion","2.25.4")
     set("testContainersVersion", "2.0.2")
     set("byteBuddyVersion", "1.17.5")
 }


### PR DESCRIPTION
## Summary
Upgrade log4j verstion to 2.25.4

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
