### PR TITLE
Table API / Flink SQL sink support

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,7 +38,8 @@ jobs:
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
           FLINK_VERSION: ${{ matrix.flink }}
-        run: ./gradlew :flink-connector-clickhouse-1.17:test
+        # -base's Flink-free tests gate here; no other merge-gating job runs them.
+        run: ./gradlew :flink-connector-clickhouse-base:test :flink-connector-clickhouse-1.17:test
   test-flink-2:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -46,7 +47,10 @@ jobs:
       fail-fast: false
       matrix:
         clickhouse: [ "25.3", "25.8", "25.10", "25.11", "25.12", "latest" ]
-    name: Apache Flink 2.0.0 ClickHouse Connector tests with ClickHouse ${{ matrix.clickhouse }}
+        # 2.1 adds the DESCRIPTOR and VARIANT roots; ClickHouseTypeMapper registers them by name,
+        # so the exhaustiveness guard holds on both generations.
+        flink: [ "2.0.0", "2.1.0" ]
+    name: Apache Flink ${{ matrix.flink }} ClickHouse Connector tests with ClickHouse ${{ matrix.clickhouse }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK 17
@@ -60,4 +64,5 @@ jobs:
       - name: Execute Gradle 'test' task
         env:
           CLICKHOUSE_VERSION: ${{ matrix.clickhouse }}
+          FLINK_2_VERSION: ${{ matrix.flink }}
         run: ./gradlew :flink-connector-clickhouse-2.0.0:test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,41 @@
+## Unreleased — Table API / Flink SQL sink
+
+### New
+
+- Flink SQL / Table API sink: `'connector' = 'clickhouse'`, insert-only. At planning time the
+  connector reads the target table's columns from ClickHouse and validates the Flink schema
+  against them, so mismatches fail at job submission. Options (`sink.buffer-flush.*`,
+  `sink.max-in-flight-requests`, `sink.max-buffered-requests`, `sink.record.max-bytes`,
+  `sink.parallelism`, `sink.max-retries`, `sink.batch-failure-strategy`, `sink.timezone`,
+  `sink.ignore-unknown-flink-columns`, `sink.strict-numeric-mapping`, `clickhouse.client.*` / `clickhouse.server.*`
+  passthrough) and the type mapping are documented in the README's "Table API" section.
+- `ClickHouseClientConfig`: `copy()`, `verifyConnectivity()`, and `createPlanningClient(Map)`
+  (planning-only server settings).
+- `ClickHouseAsyncSinkBuilder.setVerifyConnectivity(boolean)`: opt out of the connectivity
+  check that `build()` performs.
+- `ClickHouseSinkDefaults`: the batching defaults shared by the DataStream builder and the SQL options.
+
+### Changed
+
+- The connectivity ping moved from the `ClickHouseClientConfig` constructors to
+  `ClickHouseAsyncSinkBuilder.build()`. It still runs on the job driver and fails fast on an
+  unreachable server, now on a client that is closed afterwards; constructing a config no
+  longer touches the network.
+
+### Fixed
+
+- `DataWriter` sized `Nullable(FixedString(n))` values by the column's estimated length (1)
+  instead of `n`.
+
+### Checkpoint migration
+
+- Checkpoint entry format V3: strings and map keys are int-length-prefixed UTF-8, so values
+  above `writeUTF`'s 64 KB limit checkpoint safely. Checkpoints written by 0.2.0 (V2) restore
+  transparently; 0.1.x STRING-mode checkpoints still restore as before.
+- **Rolling back to 0.2.0 from a V3 checkpoint is NOT supported**: 0.2.0 fails on restore with
+  `Unknown entry marker: 3`. Drain the sink before downgrading: stop the source, wait for the
+  buffer to flush, take a checkpoint with zero in-flight entries, then roll back.
+
 ## 0.2.0 — Map-based payload, RowBinaryWithNamesAndTypes
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ Table of Contents
 
 This is a repo of ClickHouse official Apache Flink Connector supported by the ClickHouse team.
 The connector supports two main Apache Flink APIs: 
-- DataStreamAPI
-- Table API (This feature is not implemented yet and is planned for a future release)
+- DataStream API
+- Table API / Flink SQL (sink only, insert-only changelog)
 
 ## Supported Flink Versions
 
@@ -126,17 +126,138 @@ For more detailed instructions, see the [Example Guide](examples#readme)
 
 ## Table API
 
-Table API is planned for a future release. This section will be updated once available.
+The connector registers itself as the `clickhouse` SQL connector: create a table with
+`'connector' = 'clickhouse'` and `INSERT INTO` it from Flink SQL or the Table API
+(`TableDescriptor.forConnector("clickhouse")`). The sink is insert-only: append queries work,
+update-producing queries (e.g. a plain `GROUP BY` aggregation) are rejected by the planner —
+use `ReplacingMergeTree`/`AggregatingMergeTree` plus `FINAL`/`argMax` for upsert-style needs.
+
+At planning time the connector reads the real column types from the target ClickHouse table
+and validates the Flink schema against them, so typos, type mismatches, narrowing and
+unsupported types fail at job submission with a precise message instead of at the first
+flush. Columns are matched **by name, case-sensitively**; ClickHouse columns you leave out of
+the Flink schema get their server-side `DEFAULT`, or the type's default value (`0`/`''`/empty)
+if they have none — the latter is logged as a warning at planning. A nullable Flink column can only target a
+`Nullable(...)` ClickHouse column — declare columns `NOT NULL` when the target column isn't
+`Nullable` (in Flink SQL, columns and collection elements are nullable unless declared
+otherwise).
 
 ### Snippet
 
-Planned for a future release — this section will provide a usage snippet for configuring the Table API.
+```sql
+CREATE TABLE ch_events (
+    event_id   BIGINT NOT NULL,
+    amount     DECIMAL(18, 4) NOT NULL,
+    created_at TIMESTAMP(3) NOT NULL
+) WITH (
+    'connector' = 'clickhouse',
+    'url'       = 'http://localhost:8123',
+    'username'  = 'default',
+    'password'  = '',
+    'database'  = 'analytics',
+    'table'     = 'events'
+    -- + optional batching/retry options, see below
+);
+
+INSERT INTO ch_events SELECT event_id, amount, created_at FROM kafka_src;
+```
+
+### Connector options
+
+Connection options (required unless noted): `url`, `username`, `password` (defaults to `''`),
+`database`, `table`.
+
+**Batching / backpressure**
+
+| Option | Default | DataStream equivalent |
+|---|---|---|
+| `sink.buffer-flush.max-rows` | `500` | `builder.setMaxBatchSize()` |
+| `sink.buffer-flush.max-bytes` | `5mb` | `builder.setMaxBatchSizeInBytes()` |
+| `sink.buffer-flush.interval` | `5s` | `builder.setMaxTimeInBufferMS()` |
+| `sink.max-in-flight-requests` | `50` | `builder.setMaxInFlightRequests()` |
+| `sink.max-buffered-requests` | `10000` | `builder.setMaxBufferedRequests()` |
+| `sink.record.max-bytes` | `1mb` | `builder.setMaxRecordSizeInBytes()` |
+| `sink.parallelism` | (query parallelism) | `sinkTo(sink).setParallelism(n)` |
+
+**Reliability**
+
+| Option | Default | DataStream equivalent |
+|---|---|---|
+| `sink.max-retries` | `-1` (retry forever) | `config.setRetryPolicy()` |
+| `sink.batch-failure-strategy` | `stop-flink` (`drop-batch`) | `config.setBatchFailureStrategy()` |
+
+**Type / compatibility**
+
+| Option | Default | Effect |
+|---|---|---|
+| `sink.timezone` | `UTC` | zone in which `TIMESTAMP` (no time zone) wall-clock values are interpreted; DST gap wall clocks shift forward, ambiguous fall-back wall clocks take the earlier offset |
+| `sink.ignore-unknown-flink-columns` | `false` | `true` drops Flink columns absent from the ClickHouse table instead of failing |
+| `sink.strict-numeric-mapping` | `false` | `true` rejects at planning every numeric type pair whose values may not all fit the column (a narrower or unsigned integer column, a `DECIMAL(p,0)` at an integer's digit boundary or into an unsigned integer), instead of range-checking each value at write time; lossless widening stays allowed |
+
+**Passthrough**: `clickhouse.client.<key>` options are forwarded to the ClickHouse client,
+`clickhouse.server.<key>` become per-query server settings. The connector sends
+`print_pretty_type_names = 0` with its schema introspection only, so the type names it reads are
+canonical (named `Tuple` columns are otherwise pretty-printed across lines and rejected in the
+insert header), and pins `input_format_null_as_default`, `input_format_defaults_for_omitted_fields`
+and (for `JSON` columns) `input_format_binary_read_json_as_string` on every insert; a user copy of
+any of these settings, in either spelling, is rejected.
+
+Flink `STRING` into a ClickHouse `JSON` column works out of the box — the connector enables
+the client's JSON-as-string mode automatically exactly when a `JSON` column is mapped.
+
+### Type mapping
+
+Lossless widening is implicit; a pair that would round a value (`DOUBLE` into `Float32`, a narrower
+`Decimal` scale or timestamp precision) is rejected at planning. A pair whose values may not all fit the
+column (the "Notes" below) is accepted and every value is checked at write time, failing the job naming
+the column, value and range; with `'sink.strict-numeric-mapping' = 'true'` the numeric pairs among them are
+rejected at planning instead, since a wider column can always take their place. Any other pair fails at
+planning naming the column and both types.
+
+| Flink SQL type | ClickHouse column types | Notes |
+|---|---|---|
+| `BOOLEAN` | `Bool` | |
+| `TINYINT` / `SMALLINT` / `INT` / `BIGINT` | any `Int8..Int256` or `UInt8..UInt256` | a narrower or unsigned column is range-checked per record |
+| `DECIMAL(p, s)` | a `Decimal(p', s')` it fits; with `s = 0` also any `Int8..Int256` / `UInt8..UInt256` whose digits cover `p` | boundary precisions (`DECIMAL(19, 0)` → `Int64`, `DECIMAL(20, 0)` → `UInt64`) and unsigned targets are range-checked per record |
+| `FLOAT` | `Float32`, `Float64` | |
+| `DOUBLE` | `Float64` | `Float32` would round — `CAST` to `FLOAT` to round explicitly |
+| `CHAR` / `VARCHAR` / `STRING` | `String`, `FixedString(n)`, `UUID`, `JSON` | `FixedString` length checked in UTF-8 bytes per record, whatever the declared Flink length (Flink does not enforce it by default); `UUID` text checked per record |
+| `DATE` | `Date`, `Date32` | range-checked per record: `Date` 1970-01-01..2149-06-06, `Date32` 1900-01-01..2299-12-31 |
+| `TIMESTAMP(p)` / `TIMESTAMP_LTZ(p)` | `DateTime` (`p = 0`), `DateTime64(s >= p)` | range-checked per record: `DateTime` 1970-01-01..2106-02-07, `DateTime64` 1900-01-01..2299-12-31 (2262-04-11 at scale 9). Flink's default `TIMESTAMP` is precision 6 — declare `TIMESTAMP(3)` for `DateTime64(3)`. `TIMESTAMP` is a wall clock in `sink.timezone`; `TIMESTAMP_LTZ` an instant |
+| `ARRAY<t>` | `Array(T)` | only `Array(Nullable(T))` can carry nested NULLs |
+| `MAP<k, v>` | `Map(K, V)` | string/integer/decimal keys except `UInt64`; values not `Nullable` |
+| `MULTISET<t>` | `Map(T, UInt64)` | counts become the values |
+| `ROW<...>` | `Tuple(...)` | positional — a ROW whose field names are a named Tuple's element names in another order is rejected at planning; fields/elements not nullable |
+
+Unsupported: `BINARY`/`VARBINARY`, `TIME`, `TIMESTAMP WITH TIME ZONE`, `INTERVAL`; ClickHouse
+`Enum` (#43), `Variant` (#60), `Time` (#91), `IPv4/6`, `Dynamic`, geo — exclude such columns
+and let server defaults fill them.
+
+Everywhere: nullable Flink columns need `Nullable(...)` targets — except `Nullable(UInt8/16/32/64)`,
+blocked until issue #144 — and composites must be `NOT NULL`. `LowCardinality` is transparent;
+`SimpleAggregateFunction(f, T)` matches as `T`, top-level only.
+
+Notes for SQL users:
+- Operator names are planner-generated (e.g. `Sink: ch_events[3]`), which affects metric
+  identifiers; `numRecordsSend` counts at flush, so retried batches double-count versus
+  `SELECT count()`.
+- A compiled plan does not freeze the ClickHouse mapping: an `ALTER TABLE` between planning
+  and execution fails at the first flush (same exposure as the DataStream path).
+- The community `itinycheng` connector also registers the `clickhouse` identifier; having
+  both jars on the classpath fails with Flink's "multiple factories" error — keep only one.
+- SQL gateways without ClickHouse network access can deploy in application mode, where
+  planning runs on the JobManager inside the data plane.
 
 ### Example
 
-Planned for a future release — a complete end-to-end example will be added once the Table API becomes available.
+See the round-trip integration test
+[`ClickHouseTableApiIntegrationTests`](flink-connector-clickhouse-table/src/integrationTest/java/org/apache/flink/connector/clickhouse/table/ClickHouseTableApiIntegrationTests.java)
+for a complete DDL + `INSERT INTO` example against a real ClickHouse.
 
 ## Supported ClickHouse Types
+
+This is the DataStream (Java value) view; for the Flink SQL / Table API pairing rules see
+[Type mapping](#type-mapping).
 
 | Java Type       | ClickHouse Type | Supported | Serialize Method            |
 |-----------------|-----------------|-----------|-----------------------------| 

--- a/flink-connector-clickhouse-1.17/build.gradle.kts
+++ b/flink-connector-clickhouse-1.17/build.gradle.kts
@@ -64,8 +64,14 @@ dependencies {
     // Apache Flink Libraries
     implementation("org.apache.flink:flink-connector-base:${project.extra["flinkVersion"]}")
     implementation("org.apache.flink:flink-streaming-java:${project.extra["flinkVersion"]}")
+    // Table API glue (factory + sink) — provided by the Flink dist, never bundled.
+    compileOnly("org.apache.flink:flink-table-common:${project.extra["flinkVersion"]}")
 
-
+    testImplementation("org.apache.flink:flink-table-common:${project.extra["flinkVersion"]}")
+    testImplementation("org.apache.flink:flink-table-api-java-bridge:${project.extra["flinkVersion"]}")
+    // planner-loader keeps the planner's Scala 2.12 isolated from this module's Scala 2.13
+    testRuntimeOnly("org.apache.flink:flink-table-planner-loader:${project.extra["flinkVersion"]}")
+    testRuntimeOnly("org.apache.flink:flink-table-runtime:${project.extra["flinkVersion"]}")
     testImplementation("org.apache.flink:flink-connector-files:${project.extra["flinkVersion"]}")
     testImplementation("org.apache.flink:flink-connector-base:${project.extra["flinkVersion"]}")
     testImplementation("org.apache.flink:flink-streaming-java:${project.extra["flinkVersion"]}")
@@ -93,6 +99,8 @@ sourceSets {
         }
         java {
             srcDirs("src/main/java")
+            // Table API / SQL core, compiled here against this module's Flink rather than consumed as a jar
+            srcDir(project(":flink-connector-clickhouse-table").file("src/main/java"))
             srcDir(project(":flink-connector-clickhouse-base").layout.buildDirectory.file("generated/sources/version/java").get().asFile) // to include ClickHouseSinkVersion in the classpath
         }
     }
@@ -102,15 +110,27 @@ sourceSets {
         }
         java {
             srcDirs("src/test/java")
+            // Table API / SQL unit tests, run here against this module's Flink — the
+            // LogicalTypeRoot exhaustiveness guard can only fire on the generation under test
+            srcDir(project(":flink-connector-clickhouse-table").file("src/test/java"))
+            // Shared integration tests; not in -table's own test sourceSet (they need this
+            // module's Flink and embedded-ClickHouse test deps)
+            srcDir(project(":flink-connector-clickhouse-table").file("src/integrationTest/java"))
         }
     }
 }
+
+// The -table sources compile here too; this keeps their flink-table-common-only floor compile on every CI and publish path.
+tasks.compileJava { dependsOn(":flink-connector-clickhouse-table:compileJava") }
+tasks.compileTestJava { dependsOn(":flink-connector-clickhouse-table:compileTestJava") }
 
 tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("all")
     dependencies {
         include(dependency("org.apache.flink.connector.clickhouse:.*"))
         include(project(":flink-connector-clickhouse-base"))
+        // :flink-connector-clickhouse-table is absent by design — this filters the runtimeClasspath,
+        // and its classes are in this module's own output (see sourceSets).
         include(dependency("com.clickhouse:client-v2:${clickhouseVersion}:all"))
     }
     mergeServiceFiles()

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilder.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilder.java
@@ -20,21 +20,18 @@ import java.util.Optional;
  *
  * <p>Optional with defaults: batch tuning, format. In typed (POJO) mode the format
  * is forced to {@code RowBinaryWithNamesAndTypes} regardless of configuration.
+ *
+ * <p>{@link #build()} pings ClickHouse and fails fast if it is unreachable from the job
+ * driver; {@link #setVerifyConnectivity} turns that check off.
  */
 public class ClickHouseAsyncSinkBuilder<InputT>
         extends AsyncSinkBaseBuilder<
                 InputT, ClickHousePayload, ClickHouseAsyncSinkBuilder<InputT>> {
 
-    private static final int DEFAULT_MAX_BATCH_SIZE = 500;
-    private static final int DEFAULT_MAX_IN_FLIGHT_REQUESTS = 50;
-    private static final int DEFAULT_MAX_BUFFERED_REQUESTS = 10_000;
-    private static final long DEFAULT_MAX_BATCH_SIZE_IN_BYTES = 5L * 1024 * 1024;
-    private static final long DEFAULT_MAX_TIME_IN_BUFFER_MS = 5_000;
-    private static final long DEFAULT_MAX_RECORD_SIZE_IN_BYTES = 1L * 1024 * 1024;
-
     private ClickHouseConvertor<InputT> elementConverter;
     private ClickHouseClientConfig clickHouseClientConfig;
     private ClickHouseFormat clickHouseFormat;
+    private boolean verifyConnectivity = true;
 
     ClickHouseAsyncSinkBuilder() {}
 
@@ -55,19 +52,32 @@ public class ClickHouseAsyncSinkBuilder<InputT>
         return this;
     }
 
+    /**
+     * Whether {@link #build()} pings ClickHouse and fails fast when it is unreachable
+     * (default {@code true}). Turn off when the job driver cannot reach the server or
+     * connectivity was already verified, as the Table API factory does at planning.
+     */
+    public ClickHouseAsyncSinkBuilder<InputT> setVerifyConnectivity(boolean verifyConnectivity) {
+        this.verifyConnectivity = verifyConnectivity;
+        return this;
+    }
+
     @Override
     public ClickHouseAsyncSink<InputT> build() {
         Preconditions.checkNotNull(elementConverter, "elementConverter is required");
         Preconditions.checkNotNull(clickHouseClientConfig, "clickHouseClientConfig is required");
+        if (verifyConnectivity) {
+            clickHouseClientConfig.verifyConnectivity();
+        }
 
         return new ClickHouseAsyncSink<>(
                 elementConverter,
-                Optional.ofNullable(getMaxBatchSize()).orElse(DEFAULT_MAX_BATCH_SIZE),
-                Optional.ofNullable(getMaxInFlightRequests()).orElse(DEFAULT_MAX_IN_FLIGHT_REQUESTS),
-                Optional.ofNullable(getMaxBufferedRequests()).orElse(DEFAULT_MAX_BUFFERED_REQUESTS),
-                Optional.ofNullable(getMaxBatchSizeInBytes()).orElse(DEFAULT_MAX_BATCH_SIZE_IN_BYTES),
-                Optional.ofNullable(getMaxTimeInBufferMS()).orElse(DEFAULT_MAX_TIME_IN_BUFFER_MS),
-                Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(DEFAULT_MAX_RECORD_SIZE_IN_BYTES),
+                Optional.ofNullable(getMaxBatchSize()).orElse(ClickHouseSinkDefaults.MAX_BATCH_SIZE),
+                Optional.ofNullable(getMaxInFlightRequests()).orElse(ClickHouseSinkDefaults.MAX_IN_FLIGHT_REQUESTS),
+                Optional.ofNullable(getMaxBufferedRequests()).orElse(ClickHouseSinkDefaults.MAX_BUFFERED_REQUESTS),
+                Optional.ofNullable(getMaxBatchSizeInBytes()).orElse(ClickHouseSinkDefaults.MAX_BATCH_SIZE_IN_BYTES),
+                Optional.ofNullable(getMaxTimeInBufferMS()).orElse(ClickHouseSinkDefaults.MAX_TIME_IN_BUFFER_MS),
+                Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(ClickHouseSinkDefaults.MAX_RECORD_SIZE_IN_BYTES),
                 clickHouseClientConfig,
                 clickHouseFormat,
                 elementConverter.isStringMode());

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -16,20 +16,24 @@ import java.util.Map;
  * <p>Per design spec §15. Parent {@link AsyncSinkWriterStateSerializer} owns the
  * per-blob framing; we override only the per-entry stream methods.
  *
- * <p>Two entry markers exist in the read path; only {@code ENTRY_MAP} is written:
+ * <p>Three entry markers exist in the read path; only {@code ENTRY_MAP_LONG_STRINGS} is written:
  * <ul>
  *   <li>{@code ENTRY_BYTES_ONLY} — legacy V1 entries, read-only. Wrapped as
  *       {@code Map{RAW_KEY: bytes}} when {@code stringMode = true}; otherwise the
  *       restore fails with a drain-first error.</li>
- *   <li>{@code ENTRY_MAP} — V2 entries: tagged {@code Map<String,Object>}.</li>
+ *   <li>{@code ENTRY_MAP} — V2 entries, read-only: tagged {@code Map<String,Object>}
+ *       with writeUTF keys, which cap at 64 KB.</li>
+ *   <li>{@code ENTRY_MAP_LONG_STRINGS} — V3 entries: keys and string values are int-length-prefixed
+ *       UTF-8, so anything above writeUTF's 64 KB limit checkpoints safely.</li>
  * </ul>
  */
 public class ClickHouseAsyncSinkSerializer
         extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
 
-    private static final int V2 = 2;
     private static final int ENTRY_BYTES_ONLY = 1;
-    private static final int ENTRY_MAP = 2;
+    // Map entry markers double as the TypeTags entry format version they were written under.
+    private static final int ENTRY_MAP = TypeTags.V2;
+    private static final int ENTRY_MAP_LONG_STRINGS = TypeTags.V3;
     private static final int MAX_REASONABLE_BYTES = 256 * 1024 * 1024;
 
     private final boolean stringMode;
@@ -39,16 +43,16 @@ public class ClickHouseAsyncSinkSerializer
     }
 
     @Override
-    public int getVersion() { return V2; }
+    public int getVersion() { return TypeTags.V3; }
 
     @Override
     protected void serializeRequestToStream(ClickHousePayload entry, DataOutputStream out)
             throws IOException {
-        out.writeInt(ENTRY_MAP);
+        out.writeInt(ENTRY_MAP_LONG_STRINGS);
         Map<String, Object> m = entry.getData();
         out.writeInt(m.size());
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            out.writeUTF(e.getKey());
+            TypeTags.writeUtf8(e.getKey(), out);
             TypeTags.write(e.getValue(), out);
         }
     }
@@ -59,7 +63,8 @@ public class ClickHouseAsyncSinkSerializer
         int marker = in.readInt();
         switch (marker) {
             case ENTRY_BYTES_ONLY: return readLegacyBytesOnly(in);
-            case ENTRY_MAP:        return readMapEntry(in);
+            case ENTRY_MAP:
+            case ENTRY_MAP_LONG_STRINGS: return readMapEntry(in, marker);
             default: throw new IOException("Unknown entry marker: " + marker);
         }
     }
@@ -87,16 +92,15 @@ public class ClickHouseAsyncSinkSerializer
             + "or configure this sink for STRING mode for one-shot pass-through.");
     }
 
-    private ClickHousePayload readMapEntry(DataInputStream in) throws IOException {
+    private ClickHousePayload readMapEntry(DataInputStream in, int entryVersion) throws IOException {
         int n = in.readInt();
         if (n < 0 || n > 1_000_000) {
             throw new IOException("Implausible map key count: " + n);
         }
         Map<String, Object> data = new LinkedHashMap<>(n);
         for (int i = 0; i < n; i++) {
-            String key = in.readUTF();
-            Object value = TypeTags.read(in);
-            data.put(key, value);
+            String key = TypeTags.readString(in, entryVersion);
+            data.put(key, TypeTags.read(in, entryVersion));
         }
         return ClickHousePayload.ofData(data);
     }

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
@@ -14,6 +14,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Connection settings for the sink, serialized to the task managers. Constructing one never
+ * touches the network: {@link ClickHouseAsyncSinkBuilder#build()} verifies connectivity on the
+ * job driver via {@link #verifyConnectivity()}, while the Table API factory relies on its
+ * planning-time DESCRIBE through {@link #createPlanningClient(Map)} failing instead.
+ */
 public class ClickHouseClientConfig implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseClientConfig.class);
     private static final long serialVersionUID = 1L;
@@ -29,7 +35,7 @@ public class ClickHouseClientConfig implements Serializable {
     private Boolean supportDefault = null;
     private final Map<String, String> options;
     private final Map<String, String> serverSettings;
-    private boolean enableJsonSupportAsString = true;
+    private boolean enableJsonSupportAsString;
     private transient Client client = null;
     private RetryPolicy retryPolicy = RetryPolicy.forever();
     private BatchFailureStrategy batchFailureStrategy = BatchFailureStrategy.STOP_FLINK;
@@ -43,27 +49,8 @@ public class ClickHouseClientConfig implements Serializable {
         this.fullProductName = String.format("Flink-ClickHouse-Sink/%s (fv:flink/%s, lv:scala/%s)", ClickHouseSinkVersion.getVersion(), EnvironmentInformation.getVersion(), EnvironmentInformation.getScalaVersion());
         this.options = new HashMap<>(Optional.ofNullable(options).orElseGet(HashMap::new));
         this.serverSettings = new HashMap<>(Optional.ofNullable(serverSettings).orElseGet(HashMap::new));
-        this.enableJsonSupportAsString =  enableJsonSupportAsString;
-        LOG.info("ClickHouseClientConfig: url={}, user={}, password={}, database={}", url, username, "x".repeat(password.length()), database);
-        Client clientTmp = initClient(database);
-
-        boolean isServerAlive = false;
-        for (int i = 0; i < retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES) && !isServerAlive; i++) {
-            isServerAlive = clientTmp.ping();
-            if (!isServerAlive) {
-                LOG.warn(
-                    "Ping failed; will retry up to {} times in {} seconds.",
-                    retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES), 1);
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ignored) {
-
-                }
-            }
-        }
-        if (!isServerAlive) {
-            throw new RuntimeException("ClickHouse server is noy accessible. Please check your configuration or ClickHouse server.");
-        }
+        this.enableJsonSupportAsString = enableJsonSupportAsString;
+        LOG.info("ClickHouseClientConfig: url={}, user={}, password=******, database={}", url, username, database);
     }
 
     public ClickHouseClientConfig(String url, String username, String password, String database, String tableName) {
@@ -74,7 +61,53 @@ public class ClickHouseClientConfig implements Serializable {
         this(url, username, password, database, tableName, new HashMap<>(), new HashMap<>(), enableJsonSupport);
     }
 
-    private Client initClient(String database) {
+    /** Deep copy for DynamicTableSink#copy(); the cached client is not shared. */
+    public ClickHouseClientConfig copy() {
+        ClickHouseClientConfig copy = new ClickHouseClientConfig(
+                url, username, password, database, tableName, options, serverSettings, enableJsonSupportAsString);
+        copy.setSupportDefault(supportDefault);
+        copy.setRetryPolicy(retryPolicy);
+        copy.setBatchFailureStrategy(batchFailureStrategy);
+        return copy;
+    }
+
+    /**
+     * Pings up to {@link #DEFAULT_MAX_RETRIES} times, 1s apart, on a probe client closed either
+     * way — a fixed bound, independent of the retry policy, which governs batch retries. An
+     * interrupt during the retry sleep is re-asserted and fails with its own message; one that
+     * lands inside client-v2's {@code ping()} is swallowed there (it returns false with the flag
+     * cleared) and counts as a failed attempt.
+     */
+    public void verifyConnectivity() {
+        try (Client probe = initClient(database, Map.of())) {
+            boolean isServerAlive = false;
+            for (int i = 0; i < DEFAULT_MAX_RETRIES && !isServerAlive; i++) {
+                isServerAlive = probe.ping();
+                if (!isServerAlive) {
+                    LOG.warn("Ping failed; will retry up to {} times in {} seconds.", DEFAULT_MAX_RETRIES, 1);
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted while checking ClickHouse connectivity.", e);
+                    }
+                }
+            }
+            if (!isServerAlive) {
+                throw new RuntimeException("ClickHouse server is not accessible. Please check your configuration or ClickHouse server.");
+            }
+        }
+    }
+
+    /**
+     * A fresh, uncached client for planning; the caller closes it. The extra server settings
+     * reach this client only, never the serialized runtime config.
+     */
+    public Client createPlanningClient(Map<String, String> planningServerSettings) {
+        return initClient(database, planningServerSettings);
+    }
+
+    private Client initClient(String database, Map<String, String> extraServerSettings) {
         Client.Builder clientBuilder = new Client.Builder()
                 .addEndpoint(url)
                 .setUsername(username)
@@ -87,12 +120,15 @@ public class ClickHouseClientConfig implements Serializable {
         for (Map.Entry<String, String> entry : serverSettings.entrySet()) {
             clientBuilder.serverSetting(entry.getKey(), entry.getValue());
         }
+        for (Map.Entry<String, String> entry : extraServerSettings.entrySet()) {
+            clientBuilder.serverSetting(entry.getKey(), entry.getValue());
+        }
         return clientBuilder.build();
     }
 
     public Client createClient(String database) {
         if (this.client == null) {
-            this.client = initClient(database);
+            this.client = initClient(database, Map.of());
         }
         return client;
     }
@@ -135,7 +171,7 @@ public class ClickHouseClientConfig implements Serializable {
 
     public void setBatchFailureStrategy(BatchFailureStrategy batchFailureStrategy) {
         this.batchFailureStrategy = Objects.requireNonNull(
-            batchFailureStrategy,"batchFailureStrategy must not be null");
+                batchFailureStrategy,"batchFailureStrategy must not be null");
     }
 
     public void setEnableJsonSupportAsString(boolean enableJsonSupportAsString) {

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSink.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSink.java
@@ -1,0 +1,82 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.data.ClickHouseFormat;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseAsyncSink;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.Objects;
+
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.DATABASE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_BUFFERED_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_IN_FLIGHT_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_RECORD_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.TABLE;
+
+/**
+ * Wraps the existing {@link ClickHouseAsyncSink} behind Flink's {@code DynamicTableSink}
+ * contract with an insert-only changelog; the planner rejects update-producing queries.
+ * Upsert is issue #148.
+ */
+public class ClickHouseDynamicTableSink implements DynamicTableSink {
+
+    private final ClickHouseClientConfig clientConfig;
+    private final RowDataDataMapper mapper;
+    /** The factory-validated table options, read here so a batching option is named in one place. */
+    private final ReadableConfig options;
+
+    public ClickHouseDynamicTableSink(ClickHouseClientConfig clientConfig, RowDataDataMapper mapper, ReadableConfig options) {
+        this.clientConfig = Objects.requireNonNull(clientConfig, "clientConfig");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.options = Objects.requireNonNull(options, "options");
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        // Appending retractions would corrupt the table — #148's upsert lands here.
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        return SinkV2Provider.of(buildSink(), options.getOptional(FactoryUtil.SINK_PARALLELISM).orElse(null));
+    }
+
+    private ClickHouseAsyncSink<RowData> buildSink() {
+        return ClickHouseAsyncSink.<RowData>builder()
+                .setElementConverter(new ClickHouseConvertor<>(RowData.class, mapper))
+                .setClickHouseFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+                .setMaxBatchSize(options.get(SINK_BUFFER_FLUSH_MAX_ROWS))
+                .setMaxBatchSizeInBytes(options.get(SINK_BUFFER_FLUSH_MAX_BYTES).getBytes())
+                .setMaxTimeInBufferMS(options.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis())
+                .setMaxInFlightRequests(options.get(SINK_MAX_IN_FLIGHT_REQUESTS))
+                .setMaxBufferedRequests(options.get(SINK_MAX_BUFFERED_REQUESTS))
+                .setMaxRecordSizeInBytes(options.get(SINK_RECORD_MAX_BYTES).getBytes())
+                .setClickHouseClientConfig(clientConfig)
+                // The factory's DESCRIBE proved connectivity; a planner hook must not go back to the network.
+                .setVerifyConnectivity(false)
+                .build();
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        // The config is mutable (setters, cached client) and must not be shared; the rest is read-only.
+        return new ClickHouseDynamicTableSink(clientConfig.copy(), mapper, options);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "ClickHouse[" + options.get(DATABASE) + "." + options.get(TABLE) + "]";
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactory.java
+++ b/flink-connector-clickhouse-1.17/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactory.java
@@ -1,0 +1,465 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.client.api.ClientMisconfigurationException;
+import com.clickhouse.client.api.ServerException;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
+import com.clickhouse.client.api.internal.ServerSettings;
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.config.BatchFailureStrategy;
+import com.clickhouse.config.RetryPolicy;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.connector.clickhouse.table.schema.ResolvedColumnMapping;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolver;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolverOptions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.CLIENT_OPTIONS_PREFIX;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.DATABASE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.MAX_RETRIES_UNLIMITED;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.PASSWORD;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BATCH_FAILURE_STRATEGY;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_IGNORE_UNKNOWN_FLINK_COLUMNS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_BUFFERED_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_IN_FLIGHT_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_RETRIES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_RECORD_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_TIMEZONE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_STRICT_NUMERIC_MAPPING;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.TABLE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.URL;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.USERNAME;
+
+/**
+ * Flink SQL factory for {@code 'connector' = 'clickhouse'}: validate options → introspect
+ * the target table → resolve the schema → build the sink. All option, schema
+ * and connectivity errors surface here, at planning time.
+ *
+ * <p>Re-invoked by {@code EXPLAIN}, statement sets and {@code EXECUTE PLAN} — each
+ * invocation introspects anew through a short-lived client, so planning always
+ * validates against the table's current schema, even after {@code ALTER TABLE} in a
+ * long-lived planner JVM (SQL gateway, session cluster).
+ */
+public class ClickHouseDynamicTableSinkFactory implements DynamicTableSinkFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseDynamicTableSinkFactory.class);
+
+    public static final String IDENTIFIER = "clickhouse";
+
+    /** Set from the first-class options; a passthrough copy — client option, server setting or request header — would shadow or break them without naming the option. */
+    private static final Map<String, ConfigOption<?>> RESERVED_CLIENT_KEYS = Map.of(
+            ClientConfigProperties.DATABASE.getKey(), DATABASE,
+            ClientConfigProperties.USER.getKey(), USERNAME,
+            ClientConfigProperties.PASSWORD.getKey(), PASSWORD);
+
+    /** The identity headers the client derives from those options: a user copy either replaces the connector's (database) or is dropped by the client's auth-header cleanup (user, key); header names are case-insensitive. */
+    private static final Map<String, ConfigOption<?>> RESERVED_CLIENT_HEADERS = Map.of(
+            ClickHouseHttpProto.HEADER_DATABASE.toLowerCase(Locale.ROOT), DATABASE,
+            ClickHouseHttpProto.HEADER_DB_USER.toLowerCase(Locale.ROOT), USERNAME,
+            ClickHouseHttpProto.HEADER_DB_PASSWORD.toLowerCase(Locale.ROOT), PASSWORD);
+
+    /**
+     * Sent with the planning DESCRIBE only: the introspected type text goes verbatim into every
+     * RowBinaryWithNamesAndTypes header, and the server rejects a pretty-printed
+     * {@code Tuple(<newline>    a Int32, …)} there with code 117.
+     */
+    static final String PRINT_PRETTY_TYPE_NAMES = "print_pretty_type_names";
+    private static final Map<String, String> PLANNING_SERVER_SETTINGS = Map.of(PRINT_PRETTY_TYPE_NAMES, "0");
+
+    /** Pinned per insert by ClickHouseAsyncWriter; client-v2 lets operation settings win, so a user copy would be discarded silently. */
+    static final Set<String> INSERT_SERVER_SETTINGS = Set.of(
+            "input_format_null_as_default",
+            "input_format_defaults_for_omitted_fields",
+            ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING);
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(URL);
+        options.add(USERNAME);
+        options.add(DATABASE);
+        options.add(TABLE);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PASSWORD);
+        options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
+        options.add(SINK_BUFFER_FLUSH_MAX_BYTES);
+        options.add(SINK_BUFFER_FLUSH_INTERVAL);
+        options.add(SINK_MAX_IN_FLIGHT_REQUESTS);
+        options.add(SINK_MAX_BUFFERED_REQUESTS);
+        options.add(SINK_RECORD_MAX_BYTES);
+        options.add(FactoryUtil.SINK_PARALLELISM);
+        options.add(SINK_MAX_RETRIES);
+        options.add(SINK_BATCH_FAILURE_STRATEGY);
+        options.add(SINK_TIMEZONE);
+        options.add(SINK_IGNORE_UNKNOWN_FLINK_COLUMNS);
+        options.add(SINK_STRICT_NUMERIC_MAPPING);
+        return options;
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        ReadableConfig options = validatedOptions(context);
+        validateBatchingOptions(options);
+        // Checked first so an invalid url, sink.timezone or unsupported table name fails before any network call.
+        validateUrl(options.get(URL));
+        SchemaResolverOptions resolverOptions = buildResolverOptions(options);
+        logIgnoredPrimaryKey(context);
+
+        ClickHouseClientConfig clientConfig = buildClientConfig(context.getCatalogTable().getOptions(), options);
+        List<ResolvedColumnMapping> mappings = SchemaResolver.resolve(
+                context.getCatalogTable().getResolvedSchema(),
+                introspect(options, clientConfig),
+                resolverOptions);
+        // Servers too old to know input_format_binary_read_json_as_string never see it.
+        clientConfig.setEnableJsonSupportAsString(SchemaResolver.targetsJsonColumn(mappings));
+
+        return new ClickHouseDynamicTableSink(clientConfig, RowDataDataMapper.of(mappings), options);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Steps
+    // ------------------------------------------------------------------------------------
+
+    private ReadableConfig validatedOptions(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validateExcept(CLIENT_OPTIONS_PREFIX, SERVER_SETTINGS_PREFIX);
+        return helper.getOptions();
+    }
+
+    /** The AsyncSink writer re-checks these at task start; failing here names the SQL options instead. */
+    static void validateBatchingOptions(ReadableConfig options) {
+        int maxRows = options.get(SINK_BUFFER_FLUSH_MAX_ROWS);
+        long maxBytes = options.get(SINK_BUFFER_FLUSH_MAX_BYTES).getBytes();
+        int maxBuffered = options.get(SINK_MAX_BUFFERED_REQUESTS);
+        long recordMaxBytes = options.get(SINK_RECORD_MAX_BYTES).getBytes();
+
+        requirePositive(SINK_BUFFER_FLUSH_MAX_ROWS.key(), maxRows);
+        requirePositive(SINK_BUFFER_FLUSH_MAX_BYTES.key(), maxBytes);
+        requireWholeMillis(SINK_BUFFER_FLUSH_INTERVAL.key(), options.get(SINK_BUFFER_FLUSH_INTERVAL));
+        requirePositive(SINK_MAX_IN_FLIGHT_REQUESTS.key(), options.get(SINK_MAX_IN_FLIGHT_REQUESTS));
+        requirePositive(SINK_MAX_BUFFERED_REQUESTS.key(), maxBuffered);
+        requirePositive(SINK_RECORD_MAX_BYTES.key(), recordMaxBytes);
+        if (maxBuffered <= maxRows) {
+            throw new ValidationException(String.format(
+                    "'%s' (%d) must be strictly greater than '%s' (%d).",
+                    SINK_MAX_BUFFERED_REQUESTS.key(), maxBuffered,
+                    SINK_BUFFER_FLUSH_MAX_ROWS.key(), maxRows));
+        }
+        if (maxBytes < recordMaxBytes) {
+            throw new ValidationException(String.format(
+                    "'%s' (%d bytes) must be at least '%s' (%d bytes).",
+                    SINK_BUFFER_FLUSH_MAX_BYTES.key(), maxBytes,
+                    SINK_RECORD_MAX_BYTES.key(), recordMaxBytes));
+        }
+    }
+
+    private static void requirePositive(String key, long value) {
+        if (value <= 0) {
+            throw new ValidationException(
+                    String.format("'%s' must be positive, but was %d.", key, value));
+        }
+    }
+
+    /** Flink parses micros and nanos, but the writer's timer is in whole milliseconds; toMillis() would floor silently. */
+    private static void requireWholeMillis(String key, Duration value) {
+        if (value.compareTo(Duration.ofMillis(1)) < 0 || value.getNano() % 1_000_000 != 0) {
+            throw new ValidationException(String.format(
+                    "'%s' must be a whole number of milliseconds, at least 1 ms, but was %s.",
+                    key, TimeUtils.formatWithHighestUnit(value)));
+        }
+    }
+
+    private static SchemaResolverOptions buildResolverOptions(ReadableConfig options) {
+        return new SchemaResolverOptions(
+                options.get(DATABASE),
+                options.get(TABLE),
+                parseSinkTimezone(options.get(SINK_TIMEZONE)),
+                options.get(SINK_IGNORE_UNKNOWN_FLINK_COLUMNS),
+                options.get(SINK_STRICT_NUMERIC_MAPPING));
+    }
+
+    /** {@code tableOptions} are the raw DDL options, needed for the prefix scan the typed {@code options} cannot do. */
+    private static ClickHouseClientConfig buildClientConfig(Map<String, String> tableOptions, ReadableConfig options) {
+        Map<String, String> clientOptions = clientOptions(tableOptions);
+        Map<String, String> serverSettings = serverSettings(tableOptions);
+        checkServerSettingDefinedOnce(clientOptions, serverSettings);
+        ClickHouseClientConfig clientConfig = new ClickHouseClientConfig(
+                options.get(URL),
+                options.get(USERNAME),
+                options.get(PASSWORD),
+                options.get(DATABASE),
+                options.get(TABLE),
+                clientOptions,
+                serverSettings,
+                false); // JSON-as-string is decided once schema resolution has mapped the columns
+        clientConfig.setRetryPolicy(toRetryPolicy(options.get(SINK_MAX_RETRIES)));
+        clientConfig.setBatchFailureStrategy(
+                parseBatchFailureStrategy(options.get(SINK_BATCH_FAILURE_STRATEGY)));
+        return clientConfig;
+    }
+
+    /**
+     * Reads the table's current column types through a short-lived client —
+     * deliberately unmemoized so a long-lived planner sees {@code ALTER TABLE}.
+     */
+    static TableSchema introspect(ReadableConfig options, ClickHouseClientConfig clientConfig) {
+        String url = options.get(URL);
+        String database = options.get(DATABASE);
+        String table = options.get(TABLE);
+        LOG.info("Introspecting ClickHouse table {}.{} at {}", database, table, url);
+        try (Client client = clientConfig.createPlanningClient(PLANNING_SERVER_SETTINGS)) {
+            return client.getTableSchema(table, database);
+        } catch (IllegalArgumentException | ClientMisconfigurationException e) {
+            // Only Client.Builder.build() throws these here: option values and combinations parseConfigMap cannot see (the time-zone pair, SSL authentication, key store and certificate files).
+            throw new ValidationException(String.format(
+                    "Invalid '%s*' option or option combination — the ClickHouse client rejected it: %s",
+                    CLIENT_OPTIONS_PREFIX, withCause(e)), e);
+        } catch (Exception e) {
+            throw new ValidationException(String.format(
+                    "Could not read the schema of ClickHouse table %s.%s at %s — %s",
+                    database, table, url, rootMessage(e)), e);
+        }
+    }
+
+    /** client-v2 wraps a failed DESCRIBE in the constant "Failed to get table schema"; the server's reason is a cause below it, an interrupt's or a timeout's (a message-less TimeoutException) is the wrapper's own message. */
+    static String rootMessage(Throwable e) {
+        Throwable cause = e;
+        while (!(cause instanceof ServerException) && cause.getCause() != null
+                && !(cause.getCause() instanceof InterruptedException)
+                && cause.getCause().getMessage() != null) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() != null ? cause.getMessage() : cause.toString();
+    }
+
+    /** build()'s SSL failures name the unreadable file or bad password only in a cause. */
+    private static String withCause(Throwable e) {
+        return e.getCause() == null ? e.getMessage() : e.getMessage() + " (" + rootMessage(e.getCause()) + ")";
+    }
+
+    private static void logIgnoredPrimaryKey(Context context) {
+        context.getCatalogTable().getResolvedSchema().getPrimaryKey().ifPresent(pk ->
+                LOG.info("PRIMARY KEY {} on table {} is accepted and ignored — the ClickHouse sink "
+                        + "is insert-only and does not enforce keys.",
+                        pk.getColumns(), context.getObjectIdentifier()));
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Option parsing
+    // ------------------------------------------------------------------------------------
+
+    static ZoneId parseSinkTimezone(String zone) {
+        try {
+            // Fixed-offset ids (UTC, GMT, Etc/UTC) become ZoneOffsets: 'Z' in state, no rule lookup per value.
+            return ZoneId.of(zone).normalized();
+        } catch (DateTimeException e) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s': %s", zone, SINK_TIMEZONE.key(), e.getMessage()), e);
+        }
+    }
+
+    /** client-v2 parses the endpoint (java.net.URL, http/https) only when the client is built, inside the introspection step. */
+    static void validateUrl(String url) {
+        String problem = urlProblem(url);
+        if (problem != null) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s': %s — expected an endpoint like 'http://host:8123'.",
+                    url, URL.key(), problem));
+        }
+    }
+
+    /** The client's own endpoint checks (URL syntax, http/https, host, port range) on a throwaway builder; no I/O. */
+    private static String urlProblem(String url) {
+        try {
+            new Client.Builder().addEndpoint(url);
+            return null;
+        } catch (IllegalArgumentException e) {
+            return e.getMessage();
+        }
+    }
+
+    static RetryPolicy toRetryPolicy(int maxRetries) {
+        if (maxRetries == MAX_RETRIES_UNLIMITED) {
+            return RetryPolicy.forever();
+        }
+        if (maxRetries < 0) {
+            throw new ValidationException(String.format(
+                    "'%s' must be >= 0, or -1 for unlimited retries, but was %d.",
+                    SINK_MAX_RETRIES.key(), maxRetries));
+        }
+        return RetryPolicy.limited(maxRetries);
+    }
+
+    static BatchFailureStrategy parseBatchFailureStrategy(String value) {
+        try {
+            return BatchFailureStrategy.valueOf(
+                    value.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s' — supported values: 'stop-flink', 'drop-batch'.",
+                    value, SINK_BATCH_FAILURE_STRATEGY.key()));
+        }
+    }
+
+    /** The client-v2 passthrough; the client only WARN-logs unknown keys, so they are rejected here. */
+    static Map<String, String> clientOptions(Map<String, String> tableOptions) {
+        Map<String, String> options = prefixedOptions(tableOptions, CLIENT_OPTIONS_PREFIX);
+        options.keySet().forEach(ClickHouseDynamicTableSinkFactory::checkClientOptionKey);
+        options.forEach(ClickHouseDynamicTableSinkFactory::checkClientOptionValue);
+        return options;
+    }
+
+    /** The clickhouse.server.* passthrough; the connector's own settings are rejected rather than fought over. */
+    static Map<String, String> serverSettings(Map<String, String> tableOptions) {
+        Map<String, String> settings = prefixedOptions(tableOptions, SERVER_SETTINGS_PREFIX);
+        settings.keySet().forEach(setting ->
+                checkServerSettingNotConnectorOwned(SERVER_SETTINGS_PREFIX + setting, setting));
+        return settings;
+    }
+
+    /** Both key forms land on one client-builder key, the server one last, so the pair would collapse silently. */
+    static void checkServerSettingDefinedOnce(Map<String, String> clientOptions, Map<String, String> serverSettings) {
+        String prefix = ClientConfigProperties.SERVER_SETTING_PREFIX;
+        for (String key : clientOptions.keySet()) {
+            if (key.startsWith(prefix) && serverSettings.containsKey(key.substring(prefix.length()))) {
+                throw new ValidationException(String.format(
+                        "Option '%s%s' duplicates '%s%s' — set the server setting once.",
+                        CLIENT_OPTIONS_PREFIX, key, SERVER_SETTINGS_PREFIX, key.substring(prefix.length())));
+            }
+        }
+    }
+
+    private static void checkClientOptionKey(String key) {
+        checkNotConnectionOption(CLIENT_OPTIONS_PREFIX + key, RESERVED_CLIENT_KEYS.get(key));
+        // client-v2 strips the prefix and sends the rest verbatim, so a bare one becomes an empty setting or header name.
+        if (key.equals(ClientConfigProperties.HTTP_HEADER_PREFIX) || key.equals(ClientConfigProperties.SERVER_SETTING_PREFIX)) {
+            throw new ValidationException(String.format(
+                    "Option '%s%s' has no name after the prefix — expected '%s%s<name>'.",
+                    CLIENT_OPTIONS_PREFIX, key, CLIENT_OPTIONS_PREFIX, key));
+        }
+        if (key.startsWith(ClientConfigProperties.SERVER_SETTING_PREFIX)) {
+            checkServerSettingNotConnectorOwned(CLIENT_OPTIONS_PREFIX + key,
+                    key.substring(ClientConfigProperties.SERVER_SETTING_PREFIX.length()));
+        }
+        if (key.startsWith(ClientConfigProperties.HTTP_HEADER_PREFIX)) {
+            checkNotConnectionOption(CLIENT_OPTIONS_PREFIX + key, RESERVED_CLIENT_HEADERS.get(
+                    key.substring(ClientConfigProperties.HTTP_HEADER_PREFIX.length()).toLowerCase(Locale.ROOT)));
+        }
+        if (!isClientOptionKey(key)) {
+            throw new ValidationException(String.format(
+                    "Option '%s%s' is not a ClickHouse client option. Supported keys: %s; "
+                    + "'%s<name>' and '%s<name>' are accepted too.",
+                    CLIENT_OPTIONS_PREFIX, key, supportedClientKeys(),
+                    ClientConfigProperties.HTTP_HEADER_PREFIX, ClientConfigProperties.SERVER_SETTING_PREFIX));
+        }
+    }
+
+    /** Client.Builder.build() parses option values eagerly, which would report a typo as a schema failure. */
+    private static void checkClientOptionValue(String key, String value) {
+        try {
+            ClientConfigProperties.parseConfigMap(Map.of(key, value));
+        } catch (RuntimeException e) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s%s': %s", value, CLIENT_OPTIONS_PREFIX, key, e.getMessage()), e);
+        }
+    }
+
+    /** The client sends these as its own headers; as a server setting the server ignores (database) or rejects (user, password) the copy without naming the option. */
+    private static void checkNotConnectionOption(String optionKey, ConfigOption<?> firstClass) {
+        if (firstClass != null) {
+            throw new ValidationException(String.format(
+                    "Option '%s' duplicates the connection option '%s' — set '%s' instead.",
+                    optionKey, firstClass.key(), firstClass.key()));
+        }
+    }
+
+    /** Whichever request carries the connector's copy, the client keeps exactly one value per setting, so the user's would lose silently. */
+    private static void checkServerSettingNotConnectorOwned(String optionKey, String setting) {
+        checkNotConnectionOption(optionKey, RESERVED_CLIENT_KEYS.get(setting));
+        if (PRINT_PRETTY_TYPE_NAMES.equals(setting)) {
+            throw connectorOwnedSetting(optionKey, "with its schema introspection");
+        }
+        if (INSERT_SERVER_SETTINGS.contains(setting)) {
+            throw connectorOwnedSetting(optionKey, "with every insert");
+        }
+    }
+
+    private static ValidationException connectorOwnedSetting(String optionKey, String sentWith) {
+        return new ValidationException(String.format(
+                "Option '%s' collides with the setting the connector itself sends %s — remove it.",
+                optionKey, sentWith));
+    }
+
+    private static boolean isClientOptionKey(String key) {
+        return key.startsWith(ClientConfigProperties.HTTP_HEADER_PREFIX)
+                || key.startsWith(ClientConfigProperties.SERVER_SETTING_PREFIX)
+                || Arrays.stream(ClientConfigProperties.values()).anyMatch(p -> p.getKey().equals(key));
+    }
+
+    private static String supportedClientKeys() {
+        return Arrays.stream(ClientConfigProperties.values())
+                .map(ClientConfigProperties::getKey)
+                .filter(key -> !RESERVED_CLIENT_KEYS.containsKey(key))
+                .sorted()
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Collects {@code <prefix><key> = value} table options into a trimmed {@code key -> value} map. A
+     * bare prefix is rejected: it would become the empty key, which the client and server silently ignore.
+     */
+    static Map<String, String> prefixedOptions(Map<String, String> tableOptions, String prefix) {
+        Map<String, String> extracted = new HashMap<>();
+        tableOptions.forEach((key, value) -> {
+            if (key.startsWith(prefix)) {
+                String setting = key.substring(prefix.length()).trim();
+                if (setting.isEmpty()) {
+                    throw new ValidationException(String.format(
+                            "Option '%s' has no key after the prefix — expected '%s<key>'.", key, prefix));
+                }
+                if (extracted.put(setting, value) != null) {
+                    throw new ValidationException(String.format(
+                            "Option '%s' duplicates another '%s%s' key once whitespace is trimmed — set it once.",
+                            key, prefix, setting));
+                }
+            }
+        });
+        return extracted;
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-clickhouse-1.17/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,1 @@
+org.apache.flink.connector.clickhouse.table.ClickHouseDynamicTableSinkFactory

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilderTest.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilderTest.java
@@ -1,0 +1,27 @@
+package org.apache.flink.connector.clickhouse.sink;
+
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseAsyncSinkBuilderTest {
+
+    /** Port 1 refuses at once, so the default ping fails after its fixed three attempts. */
+    private static ClickHouseAsyncSinkBuilder<String> unreachable() {
+        return ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setClickHouseClientConfig(new ClickHouseClientConfig("http://localhost:1", "u", "", "db", "t"));
+    }
+
+    @Test void buildFailsFastWhenTheServerIsUnreachable() {
+        RuntimeException e = assertThrows(RuntimeException.class, () -> unreachable().build());
+        assertTrue(e.getMessage().contains("not accessible"), e.getMessage());
+    }
+
+    @Test void buildCanSkipTheConnectivityCheck() {
+        assertNotNull(unreachable().setVerifyConnectivity(false).build());
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfigTest.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfigTest.java
@@ -1,0 +1,47 @@
+package org.apache.flink.connector.clickhouse.sink;
+
+import com.clickhouse.config.BatchFailureStrategy;
+import com.clickhouse.config.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseClientConfigTest {
+
+    /** No constructor touches the network, so port 1 is safe here. */
+    private static ClickHouseClientConfig config() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig("http://localhost:1", "u", "secret", "db", "t",
+                Map.of("socket_timeout", "1000"), Map.of("async_insert", "1"), false);
+        config.setRetryPolicy(RetryPolicy.limited(2));
+        return config;
+    }
+
+    @Test void copyCarriesEveryFieldAndSharesNoMutableState() {
+        ClickHouseClientConfig original = config();
+        original.setEnableJsonSupportAsString(true);
+        original.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+        original.setSupportDefault(Boolean.TRUE);
+
+        ClickHouseClientConfig copy = original.copy();
+        assertNotSame(original, copy);
+        assertEquals("t", copy.getTableName());
+        assertEquals(RetryPolicy.limited(2), copy.getRetryPolicy());
+        assertEquals(BatchFailureStrategy.DROP_BATCH, copy.getBatchFailureStrategy());
+        assertTrue(copy.getEnableJsonSupportAsString());
+        assertEquals(Boolean.TRUE, copy.getSupportDefault());
+
+        copy.setEnableJsonSupportAsString(false);
+        copy.setBatchFailureStrategy(BatchFailureStrategy.STOP_FLINK);
+        copy.setRetryPolicy(RetryPolicy.forever());
+        copy.setSupportDefault(Boolean.FALSE);
+
+        assertTrue(original.getEnableJsonSupportAsString());
+        assertEquals(BatchFailureStrategy.DROP_BATCH, original.getBatchFailureStrategy());
+        assertEquals(RetryPolicy.limited(2), original.getRetryPolicy());
+        assertEquals(Boolean.TRUE, original.getSupportDefault());
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -122,6 +122,38 @@ class ClickHouseSinkStateTests {
         assertTrue(ex.getMessage().contains("Drain the previous sink before upgrading"));
     }
 
+    /** Regression for writeUTF's 64 KB cap: SQL VARCHAR values and MAP keys can exceed it. */
+    @Test void oversizedStringsAndMapKeysCheckpointSafely() throws IOException {
+        String longValue = "v".repeat(70_000);
+        String longKey = "k".repeat(70_000);
+        ClickHousePayload p = ClickHousePayload.ofEmpty();
+        p.getData().put("text_col", longValue);
+        Map<String, Object> mapCol = new LinkedHashMap<>();
+        mapCol.put(longKey, "x");
+        p.getData().put("map_col", mapCol);
+        p.setCachedBytes(new byte[]{1});
+
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
+        BufferedRequestState<ClickHousePayload> restored = roundTrip(ser, wrap(p));
+
+        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
+        assertEquals(longValue, r.getData().get("text_col"));
+        assertEquals(mapCol, r.getData().get("map_col"));
+    }
+
+    @Test void v2MapEntryRestores() throws IOException {
+        byte[] blob = synthesizeV2Blob();
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
+        BufferedRequestState<ClickHousePayload> restored = ser.deserialize(2, blob);
+
+        assertEquals(1, restored.getBufferedRequestEntries().size());
+        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
+        assertEquals("hello", r.getData().get("str_col"));
+        Map<String, Object> expectedMap = new LinkedHashMap<>();
+        expectedMap.put("ik", 42);
+        assertEquals(expectedMap, r.getData().get("map_col"));
+    }
+
     @Test void unsupportedValueTypeFailsAtSerialize() {
         ClickHousePayload p = ClickHousePayload.ofEmpty();
         p.getData().put("bad", new java.util.Date());
@@ -145,6 +177,29 @@ class ClickHouseSinkStateTests {
                 b.write(entryPayload);
             }
             out.writeLong(body.size());                  // per-entry size prefix
+            out.write(body.toByteArray());
+        }
+        return baos.toByteArray();
+    }
+
+    /** A V2 blob exactly as the released connector wrote it: ENTRY_MAP marker, writeUTF keys, tagged values. */
+    private static byte[] synthesizeV2Blob() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeLong(-1L);                          // DATA_IDENTIFIER (parent constant)
+            out.writeInt(1);                             // one entry
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            try (DataOutputStream b = new DataOutputStream(body)) {
+                b.writeInt(2);                           // ENTRY_MAP marker
+                b.writeInt(2);                           // two top-level keys
+                b.writeUTF("str_col");
+                b.writeByte(10); b.writeUTF("hello");    // STRING tag
+                b.writeUTF("map_col");
+                b.writeByte(17); b.writeInt(1);          // MAP tag, one entry, writeUTF key
+                b.writeUTF("ik");
+                b.writeByte(4); b.writeInt(42);          // INT tag
+            }
+            out.writeLong(body.size());
             out.write(body.toByteArray());
         }
         return baos.toByteArray();

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -440,9 +440,11 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
 
     @Test
     void CheckClickHouseAlive() {
-        Assertions.assertThrows(RuntimeException.class, () -> {
-            new ClickHouseClientConfig(getServerURL(), getUsername() + "wrong_username", getPassword(), getDatabase(), "dummy");
-        });
+        ClickHouseClientConfig config = new ClickHouseClientConfig(getServerURL(), getUsername() + "wrong_username", getPassword(), getDatabase(), "dummy");
+        Assertions.assertThrows(RuntimeException.class, () -> ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setClickHouseClientConfig(config)
+                .build());
     }
 
     @Test

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactoryTest.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactoryTest.java
@@ -1,0 +1,344 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.table.api.ValidationException;
+
+import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.client.api.ClientException;
+import com.clickhouse.client.api.ServerException;
+import com.clickhouse.config.BatchFailureStrategy;
+import com.clickhouse.config.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.net.ConnectException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseDynamicTableSinkFactoryTest {
+
+    @Test void maxRetriesMinusOneMeansForever() {
+        assertEquals(RetryPolicy.forever(), ClickHouseDynamicTableSinkFactory.toRetryPolicy(-1));
+    }
+
+    @Test void maxRetriesZeroMeansNoRetries() {
+        assertEquals(RetryPolicy.limited(0), ClickHouseDynamicTableSinkFactory.toRetryPolicy(0));
+    }
+
+    @Test void maxRetriesMapsVerbatim() {
+        assertEquals(RetryPolicy.limited(5), ClickHouseDynamicTableSinkFactory.toRetryPolicy(5));
+    }
+
+    /** Only -1 is the documented forever sentinel; other negatives are configuration mistakes. */
+    @Test void maxRetriesOtherNegativesAreRejected() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.toRetryPolicy(-3));
+        assertTrue(ex.getMessage().contains("sink.max-retries"));
+        assertTrue(ex.getMessage().contains("-3"));
+    }
+
+    @Test void batchFailureStrategyAcceptsTheDocumentedSpellings() {
+        assertEquals(BatchFailureStrategy.STOP_FLINK,
+                ClickHouseDynamicTableSinkFactory.parseBatchFailureStrategy("stop-flink"));
+        assertEquals(BatchFailureStrategy.DROP_BATCH,
+                ClickHouseDynamicTableSinkFactory.parseBatchFailureStrategy(" Drop_Batch "));
+    }
+
+    @Test void unknownBatchFailureStrategyIsRejectedNamingTheOption() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.parseBatchFailureStrategy("retry-forever"));
+        assertTrue(ex.getMessage().contains("sink.batch-failure-strategy"));
+        assertTrue(ex.getMessage().contains("'retry-forever'"));
+    }
+
+    @Test void sinkTimezoneMustBeAValidZoneId() {
+        assertEquals(ZoneId.of("Asia/Tokyo"), ClickHouseDynamicTableSinkFactory.parseSinkTimezone("Asia/Tokyo"));
+        // The default: a ZoneOffset, so state stores 'Z' and conversion skips the rules lookup.
+        assertEquals(ZoneOffset.UTC, ClickHouseDynamicTableSinkFactory.parseSinkTimezone("UTC"));
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.parseSinkTimezone("Mars/Olympus_Mons"));
+        assertTrue(ex.getMessage().contains("sink.timezone"));
+        assertTrue(ex.getMessage().contains("'Mars/Olympus_Mons'"));
+    }
+
+    /** clickhouse.client.* and clickhouse.server.* keys lose their prefix and never mix. */
+    @Test void passthroughPrefixesAreStrippedAndKeptApart() {
+        Map<String, String> tableOptions = Map.of(
+                "connector", "clickhouse",
+                "clickhouse.client.socket_timeout", "30000",
+                "clickhouse.server.async_insert", "1",
+                "clickhouse.server.wait_for_async_insert", "1");
+        assertEquals(Map.of("socket_timeout", "30000"),
+                ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        tableOptions, ClickHouseConnectorOptions.CLIENT_OPTIONS_PREFIX));
+        assertEquals(Map.of("async_insert", "1", "wait_for_async_insert", "1"),
+                ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        tableOptions, ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX));
+    }
+
+    /** A bare prefix would otherwise become the empty key, which client-v2 and ClickHouse silently ignore. */
+    @Test void barePassthroughPrefixIsRejectedNamingTheOption() {
+        for (String prefix : List.of(
+                ClickHouseConnectorOptions.CLIENT_OPTIONS_PREFIX, ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX)) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.prefixedOptions(Map.of(prefix, "1"), prefix));
+            assertTrue(ex.getMessage().contains("'" + prefix + "'"));
+            assertTrue(ex.getMessage().contains(prefix + "<key>"));
+        }
+    }
+
+    /** client-v2 strips its own prefixes and sends the rest verbatim, so a bare one would become an empty header or setting name. */
+    @Test void bareClientHeaderAndServerSettingPrefixesAreRejectedNamingTheOption() {
+        for (String prefix : List.of(ClientConfigProperties.HTTP_HEADER_PREFIX, ClientConfigProperties.SERVER_SETTING_PREFIX)) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client." + prefix, "1")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client." + prefix + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains(prefix + "<name>"), ex.getMessage());
+        }
+    }
+
+    /** Flink keeps option keys verbatim, so a padded key must not reach the client or server untrimmed. */
+    @Test void passthroughKeysAreTrimmed() {
+        assertEquals(Map.of("max_insert_block_size", "777777"),
+                ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        Map.of("clickhouse.server.max_insert_block_size ", "777777"),
+                        ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX));
+    }
+
+    /** Two keys differing only in whitespace would otherwise collapse in HashMap order, not DDL order. */
+    @Test void passthroughKeysCollidingAfterTrimAreRejected() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        Map.of("clickhouse.server.max_insert_block_size", "1000",
+                                "clickhouse.server.max_insert_block_size ", "777777"),
+                        ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX));
+        assertTrue(ex.getMessage().contains("clickhouse.server.max_insert_block_size"), ex.getMessage());
+    }
+
+    /** The AsyncSink re-checks these at task start; failing at planning names the SQL options. */
+    @Test void batchingOptionsMustBeMutuallyConsistent() {
+        ValidationException rows = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                        Configuration.fromMap(Map.of("sink.buffer-flush.max-rows", "10000"))));
+        assertEquals("'sink.max-buffered-requests' (10000) must be strictly greater than "
+                + "'sink.buffer-flush.max-rows' (10000).", rows.getMessage());
+        ValidationException buffered = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                        Configuration.fromMap(Map.of("sink.max-buffered-requests", "400"))));
+        assertEquals("'sink.max-buffered-requests' (400) must be strictly greater than "
+                + "'sink.buffer-flush.max-rows' (500).", buffered.getMessage());
+        ValidationException bytes = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                        Configuration.fromMap(Map.of("sink.buffer-flush.max-bytes", "512kb"))));
+        assertTrue(bytes.getMessage().contains("must be at least 'sink.record.max-bytes'"), bytes.getMessage());
+        ClickHouseDynamicTableSinkFactory.validateBatchingOptions(Configuration.fromMap(Map.of()));
+    }
+
+    /** Flink parses micros and nanos; a sub-millisecond interval must be rejected, not floored to 0 or 1 ms. */
+    @Test void flushIntervalMustBeWholeMilliseconds() {
+        for (String bad : List.of("0 ms", "500 micros", "1500 micros")) {
+            Configuration options = Configuration.fromMap(Map.of("sink.buffer-flush.interval", bad));
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(options));
+            assertTrue(ex.getMessage().contains("'sink.buffer-flush.interval'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("whole number of milliseconds"), ex.getMessage());
+        }
+        ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                Configuration.fromMap(Map.of("sink.buffer-flush.interval", "2000 micros")));
+    }
+
+    /** These keys are set from the first-class options; a passthrough copy would override them silently. */
+    @Test void clientPassthroughRejectsKeysOwnedByFirstClassOptions() {
+        Map<String, String> firstClass = Map.of("database", "database", "user", "username", "password", "password");
+        firstClass.forEach((key, option) -> {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client." + key, "x")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client." + key + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("set '" + option + "' instead"), ex.getMessage());
+        });
+    }
+
+    /** The client sends database, user and password as its own headers; the header spelling replaces them and the server-setting spelling is ignored or rejected by the server, neither naming the option. */
+    @Test void connectionOptionsRespelledAsHeadersOrServerSettingsAreRejected() {
+        Map<String, String> settings = Map.of("database", "database", "user", "username", "password", "password");
+        settings.forEach((setting, option) -> {
+            ValidationException server = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.serverSettings(Map.of("clickhouse.server." + setting, "x")));
+            assertTrue(server.getMessage().contains("'clickhouse.server." + setting + "'"), server.getMessage());
+            assertTrue(server.getMessage().contains("set '" + option + "' instead"), server.getMessage());
+            ValidationException client = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.clickhouse_setting_" + setting, "x")));
+            assertTrue(client.getMessage().contains("'clickhouse.client.clickhouse_setting_" + setting + "'"), client.getMessage());
+            assertTrue(client.getMessage().contains("set '" + option + "' instead"), client.getMessage());
+        });
+        // Header names are case-insensitive on the wire, so every casing must be caught.
+        Map<String, String> headers = Map.of("X-ClickHouse-Database", "database", "x-clickhouse-user", "username", "X-CLICKHOUSE-KEY", "password");
+        headers.forEach((header, option) -> {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.http_header_" + header, "x")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client.http_header_" + header + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("set '" + option + "' instead"), ex.getMessage());
+        });
+        assertEquals(Map.of("http_header_X-Trace", "abc", "clickhouse_setting_max_threads", "2"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(Map.of(
+                        "clickhouse.client.http_header_X-Trace", "abc", "clickhouse.client.clickhouse_setting_max_threads", "2")));
+    }
+
+    /** client-v2 only WARN-logs unknown keys, so a typo would be accepted at planning and ignored at runtime. */
+    @Test void clientPassthroughRejectsUnknownKeysListingTheSupportedOnes() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.connect_timeout", "1000")));
+        assertTrue(ex.getMessage().contains("'clickhouse.client.connect_timeout'"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("connection_timeout"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("http_header_"), ex.getMessage());
+    }
+
+    /** Client.Builder.build() parses values eagerly, which would report a typo as a schema failure. */
+    @Test void clientPassthroughRejectsUnparsableValuesNamingTheOption() {
+        for (String key : List.of("connection_timeout", "retry")) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client." + key, "abc")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client." + key + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("'abc'"), ex.getMessage());
+        }
+    }
+
+    @Test void clientPassthroughAcceptsClientKeysHeadersAndServerSettings() {
+        Map<String, String> tableOptions = Map.of(
+                "connector", "clickhouse",
+                "clickhouse.client.connection_timeout", "1000",
+                "clickhouse.client.http_header_X-Trace", "abc",
+                "clickhouse.client.clickhouse_setting_max_threads", "2",
+                "clickhouse.server.async_insert", "1");
+        assertEquals(
+                Map.of("connection_timeout", "1000", "http_header_X-Trace", "abc", "clickhouse_setting_max_threads", "2"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(tableOptions));
+    }
+
+    /** client-v2 wraps every failed DESCRIBE in a constant message; the server's reason must surface. */
+    @Test void introspectionErrorsSurfaceTheServerReason() {
+        ServerException server = new ServerException(60,
+                "Code: 60. DB::Exception: Table db.evnts does not exist. (UNKNOWN_TABLE)");
+        assertEquals(server.getMessage(), ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Failed to get table schema", server)));
+        assertEquals("Connection refused", ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Failed to get table schema",
+                        new ClientException("Failed to connect", new ConnectException("Connection refused")))));
+        assertEquals("plain", ClickHouseDynamicTableSinkFactory.rootMessage(new RuntimeException("plain")));
+        // The wrapper says what was interrupted; the JDK's "sleep interrupted" does not.
+        assertEquals("Failed to get table schema", ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Failed to get table schema", new InterruptedException("sleep interrupted"))));
+    }
+
+    /** client-v2 reports a DESCRIBE timeout as a message-less TimeoutException under a wrapper that names the limit. */
+    @Test void introspectionTimeoutKeepsTheWrapperMessage() {
+        assertEquals("Operation has likely timed out after 5 seconds.", ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Operation has likely timed out after 5 seconds.", new TimeoutException())));
+    }
+
+    /** client-v2 parses the endpoint only when the client is built, which would report a typo or a missing port as a schema failure. */
+    @Test void urlIsValidatedBeforeAnyNetworkCall() {
+        ClickHouseDynamicTableSinkFactory.validateUrl("http://localhost:8123");
+        ClickHouseDynamicTableSinkFactory.validateUrl("HTTPS://my_host.example:8443/");
+        for (String bad : List.of("localhost:8123", "ftp://host:8123", "http://", "http:/host",
+                "http://localhost", "http://host:99999", "http://:8123")) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.validateUrl(bad));
+            assertTrue(ex.getMessage().contains("'url'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("'" + bad + "'"), ex.getMessage());
+        }
+    }
+
+    /** The planning DESCRIBE needs canonical type names; a user copy of that setting in either spelling would fight it. */
+    @Test void printPrettyTypeNamesIsReservedForPlanning() {
+        assertEquals(Map.of("async_insert", "1"),
+                ClickHouseDynamicTableSinkFactory.serverSettings(
+                        Map.of("connector", "clickhouse", "clickhouse.server.async_insert", "1")));
+        ValidationException server = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.serverSettings(
+                        Map.of("clickhouse.server.print_pretty_type_names", "1")));
+        assertTrue(server.getMessage().contains("'clickhouse.server.print_pretty_type_names'"), server.getMessage());
+        ValidationException client = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.clientOptions(
+                        Map.of("clickhouse.client.clickhouse_setting_print_pretty_type_names", "1")));
+        assertTrue(client.getMessage().contains("'clickhouse.client.clickhouse_setting_print_pretty_type_names'"),
+                client.getMessage());
+    }
+
+    /** Client.Builder.build() checks option combinations parseConfigMap cannot see; they must read as option errors, not schema failures. */
+    @Test void clientOptionCombinationsTheBuilderRejectsAreReportedAsOptionErrors() {
+        // The key and value pass the per-option pre-validation on their own …
+        assertEquals(Map.of("use_time_zone", "Asia/Tokyo"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.use_time_zone", "Asia/Tokyo")));
+        // … and only Client.Builder.build() rejects them against the default use_server_time_zone=true, before any I/O.
+        ValidationException ex = assertThrows(ValidationException.class, () -> ClickHouseDynamicTableSinkFactory.introspect(
+                planningOptions("http://localhost:1"), planningConfig("http://localhost:1", Map.of("use_time_zone", "Asia/Tokyo"))));
+        assertTrue(ex.getMessage().contains("'clickhouse.client.*'"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("USE_TIME_ZONE"), ex.getMessage());
+        assertFalse(ex.getMessage().contains("Could not read the schema"), ex.getMessage());
+    }
+
+    /** Single values only the built client rejects: a TimeZone-typed value parseConfigMap turns into GMT, and an SSL file the client cannot open (a ClientMisconfigurationException, not an IllegalArgumentException). */
+    @Test void clientOptionValuesOnlyTheBuiltClientRejectsAreReportedAsOptionErrors() {
+        assertEquals(Map.of("server_time_zone", "Mars/Olympus_Mons"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.server_time_zone", "Mars/Olympus_Mons")));
+        ValidationException zone = assertThrows(ValidationException.class, () -> ClickHouseDynamicTableSinkFactory.introspect(
+                planningOptions("http://localhost:1"), planningConfig("http://localhost:1", Map.of("server_time_zone", "Mars/Olympus_Mons"))));
+        assertTrue(zone.getMessage().contains("'clickhouse.client.*'"), zone.getMessage());
+        assertTrue(zone.getMessage().contains("Mars/Olympus_Mons"), zone.getMessage());
+        assertFalse(zone.getMessage().contains("Could not read the schema"), zone.getMessage());
+
+        // An https endpoint builds the SSL context inside build(), before any request is made.
+        ValidationException ssl = assertThrows(ValidationException.class, () -> ClickHouseDynamicTableSinkFactory.introspect(
+                planningOptions("https://localhost:1"), planningConfig("https://localhost:1", Map.of("sslrootcert", "/nonexistent/ca.pem"))));
+        assertTrue(ssl.getMessage().contains("'clickhouse.client.*'"), ssl.getMessage());
+        assertTrue(ssl.getMessage().contains("SSL context"), ssl.getMessage());
+        assertTrue(ssl.getMessage().contains("/nonexistent/ca.pem"), ssl.getMessage());
+        assertFalse(ssl.getMessage().contains("Could not read the schema"), ssl.getMessage());
+    }
+
+    /** ClickHouseAsyncWriter pins these on every insert and client-v2 lets operation settings win, so a user copy would be discarded silently. */
+    @Test void serverSettingsTheWriterPinsPerInsertAreRejectedInEitherSpelling() {
+        for (String setting : ClickHouseDynamicTableSinkFactory.INSERT_SERVER_SETTINGS) {
+            ValidationException server = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.serverSettings(Map.of("clickhouse.server." + setting, "0")));
+            assertTrue(server.getMessage().contains("'clickhouse.server." + setting + "'"), server.getMessage());
+            assertTrue(server.getMessage().contains("every insert"), server.getMessage());
+            ValidationException client = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(
+                            Map.of("clickhouse.client.clickhouse_setting_" + setting, "0")));
+            assertTrue(client.getMessage().contains("'clickhouse.client.clickhouse_setting_" + setting + "'"), client.getMessage());
+        }
+        assertEquals(List.of("input_format_binary_read_json_as_string", "input_format_defaults_for_omitted_fields",
+                        "input_format_null_as_default"),
+                ClickHouseDynamicTableSinkFactory.INSERT_SERVER_SETTINGS.stream().sorted().collect(java.util.stream.Collectors.toList()));
+    }
+
+    private static Configuration planningOptions(String url) {
+        return Configuration.fromMap(Map.of("url", url, "database", "db", "table", "t"));
+    }
+
+    /** Port 1: nothing here reaches the network. */
+    private static ClickHouseClientConfig planningConfig(String url, Map<String, String> clientOptions) {
+        return new ClickHouseClientConfig(url, "u", "", "db", "t", clientOptions, Map.of(), false);
+    }
+
+    /** clickhouse.server.<k> and clickhouse.client.clickhouse_setting_<k> land on one builder key; the pair must not collapse silently. */
+    @Test void serverSettingDefinedThroughBothPrefixesIsRejected() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.checkServerSettingDefinedOnce(
+                        Map.of("clickhouse_setting_async_insert", "0"), Map.of("async_insert", "1")));
+        assertTrue(ex.getMessage().contains("'clickhouse.client.clickhouse_setting_async_insert'"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("'clickhouse.server.async_insert'"), ex.getMessage());
+        ClickHouseDynamicTableSinkFactory.checkServerSettingDefinedOnce(
+                Map.of("clickhouse_setting_max_threads", "2", "socket_timeout", "1000"), Map.of("async_insert", "1"));
+    }
+}

--- a/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkTest.java
+++ b/flink-connector-clickhouse-1.17/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkTest.java
@@ -1,0 +1,64 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseColumn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolver;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolverOptions;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.ZoneId;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class ClickHouseDynamicTableSinkTest {
+
+    /** Built the way the factory builds it, minus the network. */
+    private static ClickHouseDynamicTableSink sink() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig("http://localhost:1", "u", "", "db", "t",
+                Map.of(), Map.of(), false);
+        RowDataDataMapper mapper = RowDataDataMapper.of(SchemaResolver.resolve(
+                ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT().notNull())),
+                new TableSchema(ClickHouseColumn.parse("id Int64")),
+                new SchemaResolverOptions("db", "t", ZoneId.of("UTC"), false)));
+        return new ClickHouseDynamicTableSink(config, mapper, Configuration.fromMap(Map.of("database", "db", "table", "t")));
+    }
+
+    /** The planner copies the sink per INSERT of a statement set; the copies must not share the config. */
+    @Test void copyIsADistinctSinkWithItsOwnClientConfig() throws Exception {
+        ClickHouseDynamicTableSink original = sink();
+        DynamicTableSink copy = original.copy();
+
+        assertNotSame(original, copy);
+        assertEquals(original.asSummaryString(), copy.asSummaryString());
+        configOf(copy).setEnableJsonSupportAsString(true);
+        assertFalse(configOf(original).getEnableJsonSupportAsString());
+    }
+
+    @Test void summaryNamesTheTargetTable() {
+        assertEquals("ClickHouse[db.t]", sink().asSummaryString());
+    }
+
+    @Test void changelogModeIsInsertOnlyWhateverThePlannerRequests() {
+        assertEquals(ChangelogMode.insertOnly(), sink().getChangelogMode(ChangelogMode.all()));
+        assertEquals(ChangelogMode.insertOnly(), sink().getChangelogMode(ChangelogMode.upsert()));
+    }
+
+    private static ClickHouseClientConfig configOf(DynamicTableSink sink) throws Exception {
+        Field field = ClickHouseDynamicTableSink.class.getDeclaredField("clientConfig");
+        field.setAccessible(true);
+        return (ClickHouseClientConfig) field.get(sink);
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/build.gradle.kts
+++ b/flink-connector-clickhouse-2.0.0/build.gradle.kts
@@ -24,8 +24,12 @@ repositories {
     mavenCentral()
 }
 
+// Lets CI compile this module against any 2.x. Separate from -1.17's FLINK_VERSION on
+// purpose: a shared var would let a 1.x value break this build.
+val flinkVersion = System.getenv("FLINK_2_VERSION")?.takeIf { it.isNotBlank() } ?: "2.0.0"
+
 extra.apply {
-    set("flinkVersion", "2.0.0") // the default still will be 2.0.0 since it is more popular currently
+    set("flinkVersion", flinkVersion) // the default still will be 2.0.0 since it is more popular currently
     set("log4jVersion","2.25.4")
     set("testContainersVersion", "2.0.2")
     set("testContainersClickHouseVersion", "1.21.3")
@@ -61,7 +65,14 @@ dependencies {
     implementation("org.apache.flink:flink-connector-base:${project.extra["flinkVersion"]}")
     implementation("org.apache.flink:flink-streaming-java:${project.extra["flinkVersion"]}")
     implementation(project(":flink-connector-clickhouse-base"))
+    // Table API glue (factory + sink) — provided by the Flink dist, never bundled.
+    compileOnly("org.apache.flink:flink-table-common:${project.extra["flinkVersion"]}")
 
+    testImplementation("org.apache.flink:flink-table-common:${project.extra["flinkVersion"]}")
+    testImplementation("org.apache.flink:flink-table-api-java-bridge:${project.extra["flinkVersion"]}")
+    // planner-loader keeps the planner's Scala 2.12 isolated from this module's Scala 2.13
+    testRuntimeOnly("org.apache.flink:flink-table-planner-loader:${project.extra["flinkVersion"]}")
+    testRuntimeOnly("org.apache.flink:flink-table-runtime:${project.extra["flinkVersion"]}")
     testImplementation("org.apache.flink:flink-connector-files:${project.extra["flinkVersion"]}")
     testImplementation("org.apache.flink:flink-connector-base:${project.extra["flinkVersion"]}")
     testImplementation("org.apache.flink:flink-streaming-java:${project.extra["flinkVersion"]}")
@@ -89,6 +100,8 @@ sourceSets {
         }
         java {
             srcDirs("src/main/java")
+            // Table API / SQL core, compiled here against this module's Flink rather than consumed as a jar
+            srcDir(project(":flink-connector-clickhouse-table").file("src/main/java"))
             srcDir(project(":flink-connector-clickhouse-base").layout.buildDirectory.file("generated/sources/version/java").get().asFile) // to include ClickHouseSinkVersion in the classpath
         }
     }
@@ -98,15 +111,62 @@ sourceSets {
         }
         java {
             srcDirs("src/test/java")
+            // Table API / SQL unit tests, run here against this module's Flink — the
+            // LogicalTypeRoot exhaustiveness guard can only fire on the generation under test
+            srcDir(project(":flink-connector-clickhouse-table").file("src/test/java"))
+            // Shared integration tests; not in -table's own test sourceSet (they need this
+            // module's Flink and embedded-ClickHouse test deps)
+            srcDir(project(":flink-connector-clickhouse-table").file("src/integrationTest/java"))
         }
     }
 }
+
+// These files are hand-duplicated across the version modules (the Table API pair needs this
+// module's ClickHouseAsyncSink/ClickHouseClientConfig, so it cannot be single-sourced in
+// :flink-connector-clickhouse-table until those are; the config and builder predate the split).
+// Fail the build on drift instead. Files that legitimately differ per Flink generation
+// (ClickHouseConvertor, ClickHouseAsyncWriter, ...) must stay out of this list.
+val checkCrossVersionCopiesInSync by tasks.registering {
+    val copies = listOf(
+        "src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSink.java",
+        "src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactory.java",
+        "src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory",
+        "src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java",
+        "src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilder.java",
+        // Flink-version-free, and both generations must keep one checkpoint format.
+        "src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java",
+        "src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java",
+        "src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfigTest.java",
+        "src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilderTest.java",
+        "src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactoryTest.java",
+        "src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkTest.java",
+    ).map { file(it) to project(":flink-connector-clickhouse-1.17").file(it) }
+    inputs.files(copies.flatMap { listOf(it.first, it.second) })
+    doLast {
+        copies.forEach { (ours, theirs) ->
+            check(ours.readBytes().contentEquals(theirs.readBytes())) {
+                "$ours differs from $theirs — these copies must stay identical; apply the change to both."
+            }
+        }
+    }
+}
+// check alone never runs in the pipelines: CI invokes test / runScalaTests directly, and
+// the publish workflows invoke shadowJar (publishToMavenLocal / CentralPortal build it).
+listOf("check", "test", "runScalaTests", "shadowJar").forEach {
+    tasks.named(it) { dependsOn(checkCrossVersionCopiesInSync) }
+}
+
+// The -table sources compile here too; this keeps their flink-table-common-only floor compile on every CI and publish path.
+tasks.compileJava { dependsOn(":flink-connector-clickhouse-table:compileJava") }
+tasks.compileTestJava { dependsOn(":flink-connector-clickhouse-table:compileTestJava") }
 
 tasks.named<ShadowJar>("shadowJar") {
     archiveClassifier.set("all")
     dependencies {
         include(dependency("org.apache.flink.connector.clickhouse:.*"))
         include(project(":flink-connector-clickhouse-base"))
+        // :flink-connector-clickhouse-table is absent by design — this filters the runtimeClasspath,
+        // and its classes are in this module's own output (see sourceSets).
         include(dependency("com.clickhouse:client-v2:${clickhouseVersion}:all"))
     }
     mergeServiceFiles()

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilder.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilder.java
@@ -20,21 +20,18 @@ import java.util.Optional;
  *
  * <p>Optional with defaults: batch tuning, format. In typed (POJO) mode the format
  * is forced to {@code RowBinaryWithNamesAndTypes} regardless of configuration.
+ *
+ * <p>{@link #build()} pings ClickHouse and fails fast if it is unreachable from the job
+ * driver; {@link #setVerifyConnectivity} turns that check off.
  */
 public class ClickHouseAsyncSinkBuilder<InputT>
         extends AsyncSinkBaseBuilder<
                 InputT, ClickHousePayload, ClickHouseAsyncSinkBuilder<InputT>> {
 
-    private static final int DEFAULT_MAX_BATCH_SIZE = 500;
-    private static final int DEFAULT_MAX_IN_FLIGHT_REQUESTS = 50;
-    private static final int DEFAULT_MAX_BUFFERED_REQUESTS = 10_000;
-    private static final long DEFAULT_MAX_BATCH_SIZE_IN_BYTES = 5L * 1024 * 1024;
-    private static final long DEFAULT_MAX_TIME_IN_BUFFER_MS = 5_000;
-    private static final long DEFAULT_MAX_RECORD_SIZE_IN_BYTES = 1L * 1024 * 1024;
-
     private ClickHouseConvertor<InputT> elementConverter;
     private ClickHouseClientConfig clickHouseClientConfig;
     private ClickHouseFormat clickHouseFormat;
+    private boolean verifyConnectivity = true;
 
     ClickHouseAsyncSinkBuilder() {}
 
@@ -55,19 +52,32 @@ public class ClickHouseAsyncSinkBuilder<InputT>
         return this;
     }
 
+    /**
+     * Whether {@link #build()} pings ClickHouse and fails fast when it is unreachable
+     * (default {@code true}). Turn off when the job driver cannot reach the server or
+     * connectivity was already verified, as the Table API factory does at planning.
+     */
+    public ClickHouseAsyncSinkBuilder<InputT> setVerifyConnectivity(boolean verifyConnectivity) {
+        this.verifyConnectivity = verifyConnectivity;
+        return this;
+    }
+
     @Override
     public ClickHouseAsyncSink<InputT> build() {
         Preconditions.checkNotNull(elementConverter, "elementConverter is required");
         Preconditions.checkNotNull(clickHouseClientConfig, "clickHouseClientConfig is required");
+        if (verifyConnectivity) {
+            clickHouseClientConfig.verifyConnectivity();
+        }
 
         return new ClickHouseAsyncSink<>(
                 elementConverter,
-                Optional.ofNullable(getMaxBatchSize()).orElse(DEFAULT_MAX_BATCH_SIZE),
-                Optional.ofNullable(getMaxInFlightRequests()).orElse(DEFAULT_MAX_IN_FLIGHT_REQUESTS),
-                Optional.ofNullable(getMaxBufferedRequests()).orElse(DEFAULT_MAX_BUFFERED_REQUESTS),
-                Optional.ofNullable(getMaxBatchSizeInBytes()).orElse(DEFAULT_MAX_BATCH_SIZE_IN_BYTES),
-                Optional.ofNullable(getMaxTimeInBufferMS()).orElse(DEFAULT_MAX_TIME_IN_BUFFER_MS),
-                Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(DEFAULT_MAX_RECORD_SIZE_IN_BYTES),
+                Optional.ofNullable(getMaxBatchSize()).orElse(ClickHouseSinkDefaults.MAX_BATCH_SIZE),
+                Optional.ofNullable(getMaxInFlightRequests()).orElse(ClickHouseSinkDefaults.MAX_IN_FLIGHT_REQUESTS),
+                Optional.ofNullable(getMaxBufferedRequests()).orElse(ClickHouseSinkDefaults.MAX_BUFFERED_REQUESTS),
+                Optional.ofNullable(getMaxBatchSizeInBytes()).orElse(ClickHouseSinkDefaults.MAX_BATCH_SIZE_IN_BYTES),
+                Optional.ofNullable(getMaxTimeInBufferMS()).orElse(ClickHouseSinkDefaults.MAX_TIME_IN_BUFFER_MS),
+                Optional.ofNullable(getMaxRecordSizeInBytes()).orElse(ClickHouseSinkDefaults.MAX_RECORD_SIZE_IN_BYTES),
                 clickHouseClientConfig,
                 clickHouseFormat,
                 elementConverter.isStringMode());

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkSerializer.java
@@ -16,20 +16,24 @@ import java.util.Map;
  * <p>Per design spec §15. Parent {@link AsyncSinkWriterStateSerializer} owns the
  * per-blob framing; we override only the per-entry stream methods.
  *
- * <p>Two entry markers exist in the read path; only {@code ENTRY_MAP} is written:
+ * <p>Three entry markers exist in the read path; only {@code ENTRY_MAP_LONG_STRINGS} is written:
  * <ul>
  *   <li>{@code ENTRY_BYTES_ONLY} — legacy V1 entries, read-only. Wrapped as
  *       {@code Map{RAW_KEY: bytes}} when {@code stringMode = true}; otherwise the
  *       restore fails with a drain-first error.</li>
- *   <li>{@code ENTRY_MAP} — V2 entries: tagged {@code Map<String,Object>}.</li>
+ *   <li>{@code ENTRY_MAP} — V2 entries, read-only: tagged {@code Map<String,Object>}
+ *       with writeUTF keys, which cap at 64 KB.</li>
+ *   <li>{@code ENTRY_MAP_LONG_STRINGS} — V3 entries: keys and string values are int-length-prefixed
+ *       UTF-8, so anything above writeUTF's 64 KB limit checkpoints safely.</li>
  * </ul>
  */
 public class ClickHouseAsyncSinkSerializer
         extends AsyncSinkWriterStateSerializer<ClickHousePayload> {
 
-    private static final int V2 = 2;
     private static final int ENTRY_BYTES_ONLY = 1;
-    private static final int ENTRY_MAP = 2;
+    // Map entry markers double as the TypeTags entry format version they were written under.
+    private static final int ENTRY_MAP = TypeTags.V2;
+    private static final int ENTRY_MAP_LONG_STRINGS = TypeTags.V3;
     private static final int MAX_REASONABLE_BYTES = 256 * 1024 * 1024;
 
     private final boolean stringMode;
@@ -39,16 +43,16 @@ public class ClickHouseAsyncSinkSerializer
     }
 
     @Override
-    public int getVersion() { return V2; }
+    public int getVersion() { return TypeTags.V3; }
 
     @Override
     protected void serializeRequestToStream(ClickHousePayload entry, DataOutputStream out)
             throws IOException {
-        out.writeInt(ENTRY_MAP);
+        out.writeInt(ENTRY_MAP_LONG_STRINGS);
         Map<String, Object> m = entry.getData();
         out.writeInt(m.size());
         for (Map.Entry<String, Object> e : m.entrySet()) {
-            out.writeUTF(e.getKey());
+            TypeTags.writeUtf8(e.getKey(), out);
             TypeTags.write(e.getValue(), out);
         }
     }
@@ -59,7 +63,8 @@ public class ClickHouseAsyncSinkSerializer
         int marker = in.readInt();
         switch (marker) {
             case ENTRY_BYTES_ONLY: return readLegacyBytesOnly(in);
-            case ENTRY_MAP:        return readMapEntry(in);
+            case ENTRY_MAP:
+            case ENTRY_MAP_LONG_STRINGS: return readMapEntry(in, marker);
             default: throw new IOException("Unknown entry marker: " + marker);
         }
     }
@@ -87,16 +92,15 @@ public class ClickHouseAsyncSinkSerializer
             + "or configure this sink for STRING mode for one-shot pass-through.");
     }
 
-    private ClickHousePayload readMapEntry(DataInputStream in) throws IOException {
+    private ClickHousePayload readMapEntry(DataInputStream in, int entryVersion) throws IOException {
         int n = in.readInt();
         if (n < 0 || n > 1_000_000) {
             throw new IOException("Implausible map key count: " + n);
         }
         Map<String, Object> data = new LinkedHashMap<>(n);
         for (int i = 0; i < n; i++) {
-            String key = in.readUTF();
-            Object value = TypeTags.read(in);
-            data.put(key, value);
+            String key = TypeTags.readString(in, entryVersion);
+            data.put(key, TypeTags.read(in, entryVersion));
         }
         return ClickHousePayload.ofData(data);
     }

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfig.java
@@ -14,6 +14,12 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+/**
+ * Connection settings for the sink, serialized to the task managers. Constructing one never
+ * touches the network: {@link ClickHouseAsyncSinkBuilder#build()} verifies connectivity on the
+ * job driver via {@link #verifyConnectivity()}, while the Table API factory relies on its
+ * planning-time DESCRIBE through {@link #createPlanningClient(Map)} failing instead.
+ */
 public class ClickHouseClientConfig implements Serializable {
     private static final Logger LOG = LoggerFactory.getLogger(ClickHouseClientConfig.class);
     private static final long serialVersionUID = 1L;
@@ -29,7 +35,7 @@ public class ClickHouseClientConfig implements Serializable {
     private Boolean supportDefault = null;
     private final Map<String, String> options;
     private final Map<String, String> serverSettings;
-    private boolean enableJsonSupportAsString = true;
+    private boolean enableJsonSupportAsString;
     private transient Client client = null;
     private RetryPolicy retryPolicy = RetryPolicy.forever();
     private BatchFailureStrategy batchFailureStrategy = BatchFailureStrategy.STOP_FLINK;
@@ -43,27 +49,8 @@ public class ClickHouseClientConfig implements Serializable {
         this.fullProductName = String.format("Flink-ClickHouse-Sink/%s (fv:flink/%s, lv:scala/%s)", ClickHouseSinkVersion.getVersion(), EnvironmentInformation.getVersion(), EnvironmentInformation.getScalaVersion());
         this.options = new HashMap<>(Optional.ofNullable(options).orElseGet(HashMap::new));
         this.serverSettings = new HashMap<>(Optional.ofNullable(serverSettings).orElseGet(HashMap::new));
-        this.enableJsonSupportAsString =  enableJsonSupportAsString;
-        LOG.info("ClickHouseClientConfig: url={}, user={}, password={}, database={}", url, username, "x".repeat(password.length()), database);
-        Client clientTmp = initClient(database);
-
-        boolean isServerAlive = false;
-        for (int i = 0; i < retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES) && !isServerAlive; i++) {
-            isServerAlive = clientTmp.ping();
-            if (!isServerAlive) {
-                LOG.warn(
-                        "Ping failed; will retry up to {} times in {} seconds.",
-                        retryPolicy.getValueOrDefault(DEFAULT_MAX_RETRIES), 1);
-                try {
-                    Thread.sleep(1000);
-                } catch (InterruptedException ignored) {
-
-                }
-            }
-        }
-        if (!isServerAlive) {
-            throw new RuntimeException("ClickHouse server is noy accessible. Please check your configuration or ClickHouse server.");
-        }
+        this.enableJsonSupportAsString = enableJsonSupportAsString;
+        LOG.info("ClickHouseClientConfig: url={}, user={}, password=******, database={}", url, username, database);
     }
 
     public ClickHouseClientConfig(String url, String username, String password, String database, String tableName) {
@@ -74,7 +61,53 @@ public class ClickHouseClientConfig implements Serializable {
         this(url, username, password, database, tableName, new HashMap<>(), new HashMap<>(), enableJsonSupport);
     }
 
-    private Client initClient(String database) {
+    /** Deep copy for DynamicTableSink#copy(); the cached client is not shared. */
+    public ClickHouseClientConfig copy() {
+        ClickHouseClientConfig copy = new ClickHouseClientConfig(
+                url, username, password, database, tableName, options, serverSettings, enableJsonSupportAsString);
+        copy.setSupportDefault(supportDefault);
+        copy.setRetryPolicy(retryPolicy);
+        copy.setBatchFailureStrategy(batchFailureStrategy);
+        return copy;
+    }
+
+    /**
+     * Pings up to {@link #DEFAULT_MAX_RETRIES} times, 1s apart, on a probe client closed either
+     * way — a fixed bound, independent of the retry policy, which governs batch retries. An
+     * interrupt during the retry sleep is re-asserted and fails with its own message; one that
+     * lands inside client-v2's {@code ping()} is swallowed there (it returns false with the flag
+     * cleared) and counts as a failed attempt.
+     */
+    public void verifyConnectivity() {
+        try (Client probe = initClient(database, Map.of())) {
+            boolean isServerAlive = false;
+            for (int i = 0; i < DEFAULT_MAX_RETRIES && !isServerAlive; i++) {
+                isServerAlive = probe.ping();
+                if (!isServerAlive) {
+                    LOG.warn("Ping failed; will retry up to {} times in {} seconds.", DEFAULT_MAX_RETRIES, 1);
+                    try {
+                        Thread.sleep(1000);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        throw new RuntimeException("Interrupted while checking ClickHouse connectivity.", e);
+                    }
+                }
+            }
+            if (!isServerAlive) {
+                throw new RuntimeException("ClickHouse server is not accessible. Please check your configuration or ClickHouse server.");
+            }
+        }
+    }
+
+    /**
+     * A fresh, uncached client for planning; the caller closes it. The extra server settings
+     * reach this client only, never the serialized runtime config.
+     */
+    public Client createPlanningClient(Map<String, String> planningServerSettings) {
+        return initClient(database, planningServerSettings);
+    }
+
+    private Client initClient(String database, Map<String, String> extraServerSettings) {
         Client.Builder clientBuilder = new Client.Builder()
                 .addEndpoint(url)
                 .setUsername(username)
@@ -87,12 +120,15 @@ public class ClickHouseClientConfig implements Serializable {
         for (Map.Entry<String, String> entry : serverSettings.entrySet()) {
             clientBuilder.serverSetting(entry.getKey(), entry.getValue());
         }
+        for (Map.Entry<String, String> entry : extraServerSettings.entrySet()) {
+            clientBuilder.serverSetting(entry.getKey(), entry.getValue());
+        }
         return clientBuilder.build();
     }
 
     public Client createClient(String database) {
         if (this.client == null) {
-            this.client = initClient(database);
+            this.client = initClient(database, Map.of());
         }
         return client;
     }

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSink.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSink.java
@@ -1,0 +1,82 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.data.ClickHouseFormat;
+
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseAsyncSink;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.connector.sink.SinkV2Provider;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import java.util.Objects;
+
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.DATABASE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_BUFFERED_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_IN_FLIGHT_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_RECORD_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.TABLE;
+
+/**
+ * Wraps the existing {@link ClickHouseAsyncSink} behind Flink's {@code DynamicTableSink}
+ * contract with an insert-only changelog; the planner rejects update-producing queries.
+ * Upsert is issue #148.
+ */
+public class ClickHouseDynamicTableSink implements DynamicTableSink {
+
+    private final ClickHouseClientConfig clientConfig;
+    private final RowDataDataMapper mapper;
+    /** The factory-validated table options, read here so a batching option is named in one place. */
+    private final ReadableConfig options;
+
+    public ClickHouseDynamicTableSink(ClickHouseClientConfig clientConfig, RowDataDataMapper mapper, ReadableConfig options) {
+        this.clientConfig = Objects.requireNonNull(clientConfig, "clientConfig");
+        this.mapper = Objects.requireNonNull(mapper, "mapper");
+        this.options = Objects.requireNonNull(options, "options");
+    }
+
+    @Override
+    public ChangelogMode getChangelogMode(ChangelogMode requestedMode) {
+        // Appending retractions would corrupt the table — #148's upsert lands here.
+        return ChangelogMode.insertOnly();
+    }
+
+    @Override
+    public SinkRuntimeProvider getSinkRuntimeProvider(Context context) {
+        return SinkV2Provider.of(buildSink(), options.getOptional(FactoryUtil.SINK_PARALLELISM).orElse(null));
+    }
+
+    private ClickHouseAsyncSink<RowData> buildSink() {
+        return ClickHouseAsyncSink.<RowData>builder()
+                .setElementConverter(new ClickHouseConvertor<>(RowData.class, mapper))
+                .setClickHouseFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+                .setMaxBatchSize(options.get(SINK_BUFFER_FLUSH_MAX_ROWS))
+                .setMaxBatchSizeInBytes(options.get(SINK_BUFFER_FLUSH_MAX_BYTES).getBytes())
+                .setMaxTimeInBufferMS(options.get(SINK_BUFFER_FLUSH_INTERVAL).toMillis())
+                .setMaxInFlightRequests(options.get(SINK_MAX_IN_FLIGHT_REQUESTS))
+                .setMaxBufferedRequests(options.get(SINK_MAX_BUFFERED_REQUESTS))
+                .setMaxRecordSizeInBytes(options.get(SINK_RECORD_MAX_BYTES).getBytes())
+                .setClickHouseClientConfig(clientConfig)
+                // The factory's DESCRIBE proved connectivity; a planner hook must not go back to the network.
+                .setVerifyConnectivity(false)
+                .build();
+    }
+
+    @Override
+    public DynamicTableSink copy() {
+        // The config is mutable (setters, cached client) and must not be shared; the rest is read-only.
+        return new ClickHouseDynamicTableSink(clientConfig.copy(), mapper, options);
+    }
+
+    @Override
+    public String asSummaryString() {
+        return "ClickHouse[" + options.get(DATABASE) + "." + options.get(TABLE) + "]";
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactory.java
+++ b/flink-connector-clickhouse-2.0.0/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactory.java
@@ -1,0 +1,465 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.client.api.ClientMisconfigurationException;
+import com.clickhouse.client.api.ServerException;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
+import com.clickhouse.client.api.internal.ServerSettings;
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.config.BatchFailureStrategy;
+import com.clickhouse.config.RetryPolicy;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.connector.clickhouse.table.schema.ResolvedColumnMapping;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolver;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolverOptions;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.factories.DynamicTableSinkFactory;
+import org.apache.flink.table.factories.FactoryUtil;
+import org.apache.flink.util.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.DateTimeException;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.CLIENT_OPTIONS_PREFIX;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.DATABASE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.MAX_RETRIES_UNLIMITED;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.PASSWORD;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BATCH_FAILURE_STRATEGY;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_INTERVAL;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_BUFFER_FLUSH_MAX_ROWS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_IGNORE_UNKNOWN_FLINK_COLUMNS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_BUFFERED_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_IN_FLIGHT_REQUESTS;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_MAX_RETRIES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_RECORD_MAX_BYTES;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_TIMEZONE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.SINK_STRICT_NUMERIC_MAPPING;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.TABLE;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.URL;
+import static org.apache.flink.connector.clickhouse.table.ClickHouseConnectorOptions.USERNAME;
+
+/**
+ * Flink SQL factory for {@code 'connector' = 'clickhouse'}: validate options → introspect
+ * the target table → resolve the schema → build the sink. All option, schema
+ * and connectivity errors surface here, at planning time.
+ *
+ * <p>Re-invoked by {@code EXPLAIN}, statement sets and {@code EXECUTE PLAN} — each
+ * invocation introspects anew through a short-lived client, so planning always
+ * validates against the table's current schema, even after {@code ALTER TABLE} in a
+ * long-lived planner JVM (SQL gateway, session cluster).
+ */
+public class ClickHouseDynamicTableSinkFactory implements DynamicTableSinkFactory {
+    private static final Logger LOG = LoggerFactory.getLogger(ClickHouseDynamicTableSinkFactory.class);
+
+    public static final String IDENTIFIER = "clickhouse";
+
+    /** Set from the first-class options; a passthrough copy — client option, server setting or request header — would shadow or break them without naming the option. */
+    private static final Map<String, ConfigOption<?>> RESERVED_CLIENT_KEYS = Map.of(
+            ClientConfigProperties.DATABASE.getKey(), DATABASE,
+            ClientConfigProperties.USER.getKey(), USERNAME,
+            ClientConfigProperties.PASSWORD.getKey(), PASSWORD);
+
+    /** The identity headers the client derives from those options: a user copy either replaces the connector's (database) or is dropped by the client's auth-header cleanup (user, key); header names are case-insensitive. */
+    private static final Map<String, ConfigOption<?>> RESERVED_CLIENT_HEADERS = Map.of(
+            ClickHouseHttpProto.HEADER_DATABASE.toLowerCase(Locale.ROOT), DATABASE,
+            ClickHouseHttpProto.HEADER_DB_USER.toLowerCase(Locale.ROOT), USERNAME,
+            ClickHouseHttpProto.HEADER_DB_PASSWORD.toLowerCase(Locale.ROOT), PASSWORD);
+
+    /**
+     * Sent with the planning DESCRIBE only: the introspected type text goes verbatim into every
+     * RowBinaryWithNamesAndTypes header, and the server rejects a pretty-printed
+     * {@code Tuple(<newline>    a Int32, …)} there with code 117.
+     */
+    static final String PRINT_PRETTY_TYPE_NAMES = "print_pretty_type_names";
+    private static final Map<String, String> PLANNING_SERVER_SETTINGS = Map.of(PRINT_PRETTY_TYPE_NAMES, "0");
+
+    /** Pinned per insert by ClickHouseAsyncWriter; client-v2 lets operation settings win, so a user copy would be discarded silently. */
+    static final Set<String> INSERT_SERVER_SETTINGS = Set.of(
+            "input_format_null_as_default",
+            "input_format_defaults_for_omitted_fields",
+            ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING);
+
+    @Override
+    public String factoryIdentifier() {
+        return IDENTIFIER;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> requiredOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(URL);
+        options.add(USERNAME);
+        options.add(DATABASE);
+        options.add(TABLE);
+        return options;
+    }
+
+    @Override
+    public Set<ConfigOption<?>> optionalOptions() {
+        Set<ConfigOption<?>> options = new HashSet<>();
+        options.add(PASSWORD);
+        options.add(SINK_BUFFER_FLUSH_MAX_ROWS);
+        options.add(SINK_BUFFER_FLUSH_MAX_BYTES);
+        options.add(SINK_BUFFER_FLUSH_INTERVAL);
+        options.add(SINK_MAX_IN_FLIGHT_REQUESTS);
+        options.add(SINK_MAX_BUFFERED_REQUESTS);
+        options.add(SINK_RECORD_MAX_BYTES);
+        options.add(FactoryUtil.SINK_PARALLELISM);
+        options.add(SINK_MAX_RETRIES);
+        options.add(SINK_BATCH_FAILURE_STRATEGY);
+        options.add(SINK_TIMEZONE);
+        options.add(SINK_IGNORE_UNKNOWN_FLINK_COLUMNS);
+        options.add(SINK_STRICT_NUMERIC_MAPPING);
+        return options;
+    }
+
+    @Override
+    public DynamicTableSink createDynamicTableSink(Context context) {
+        ReadableConfig options = validatedOptions(context);
+        validateBatchingOptions(options);
+        // Checked first so an invalid url, sink.timezone or unsupported table name fails before any network call.
+        validateUrl(options.get(URL));
+        SchemaResolverOptions resolverOptions = buildResolverOptions(options);
+        logIgnoredPrimaryKey(context);
+
+        ClickHouseClientConfig clientConfig = buildClientConfig(context.getCatalogTable().getOptions(), options);
+        List<ResolvedColumnMapping> mappings = SchemaResolver.resolve(
+                context.getCatalogTable().getResolvedSchema(),
+                introspect(options, clientConfig),
+                resolverOptions);
+        // Servers too old to know input_format_binary_read_json_as_string never see it.
+        clientConfig.setEnableJsonSupportAsString(SchemaResolver.targetsJsonColumn(mappings));
+
+        return new ClickHouseDynamicTableSink(clientConfig, RowDataDataMapper.of(mappings), options);
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Steps
+    // ------------------------------------------------------------------------------------
+
+    private ReadableConfig validatedOptions(Context context) {
+        FactoryUtil.TableFactoryHelper helper = FactoryUtil.createTableFactoryHelper(this, context);
+        helper.validateExcept(CLIENT_OPTIONS_PREFIX, SERVER_SETTINGS_PREFIX);
+        return helper.getOptions();
+    }
+
+    /** The AsyncSink writer re-checks these at task start; failing here names the SQL options instead. */
+    static void validateBatchingOptions(ReadableConfig options) {
+        int maxRows = options.get(SINK_BUFFER_FLUSH_MAX_ROWS);
+        long maxBytes = options.get(SINK_BUFFER_FLUSH_MAX_BYTES).getBytes();
+        int maxBuffered = options.get(SINK_MAX_BUFFERED_REQUESTS);
+        long recordMaxBytes = options.get(SINK_RECORD_MAX_BYTES).getBytes();
+
+        requirePositive(SINK_BUFFER_FLUSH_MAX_ROWS.key(), maxRows);
+        requirePositive(SINK_BUFFER_FLUSH_MAX_BYTES.key(), maxBytes);
+        requireWholeMillis(SINK_BUFFER_FLUSH_INTERVAL.key(), options.get(SINK_BUFFER_FLUSH_INTERVAL));
+        requirePositive(SINK_MAX_IN_FLIGHT_REQUESTS.key(), options.get(SINK_MAX_IN_FLIGHT_REQUESTS));
+        requirePositive(SINK_MAX_BUFFERED_REQUESTS.key(), maxBuffered);
+        requirePositive(SINK_RECORD_MAX_BYTES.key(), recordMaxBytes);
+        if (maxBuffered <= maxRows) {
+            throw new ValidationException(String.format(
+                    "'%s' (%d) must be strictly greater than '%s' (%d).",
+                    SINK_MAX_BUFFERED_REQUESTS.key(), maxBuffered,
+                    SINK_BUFFER_FLUSH_MAX_ROWS.key(), maxRows));
+        }
+        if (maxBytes < recordMaxBytes) {
+            throw new ValidationException(String.format(
+                    "'%s' (%d bytes) must be at least '%s' (%d bytes).",
+                    SINK_BUFFER_FLUSH_MAX_BYTES.key(), maxBytes,
+                    SINK_RECORD_MAX_BYTES.key(), recordMaxBytes));
+        }
+    }
+
+    private static void requirePositive(String key, long value) {
+        if (value <= 0) {
+            throw new ValidationException(
+                    String.format("'%s' must be positive, but was %d.", key, value));
+        }
+    }
+
+    /** Flink parses micros and nanos, but the writer's timer is in whole milliseconds; toMillis() would floor silently. */
+    private static void requireWholeMillis(String key, Duration value) {
+        if (value.compareTo(Duration.ofMillis(1)) < 0 || value.getNano() % 1_000_000 != 0) {
+            throw new ValidationException(String.format(
+                    "'%s' must be a whole number of milliseconds, at least 1 ms, but was %s.",
+                    key, TimeUtils.formatWithHighestUnit(value)));
+        }
+    }
+
+    private static SchemaResolverOptions buildResolverOptions(ReadableConfig options) {
+        return new SchemaResolverOptions(
+                options.get(DATABASE),
+                options.get(TABLE),
+                parseSinkTimezone(options.get(SINK_TIMEZONE)),
+                options.get(SINK_IGNORE_UNKNOWN_FLINK_COLUMNS),
+                options.get(SINK_STRICT_NUMERIC_MAPPING));
+    }
+
+    /** {@code tableOptions} are the raw DDL options, needed for the prefix scan the typed {@code options} cannot do. */
+    private static ClickHouseClientConfig buildClientConfig(Map<String, String> tableOptions, ReadableConfig options) {
+        Map<String, String> clientOptions = clientOptions(tableOptions);
+        Map<String, String> serverSettings = serverSettings(tableOptions);
+        checkServerSettingDefinedOnce(clientOptions, serverSettings);
+        ClickHouseClientConfig clientConfig = new ClickHouseClientConfig(
+                options.get(URL),
+                options.get(USERNAME),
+                options.get(PASSWORD),
+                options.get(DATABASE),
+                options.get(TABLE),
+                clientOptions,
+                serverSettings,
+                false); // JSON-as-string is decided once schema resolution has mapped the columns
+        clientConfig.setRetryPolicy(toRetryPolicy(options.get(SINK_MAX_RETRIES)));
+        clientConfig.setBatchFailureStrategy(
+                parseBatchFailureStrategy(options.get(SINK_BATCH_FAILURE_STRATEGY)));
+        return clientConfig;
+    }
+
+    /**
+     * Reads the table's current column types through a short-lived client —
+     * deliberately unmemoized so a long-lived planner sees {@code ALTER TABLE}.
+     */
+    static TableSchema introspect(ReadableConfig options, ClickHouseClientConfig clientConfig) {
+        String url = options.get(URL);
+        String database = options.get(DATABASE);
+        String table = options.get(TABLE);
+        LOG.info("Introspecting ClickHouse table {}.{} at {}", database, table, url);
+        try (Client client = clientConfig.createPlanningClient(PLANNING_SERVER_SETTINGS)) {
+            return client.getTableSchema(table, database);
+        } catch (IllegalArgumentException | ClientMisconfigurationException e) {
+            // Only Client.Builder.build() throws these here: option values and combinations parseConfigMap cannot see (the time-zone pair, SSL authentication, key store and certificate files).
+            throw new ValidationException(String.format(
+                    "Invalid '%s*' option or option combination — the ClickHouse client rejected it: %s",
+                    CLIENT_OPTIONS_PREFIX, withCause(e)), e);
+        } catch (Exception e) {
+            throw new ValidationException(String.format(
+                    "Could not read the schema of ClickHouse table %s.%s at %s — %s",
+                    database, table, url, rootMessage(e)), e);
+        }
+    }
+
+    /** client-v2 wraps a failed DESCRIBE in the constant "Failed to get table schema"; the server's reason is a cause below it, an interrupt's or a timeout's (a message-less TimeoutException) is the wrapper's own message. */
+    static String rootMessage(Throwable e) {
+        Throwable cause = e;
+        while (!(cause instanceof ServerException) && cause.getCause() != null
+                && !(cause.getCause() instanceof InterruptedException)
+                && cause.getCause().getMessage() != null) {
+            cause = cause.getCause();
+        }
+        return cause.getMessage() != null ? cause.getMessage() : cause.toString();
+    }
+
+    /** build()'s SSL failures name the unreadable file or bad password only in a cause. */
+    private static String withCause(Throwable e) {
+        return e.getCause() == null ? e.getMessage() : e.getMessage() + " (" + rootMessage(e.getCause()) + ")";
+    }
+
+    private static void logIgnoredPrimaryKey(Context context) {
+        context.getCatalogTable().getResolvedSchema().getPrimaryKey().ifPresent(pk ->
+                LOG.info("PRIMARY KEY {} on table {} is accepted and ignored — the ClickHouse sink "
+                        + "is insert-only and does not enforce keys.",
+                        pk.getColumns(), context.getObjectIdentifier()));
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Option parsing
+    // ------------------------------------------------------------------------------------
+
+    static ZoneId parseSinkTimezone(String zone) {
+        try {
+            // Fixed-offset ids (UTC, GMT, Etc/UTC) become ZoneOffsets: 'Z' in state, no rule lookup per value.
+            return ZoneId.of(zone).normalized();
+        } catch (DateTimeException e) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s': %s", zone, SINK_TIMEZONE.key(), e.getMessage()), e);
+        }
+    }
+
+    /** client-v2 parses the endpoint (java.net.URL, http/https) only when the client is built, inside the introspection step. */
+    static void validateUrl(String url) {
+        String problem = urlProblem(url);
+        if (problem != null) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s': %s — expected an endpoint like 'http://host:8123'.",
+                    url, URL.key(), problem));
+        }
+    }
+
+    /** The client's own endpoint checks (URL syntax, http/https, host, port range) on a throwaway builder; no I/O. */
+    private static String urlProblem(String url) {
+        try {
+            new Client.Builder().addEndpoint(url);
+            return null;
+        } catch (IllegalArgumentException e) {
+            return e.getMessage();
+        }
+    }
+
+    static RetryPolicy toRetryPolicy(int maxRetries) {
+        if (maxRetries == MAX_RETRIES_UNLIMITED) {
+            return RetryPolicy.forever();
+        }
+        if (maxRetries < 0) {
+            throw new ValidationException(String.format(
+                    "'%s' must be >= 0, or -1 for unlimited retries, but was %d.",
+                    SINK_MAX_RETRIES.key(), maxRetries));
+        }
+        return RetryPolicy.limited(maxRetries);
+    }
+
+    static BatchFailureStrategy parseBatchFailureStrategy(String value) {
+        try {
+            return BatchFailureStrategy.valueOf(
+                    value.trim().toUpperCase(Locale.ROOT).replace('-', '_'));
+        } catch (IllegalArgumentException e) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s' — supported values: 'stop-flink', 'drop-batch'.",
+                    value, SINK_BATCH_FAILURE_STRATEGY.key()));
+        }
+    }
+
+    /** The client-v2 passthrough; the client only WARN-logs unknown keys, so they are rejected here. */
+    static Map<String, String> clientOptions(Map<String, String> tableOptions) {
+        Map<String, String> options = prefixedOptions(tableOptions, CLIENT_OPTIONS_PREFIX);
+        options.keySet().forEach(ClickHouseDynamicTableSinkFactory::checkClientOptionKey);
+        options.forEach(ClickHouseDynamicTableSinkFactory::checkClientOptionValue);
+        return options;
+    }
+
+    /** The clickhouse.server.* passthrough; the connector's own settings are rejected rather than fought over. */
+    static Map<String, String> serverSettings(Map<String, String> tableOptions) {
+        Map<String, String> settings = prefixedOptions(tableOptions, SERVER_SETTINGS_PREFIX);
+        settings.keySet().forEach(setting ->
+                checkServerSettingNotConnectorOwned(SERVER_SETTINGS_PREFIX + setting, setting));
+        return settings;
+    }
+
+    /** Both key forms land on one client-builder key, the server one last, so the pair would collapse silently. */
+    static void checkServerSettingDefinedOnce(Map<String, String> clientOptions, Map<String, String> serverSettings) {
+        String prefix = ClientConfigProperties.SERVER_SETTING_PREFIX;
+        for (String key : clientOptions.keySet()) {
+            if (key.startsWith(prefix) && serverSettings.containsKey(key.substring(prefix.length()))) {
+                throw new ValidationException(String.format(
+                        "Option '%s%s' duplicates '%s%s' — set the server setting once.",
+                        CLIENT_OPTIONS_PREFIX, key, SERVER_SETTINGS_PREFIX, key.substring(prefix.length())));
+            }
+        }
+    }
+
+    private static void checkClientOptionKey(String key) {
+        checkNotConnectionOption(CLIENT_OPTIONS_PREFIX + key, RESERVED_CLIENT_KEYS.get(key));
+        // client-v2 strips the prefix and sends the rest verbatim, so a bare one becomes an empty setting or header name.
+        if (key.equals(ClientConfigProperties.HTTP_HEADER_PREFIX) || key.equals(ClientConfigProperties.SERVER_SETTING_PREFIX)) {
+            throw new ValidationException(String.format(
+                    "Option '%s%s' has no name after the prefix — expected '%s%s<name>'.",
+                    CLIENT_OPTIONS_PREFIX, key, CLIENT_OPTIONS_PREFIX, key));
+        }
+        if (key.startsWith(ClientConfigProperties.SERVER_SETTING_PREFIX)) {
+            checkServerSettingNotConnectorOwned(CLIENT_OPTIONS_PREFIX + key,
+                    key.substring(ClientConfigProperties.SERVER_SETTING_PREFIX.length()));
+        }
+        if (key.startsWith(ClientConfigProperties.HTTP_HEADER_PREFIX)) {
+            checkNotConnectionOption(CLIENT_OPTIONS_PREFIX + key, RESERVED_CLIENT_HEADERS.get(
+                    key.substring(ClientConfigProperties.HTTP_HEADER_PREFIX.length()).toLowerCase(Locale.ROOT)));
+        }
+        if (!isClientOptionKey(key)) {
+            throw new ValidationException(String.format(
+                    "Option '%s%s' is not a ClickHouse client option. Supported keys: %s; "
+                    + "'%s<name>' and '%s<name>' are accepted too.",
+                    CLIENT_OPTIONS_PREFIX, key, supportedClientKeys(),
+                    ClientConfigProperties.HTTP_HEADER_PREFIX, ClientConfigProperties.SERVER_SETTING_PREFIX));
+        }
+    }
+
+    /** Client.Builder.build() parses option values eagerly, which would report a typo as a schema failure. */
+    private static void checkClientOptionValue(String key, String value) {
+        try {
+            ClientConfigProperties.parseConfigMap(Map.of(key, value));
+        } catch (RuntimeException e) {
+            throw new ValidationException(String.format(
+                    "Invalid value '%s' for '%s%s': %s", value, CLIENT_OPTIONS_PREFIX, key, e.getMessage()), e);
+        }
+    }
+
+    /** The client sends these as its own headers; as a server setting the server ignores (database) or rejects (user, password) the copy without naming the option. */
+    private static void checkNotConnectionOption(String optionKey, ConfigOption<?> firstClass) {
+        if (firstClass != null) {
+            throw new ValidationException(String.format(
+                    "Option '%s' duplicates the connection option '%s' — set '%s' instead.",
+                    optionKey, firstClass.key(), firstClass.key()));
+        }
+    }
+
+    /** Whichever request carries the connector's copy, the client keeps exactly one value per setting, so the user's would lose silently. */
+    private static void checkServerSettingNotConnectorOwned(String optionKey, String setting) {
+        checkNotConnectionOption(optionKey, RESERVED_CLIENT_KEYS.get(setting));
+        if (PRINT_PRETTY_TYPE_NAMES.equals(setting)) {
+            throw connectorOwnedSetting(optionKey, "with its schema introspection");
+        }
+        if (INSERT_SERVER_SETTINGS.contains(setting)) {
+            throw connectorOwnedSetting(optionKey, "with every insert");
+        }
+    }
+
+    private static ValidationException connectorOwnedSetting(String optionKey, String sentWith) {
+        return new ValidationException(String.format(
+                "Option '%s' collides with the setting the connector itself sends %s — remove it.",
+                optionKey, sentWith));
+    }
+
+    private static boolean isClientOptionKey(String key) {
+        return key.startsWith(ClientConfigProperties.HTTP_HEADER_PREFIX)
+                || key.startsWith(ClientConfigProperties.SERVER_SETTING_PREFIX)
+                || Arrays.stream(ClientConfigProperties.values()).anyMatch(p -> p.getKey().equals(key));
+    }
+
+    private static String supportedClientKeys() {
+        return Arrays.stream(ClientConfigProperties.values())
+                .map(ClientConfigProperties::getKey)
+                .filter(key -> !RESERVED_CLIENT_KEYS.containsKey(key))
+                .sorted()
+                .collect(Collectors.joining(", "));
+    }
+
+    /**
+     * Collects {@code <prefix><key> = value} table options into a trimmed {@code key -> value} map. A
+     * bare prefix is rejected: it would become the empty key, which the client and server silently ignore.
+     */
+    static Map<String, String> prefixedOptions(Map<String, String> tableOptions, String prefix) {
+        Map<String, String> extracted = new HashMap<>();
+        tableOptions.forEach((key, value) -> {
+            if (key.startsWith(prefix)) {
+                String setting = key.substring(prefix.length()).trim();
+                if (setting.isEmpty()) {
+                    throw new ValidationException(String.format(
+                            "Option '%s' has no key after the prefix — expected '%s<key>'.", key, prefix));
+                }
+                if (extracted.put(setting, value) != null) {
+                    throw new ValidationException(String.format(
+                            "Option '%s' duplicates another '%s%s' key once whitespace is trimmed — set it once.",
+                            key, prefix, setting));
+                }
+            }
+        });
+        return extracted;
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
+++ b/flink-connector-clickhouse-2.0.0/src/main/resources/META-INF/services/org.apache.flink.table.factories.Factory
@@ -1,0 +1,1 @@
+org.apache.flink.connector.clickhouse.table.ClickHouseDynamicTableSinkFactory

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilderTest.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseAsyncSinkBuilderTest.java
@@ -1,0 +1,27 @@
+package org.apache.flink.connector.clickhouse.sink;
+
+import org.apache.flink.connector.clickhouse.convertor.ClickHouseConvertor;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseAsyncSinkBuilderTest {
+
+    /** Port 1 refuses at once, so the default ping fails after its fixed three attempts. */
+    private static ClickHouseAsyncSinkBuilder<String> unreachable() {
+        return ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setClickHouseClientConfig(new ClickHouseClientConfig("http://localhost:1", "u", "", "db", "t"));
+    }
+
+    @Test void buildFailsFastWhenTheServerIsUnreachable() {
+        RuntimeException e = assertThrows(RuntimeException.class, () -> unreachable().build());
+        assertTrue(e.getMessage().contains("not accessible"), e.getMessage());
+    }
+
+    @Test void buildCanSkipTheConnectivityCheck() {
+        assertNotNull(unreachable().setVerifyConnectivity(false).build());
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfigTest.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseClientConfigTest.java
@@ -1,0 +1,47 @@
+package org.apache.flink.connector.clickhouse.sink;
+
+import com.clickhouse.config.BatchFailureStrategy;
+import com.clickhouse.config.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseClientConfigTest {
+
+    /** No constructor touches the network, so port 1 is safe here. */
+    private static ClickHouseClientConfig config() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig("http://localhost:1", "u", "secret", "db", "t",
+                Map.of("socket_timeout", "1000"), Map.of("async_insert", "1"), false);
+        config.setRetryPolicy(RetryPolicy.limited(2));
+        return config;
+    }
+
+    @Test void copyCarriesEveryFieldAndSharesNoMutableState() {
+        ClickHouseClientConfig original = config();
+        original.setEnableJsonSupportAsString(true);
+        original.setBatchFailureStrategy(BatchFailureStrategy.DROP_BATCH);
+        original.setSupportDefault(Boolean.TRUE);
+
+        ClickHouseClientConfig copy = original.copy();
+        assertNotSame(original, copy);
+        assertEquals("t", copy.getTableName());
+        assertEquals(RetryPolicy.limited(2), copy.getRetryPolicy());
+        assertEquals(BatchFailureStrategy.DROP_BATCH, copy.getBatchFailureStrategy());
+        assertTrue(copy.getEnableJsonSupportAsString());
+        assertEquals(Boolean.TRUE, copy.getSupportDefault());
+
+        copy.setEnableJsonSupportAsString(false);
+        copy.setBatchFailureStrategy(BatchFailureStrategy.STOP_FLINK);
+        copy.setRetryPolicy(RetryPolicy.forever());
+        copy.setSupportDefault(Boolean.FALSE);
+
+        assertTrue(original.getEnableJsonSupportAsString());
+        assertEquals(BatchFailureStrategy.DROP_BATCH, original.getBatchFailureStrategy());
+        assertEquals(RetryPolicy.limited(2), original.getRetryPolicy());
+        assertEquals(Boolean.TRUE, original.getSupportDefault());
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkStateTests.java
@@ -122,6 +122,38 @@ class ClickHouseSinkStateTests {
         assertTrue(ex.getMessage().contains("Drain the previous sink before upgrading"));
     }
 
+    /** Regression for writeUTF's 64 KB cap: SQL VARCHAR values and MAP keys can exceed it. */
+    @Test void oversizedStringsAndMapKeysCheckpointSafely() throws IOException {
+        String longValue = "v".repeat(70_000);
+        String longKey = "k".repeat(70_000);
+        ClickHousePayload p = ClickHousePayload.ofEmpty();
+        p.getData().put("text_col", longValue);
+        Map<String, Object> mapCol = new LinkedHashMap<>();
+        mapCol.put(longKey, "x");
+        p.getData().put("map_col", mapCol);
+        p.setCachedBytes(new byte[]{1});
+
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
+        BufferedRequestState<ClickHousePayload> restored = roundTrip(ser, wrap(p));
+
+        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
+        assertEquals(longValue, r.getData().get("text_col"));
+        assertEquals(mapCol, r.getData().get("map_col"));
+    }
+
+    @Test void v2MapEntryRestores() throws IOException {
+        byte[] blob = synthesizeV2Blob();
+        ClickHouseAsyncSinkSerializer ser = new ClickHouseAsyncSinkSerializer(false);
+        BufferedRequestState<ClickHousePayload> restored = ser.deserialize(2, blob);
+
+        assertEquals(1, restored.getBufferedRequestEntries().size());
+        ClickHousePayload r = restored.getBufferedRequestEntries().iterator().next().getRequestEntry();
+        assertEquals("hello", r.getData().get("str_col"));
+        Map<String, Object> expectedMap = new LinkedHashMap<>();
+        expectedMap.put("ik", 42);
+        assertEquals(expectedMap, r.getData().get("map_col"));
+    }
+
     @Test void unsupportedValueTypeFailsAtSerialize() {
         ClickHousePayload p = ClickHousePayload.ofEmpty();
         p.getData().put("bad", new java.util.Date());
@@ -145,6 +177,29 @@ class ClickHouseSinkStateTests {
                 b.write(entryPayload);
             }
             out.writeLong(body.size());                  // per-entry size prefix
+            out.write(body.toByteArray());
+        }
+        return baos.toByteArray();
+    }
+
+    /** A V2 blob exactly as the released connector wrote it: ENTRY_MAP marker, writeUTF keys, tagged values. */
+    private static byte[] synthesizeV2Blob() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeLong(-1L);                          // DATA_IDENTIFIER (parent constant)
+            out.writeInt(1);                             // one entry
+            ByteArrayOutputStream body = new ByteArrayOutputStream();
+            try (DataOutputStream b = new DataOutputStream(body)) {
+                b.writeInt(2);                           // ENTRY_MAP marker
+                b.writeInt(2);                           // two top-level keys
+                b.writeUTF("str_col");
+                b.writeByte(10); b.writeUTF("hello");    // STRING tag
+                b.writeUTF("map_col");
+                b.writeByte(17); b.writeInt(1);          // MAP tag, one entry, writeUTF key
+                b.writeUTF("ik");
+                b.writeByte(4); b.writeInt(42);          // INT tag
+            }
+            out.writeLong(body.size());
             out.write(body.toByteArray());
         }
         return baos.toByteArray();

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkTests.java
@@ -171,6 +171,9 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
 
     @Test
     void ProductNameTest() throws Exception {
+        // Mirrors build.gradle.kts: blank falls back to the default, or we would assert a version we did not build against.
+        String flinkVersionEnv = System.getenv("FLINK_2_VERSION");
+        String flinkVersion = flinkVersionEnv != null && !flinkVersionEnv.trim().isEmpty() ? flinkVersionEnv : "2.0.0";
         String tableName = "product_name_csv_covid";
         // create table
         String tableSql = "CREATE TABLE `" + getDatabase() + "`.`" + tableName + "` (" +
@@ -231,7 +234,7 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
         // let's wait until data will be available in query log
         String startWith = String.format("Flink-ClickHouse-Sink/%s", ClickHouseSinkVersion.getVersion());
         String productName = ClickHouseServerForTests.extractProductName(ClickHouseServerForTests.getDatabase(), tableName, startWith);
-        String compareString = String.format("Flink-ClickHouse-Sink/%s (fv:flink/2.0.0, lv:scala/2.12)", ClickHouseSinkVersion.getVersion());
+        String compareString = String.format("Flink-ClickHouse-Sink/%s (fv:flink/%s, lv:scala/2.12)", ClickHouseSinkVersion.getVersion(), flinkVersion);
         boolean isContains = productName.contains(compareString);
         Assertions.assertTrue(isContains, "Expected user agent to contain: " + compareString + " but got: " + productName);
     }
@@ -452,9 +455,11 @@ public class ClickHouseSinkTests extends FlinkClusterTests {
 
     @Test
     void CheckClickHouseAlive() {
-        Assertions.assertThrows(RuntimeException.class, () -> {
-            new ClickHouseClientConfig(getServerURL(), getUsername() + "wrong_username", getPassword(), getDatabase(), "dummy");
-        });
+        ClickHouseClientConfig config = new ClickHouseClientConfig(getServerURL(), getUsername() + "wrong_username", getPassword(), getDatabase(), "dummy");
+        Assertions.assertThrows(RuntimeException.class, () -> ClickHouseAsyncSink.<String>builder()
+                .setElementConverter(new ClickHouseConvertor<>(String.class))
+                .setClickHouseClientConfig(config)
+                .build());
     }
 
     @Test

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactoryTest.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkFactoryTest.java
@@ -1,0 +1,344 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.table.api.ValidationException;
+
+import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.client.api.ClientException;
+import com.clickhouse.client.api.ServerException;
+import com.clickhouse.config.BatchFailureStrategy;
+import com.clickhouse.config.RetryPolicy;
+import org.junit.jupiter.api.Test;
+
+import java.net.ConnectException;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ClickHouseDynamicTableSinkFactoryTest {
+
+    @Test void maxRetriesMinusOneMeansForever() {
+        assertEquals(RetryPolicy.forever(), ClickHouseDynamicTableSinkFactory.toRetryPolicy(-1));
+    }
+
+    @Test void maxRetriesZeroMeansNoRetries() {
+        assertEquals(RetryPolicy.limited(0), ClickHouseDynamicTableSinkFactory.toRetryPolicy(0));
+    }
+
+    @Test void maxRetriesMapsVerbatim() {
+        assertEquals(RetryPolicy.limited(5), ClickHouseDynamicTableSinkFactory.toRetryPolicy(5));
+    }
+
+    /** Only -1 is the documented forever sentinel; other negatives are configuration mistakes. */
+    @Test void maxRetriesOtherNegativesAreRejected() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.toRetryPolicy(-3));
+        assertTrue(ex.getMessage().contains("sink.max-retries"));
+        assertTrue(ex.getMessage().contains("-3"));
+    }
+
+    @Test void batchFailureStrategyAcceptsTheDocumentedSpellings() {
+        assertEquals(BatchFailureStrategy.STOP_FLINK,
+                ClickHouseDynamicTableSinkFactory.parseBatchFailureStrategy("stop-flink"));
+        assertEquals(BatchFailureStrategy.DROP_BATCH,
+                ClickHouseDynamicTableSinkFactory.parseBatchFailureStrategy(" Drop_Batch "));
+    }
+
+    @Test void unknownBatchFailureStrategyIsRejectedNamingTheOption() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.parseBatchFailureStrategy("retry-forever"));
+        assertTrue(ex.getMessage().contains("sink.batch-failure-strategy"));
+        assertTrue(ex.getMessage().contains("'retry-forever'"));
+    }
+
+    @Test void sinkTimezoneMustBeAValidZoneId() {
+        assertEquals(ZoneId.of("Asia/Tokyo"), ClickHouseDynamicTableSinkFactory.parseSinkTimezone("Asia/Tokyo"));
+        // The default: a ZoneOffset, so state stores 'Z' and conversion skips the rules lookup.
+        assertEquals(ZoneOffset.UTC, ClickHouseDynamicTableSinkFactory.parseSinkTimezone("UTC"));
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.parseSinkTimezone("Mars/Olympus_Mons"));
+        assertTrue(ex.getMessage().contains("sink.timezone"));
+        assertTrue(ex.getMessage().contains("'Mars/Olympus_Mons'"));
+    }
+
+    /** clickhouse.client.* and clickhouse.server.* keys lose their prefix and never mix. */
+    @Test void passthroughPrefixesAreStrippedAndKeptApart() {
+        Map<String, String> tableOptions = Map.of(
+                "connector", "clickhouse",
+                "clickhouse.client.socket_timeout", "30000",
+                "clickhouse.server.async_insert", "1",
+                "clickhouse.server.wait_for_async_insert", "1");
+        assertEquals(Map.of("socket_timeout", "30000"),
+                ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        tableOptions, ClickHouseConnectorOptions.CLIENT_OPTIONS_PREFIX));
+        assertEquals(Map.of("async_insert", "1", "wait_for_async_insert", "1"),
+                ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        tableOptions, ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX));
+    }
+
+    /** A bare prefix would otherwise become the empty key, which client-v2 and ClickHouse silently ignore. */
+    @Test void barePassthroughPrefixIsRejectedNamingTheOption() {
+        for (String prefix : List.of(
+                ClickHouseConnectorOptions.CLIENT_OPTIONS_PREFIX, ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX)) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.prefixedOptions(Map.of(prefix, "1"), prefix));
+            assertTrue(ex.getMessage().contains("'" + prefix + "'"));
+            assertTrue(ex.getMessage().contains(prefix + "<key>"));
+        }
+    }
+
+    /** client-v2 strips its own prefixes and sends the rest verbatim, so a bare one would become an empty header or setting name. */
+    @Test void bareClientHeaderAndServerSettingPrefixesAreRejectedNamingTheOption() {
+        for (String prefix : List.of(ClientConfigProperties.HTTP_HEADER_PREFIX, ClientConfigProperties.SERVER_SETTING_PREFIX)) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client." + prefix, "1")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client." + prefix + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains(prefix + "<name>"), ex.getMessage());
+        }
+    }
+
+    /** Flink keeps option keys verbatim, so a padded key must not reach the client or server untrimmed. */
+    @Test void passthroughKeysAreTrimmed() {
+        assertEquals(Map.of("max_insert_block_size", "777777"),
+                ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        Map.of("clickhouse.server.max_insert_block_size ", "777777"),
+                        ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX));
+    }
+
+    /** Two keys differing only in whitespace would otherwise collapse in HashMap order, not DDL order. */
+    @Test void passthroughKeysCollidingAfterTrimAreRejected() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.prefixedOptions(
+                        Map.of("clickhouse.server.max_insert_block_size", "1000",
+                                "clickhouse.server.max_insert_block_size ", "777777"),
+                        ClickHouseConnectorOptions.SERVER_SETTINGS_PREFIX));
+        assertTrue(ex.getMessage().contains("clickhouse.server.max_insert_block_size"), ex.getMessage());
+    }
+
+    /** The AsyncSink re-checks these at task start; failing at planning names the SQL options. */
+    @Test void batchingOptionsMustBeMutuallyConsistent() {
+        ValidationException rows = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                        Configuration.fromMap(Map.of("sink.buffer-flush.max-rows", "10000"))));
+        assertEquals("'sink.max-buffered-requests' (10000) must be strictly greater than "
+                + "'sink.buffer-flush.max-rows' (10000).", rows.getMessage());
+        ValidationException buffered = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                        Configuration.fromMap(Map.of("sink.max-buffered-requests", "400"))));
+        assertEquals("'sink.max-buffered-requests' (400) must be strictly greater than "
+                + "'sink.buffer-flush.max-rows' (500).", buffered.getMessage());
+        ValidationException bytes = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                        Configuration.fromMap(Map.of("sink.buffer-flush.max-bytes", "512kb"))));
+        assertTrue(bytes.getMessage().contains("must be at least 'sink.record.max-bytes'"), bytes.getMessage());
+        ClickHouseDynamicTableSinkFactory.validateBatchingOptions(Configuration.fromMap(Map.of()));
+    }
+
+    /** Flink parses micros and nanos; a sub-millisecond interval must be rejected, not floored to 0 or 1 ms. */
+    @Test void flushIntervalMustBeWholeMilliseconds() {
+        for (String bad : List.of("0 ms", "500 micros", "1500 micros")) {
+            Configuration options = Configuration.fromMap(Map.of("sink.buffer-flush.interval", bad));
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.validateBatchingOptions(options));
+            assertTrue(ex.getMessage().contains("'sink.buffer-flush.interval'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("whole number of milliseconds"), ex.getMessage());
+        }
+        ClickHouseDynamicTableSinkFactory.validateBatchingOptions(
+                Configuration.fromMap(Map.of("sink.buffer-flush.interval", "2000 micros")));
+    }
+
+    /** These keys are set from the first-class options; a passthrough copy would override them silently. */
+    @Test void clientPassthroughRejectsKeysOwnedByFirstClassOptions() {
+        Map<String, String> firstClass = Map.of("database", "database", "user", "username", "password", "password");
+        firstClass.forEach((key, option) -> {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client." + key, "x")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client." + key + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("set '" + option + "' instead"), ex.getMessage());
+        });
+    }
+
+    /** The client sends database, user and password as its own headers; the header spelling replaces them and the server-setting spelling is ignored or rejected by the server, neither naming the option. */
+    @Test void connectionOptionsRespelledAsHeadersOrServerSettingsAreRejected() {
+        Map<String, String> settings = Map.of("database", "database", "user", "username", "password", "password");
+        settings.forEach((setting, option) -> {
+            ValidationException server = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.serverSettings(Map.of("clickhouse.server." + setting, "x")));
+            assertTrue(server.getMessage().contains("'clickhouse.server." + setting + "'"), server.getMessage());
+            assertTrue(server.getMessage().contains("set '" + option + "' instead"), server.getMessage());
+            ValidationException client = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.clickhouse_setting_" + setting, "x")));
+            assertTrue(client.getMessage().contains("'clickhouse.client.clickhouse_setting_" + setting + "'"), client.getMessage());
+            assertTrue(client.getMessage().contains("set '" + option + "' instead"), client.getMessage());
+        });
+        // Header names are case-insensitive on the wire, so every casing must be caught.
+        Map<String, String> headers = Map.of("X-ClickHouse-Database", "database", "x-clickhouse-user", "username", "X-CLICKHOUSE-KEY", "password");
+        headers.forEach((header, option) -> {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.http_header_" + header, "x")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client.http_header_" + header + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("set '" + option + "' instead"), ex.getMessage());
+        });
+        assertEquals(Map.of("http_header_X-Trace", "abc", "clickhouse_setting_max_threads", "2"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(Map.of(
+                        "clickhouse.client.http_header_X-Trace", "abc", "clickhouse.client.clickhouse_setting_max_threads", "2")));
+    }
+
+    /** client-v2 only WARN-logs unknown keys, so a typo would be accepted at planning and ignored at runtime. */
+    @Test void clientPassthroughRejectsUnknownKeysListingTheSupportedOnes() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.connect_timeout", "1000")));
+        assertTrue(ex.getMessage().contains("'clickhouse.client.connect_timeout'"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("connection_timeout"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("http_header_"), ex.getMessage());
+    }
+
+    /** Client.Builder.build() parses values eagerly, which would report a typo as a schema failure. */
+    @Test void clientPassthroughRejectsUnparsableValuesNamingTheOption() {
+        for (String key : List.of("connection_timeout", "retry")) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client." + key, "abc")));
+            assertTrue(ex.getMessage().contains("'clickhouse.client." + key + "'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("'abc'"), ex.getMessage());
+        }
+    }
+
+    @Test void clientPassthroughAcceptsClientKeysHeadersAndServerSettings() {
+        Map<String, String> tableOptions = Map.of(
+                "connector", "clickhouse",
+                "clickhouse.client.connection_timeout", "1000",
+                "clickhouse.client.http_header_X-Trace", "abc",
+                "clickhouse.client.clickhouse_setting_max_threads", "2",
+                "clickhouse.server.async_insert", "1");
+        assertEquals(
+                Map.of("connection_timeout", "1000", "http_header_X-Trace", "abc", "clickhouse_setting_max_threads", "2"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(tableOptions));
+    }
+
+    /** client-v2 wraps every failed DESCRIBE in a constant message; the server's reason must surface. */
+    @Test void introspectionErrorsSurfaceTheServerReason() {
+        ServerException server = new ServerException(60,
+                "Code: 60. DB::Exception: Table db.evnts does not exist. (UNKNOWN_TABLE)");
+        assertEquals(server.getMessage(), ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Failed to get table schema", server)));
+        assertEquals("Connection refused", ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Failed to get table schema",
+                        new ClientException("Failed to connect", new ConnectException("Connection refused")))));
+        assertEquals("plain", ClickHouseDynamicTableSinkFactory.rootMessage(new RuntimeException("plain")));
+        // The wrapper says what was interrupted; the JDK's "sleep interrupted" does not.
+        assertEquals("Failed to get table schema", ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Failed to get table schema", new InterruptedException("sleep interrupted"))));
+    }
+
+    /** client-v2 reports a DESCRIBE timeout as a message-less TimeoutException under a wrapper that names the limit. */
+    @Test void introspectionTimeoutKeepsTheWrapperMessage() {
+        assertEquals("Operation has likely timed out after 5 seconds.", ClickHouseDynamicTableSinkFactory.rootMessage(
+                new ClientException("Operation has likely timed out after 5 seconds.", new TimeoutException())));
+    }
+
+    /** client-v2 parses the endpoint only when the client is built, which would report a typo or a missing port as a schema failure. */
+    @Test void urlIsValidatedBeforeAnyNetworkCall() {
+        ClickHouseDynamicTableSinkFactory.validateUrl("http://localhost:8123");
+        ClickHouseDynamicTableSinkFactory.validateUrl("HTTPS://my_host.example:8443/");
+        for (String bad : List.of("localhost:8123", "ftp://host:8123", "http://", "http:/host",
+                "http://localhost", "http://host:99999", "http://:8123")) {
+            ValidationException ex = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.validateUrl(bad));
+            assertTrue(ex.getMessage().contains("'url'"), ex.getMessage());
+            assertTrue(ex.getMessage().contains("'" + bad + "'"), ex.getMessage());
+        }
+    }
+
+    /** The planning DESCRIBE needs canonical type names; a user copy of that setting in either spelling would fight it. */
+    @Test void printPrettyTypeNamesIsReservedForPlanning() {
+        assertEquals(Map.of("async_insert", "1"),
+                ClickHouseDynamicTableSinkFactory.serverSettings(
+                        Map.of("connector", "clickhouse", "clickhouse.server.async_insert", "1")));
+        ValidationException server = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.serverSettings(
+                        Map.of("clickhouse.server.print_pretty_type_names", "1")));
+        assertTrue(server.getMessage().contains("'clickhouse.server.print_pretty_type_names'"), server.getMessage());
+        ValidationException client = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.clientOptions(
+                        Map.of("clickhouse.client.clickhouse_setting_print_pretty_type_names", "1")));
+        assertTrue(client.getMessage().contains("'clickhouse.client.clickhouse_setting_print_pretty_type_names'"),
+                client.getMessage());
+    }
+
+    /** Client.Builder.build() checks option combinations parseConfigMap cannot see; they must read as option errors, not schema failures. */
+    @Test void clientOptionCombinationsTheBuilderRejectsAreReportedAsOptionErrors() {
+        // The key and value pass the per-option pre-validation on their own …
+        assertEquals(Map.of("use_time_zone", "Asia/Tokyo"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.use_time_zone", "Asia/Tokyo")));
+        // … and only Client.Builder.build() rejects them against the default use_server_time_zone=true, before any I/O.
+        ValidationException ex = assertThrows(ValidationException.class, () -> ClickHouseDynamicTableSinkFactory.introspect(
+                planningOptions("http://localhost:1"), planningConfig("http://localhost:1", Map.of("use_time_zone", "Asia/Tokyo"))));
+        assertTrue(ex.getMessage().contains("'clickhouse.client.*'"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("USE_TIME_ZONE"), ex.getMessage());
+        assertFalse(ex.getMessage().contains("Could not read the schema"), ex.getMessage());
+    }
+
+    /** Single values only the built client rejects: a TimeZone-typed value parseConfigMap turns into GMT, and an SSL file the client cannot open (a ClientMisconfigurationException, not an IllegalArgumentException). */
+    @Test void clientOptionValuesOnlyTheBuiltClientRejectsAreReportedAsOptionErrors() {
+        assertEquals(Map.of("server_time_zone", "Mars/Olympus_Mons"),
+                ClickHouseDynamicTableSinkFactory.clientOptions(Map.of("clickhouse.client.server_time_zone", "Mars/Olympus_Mons")));
+        ValidationException zone = assertThrows(ValidationException.class, () -> ClickHouseDynamicTableSinkFactory.introspect(
+                planningOptions("http://localhost:1"), planningConfig("http://localhost:1", Map.of("server_time_zone", "Mars/Olympus_Mons"))));
+        assertTrue(zone.getMessage().contains("'clickhouse.client.*'"), zone.getMessage());
+        assertTrue(zone.getMessage().contains("Mars/Olympus_Mons"), zone.getMessage());
+        assertFalse(zone.getMessage().contains("Could not read the schema"), zone.getMessage());
+
+        // An https endpoint builds the SSL context inside build(), before any request is made.
+        ValidationException ssl = assertThrows(ValidationException.class, () -> ClickHouseDynamicTableSinkFactory.introspect(
+                planningOptions("https://localhost:1"), planningConfig("https://localhost:1", Map.of("sslrootcert", "/nonexistent/ca.pem"))));
+        assertTrue(ssl.getMessage().contains("'clickhouse.client.*'"), ssl.getMessage());
+        assertTrue(ssl.getMessage().contains("SSL context"), ssl.getMessage());
+        assertTrue(ssl.getMessage().contains("/nonexistent/ca.pem"), ssl.getMessage());
+        assertFalse(ssl.getMessage().contains("Could not read the schema"), ssl.getMessage());
+    }
+
+    /** ClickHouseAsyncWriter pins these on every insert and client-v2 lets operation settings win, so a user copy would be discarded silently. */
+    @Test void serverSettingsTheWriterPinsPerInsertAreRejectedInEitherSpelling() {
+        for (String setting : ClickHouseDynamicTableSinkFactory.INSERT_SERVER_SETTINGS) {
+            ValidationException server = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.serverSettings(Map.of("clickhouse.server." + setting, "0")));
+            assertTrue(server.getMessage().contains("'clickhouse.server." + setting + "'"), server.getMessage());
+            assertTrue(server.getMessage().contains("every insert"), server.getMessage());
+            ValidationException client = assertThrows(ValidationException.class,
+                    () -> ClickHouseDynamicTableSinkFactory.clientOptions(
+                            Map.of("clickhouse.client.clickhouse_setting_" + setting, "0")));
+            assertTrue(client.getMessage().contains("'clickhouse.client.clickhouse_setting_" + setting + "'"), client.getMessage());
+        }
+        assertEquals(List.of("input_format_binary_read_json_as_string", "input_format_defaults_for_omitted_fields",
+                        "input_format_null_as_default"),
+                ClickHouseDynamicTableSinkFactory.INSERT_SERVER_SETTINGS.stream().sorted().collect(java.util.stream.Collectors.toList()));
+    }
+
+    private static Configuration planningOptions(String url) {
+        return Configuration.fromMap(Map.of("url", url, "database", "db", "table", "t"));
+    }
+
+    /** Port 1: nothing here reaches the network. */
+    private static ClickHouseClientConfig planningConfig(String url, Map<String, String> clientOptions) {
+        return new ClickHouseClientConfig(url, "u", "", "db", "t", clientOptions, Map.of(), false);
+    }
+
+    /** clickhouse.server.<k> and clickhouse.client.clickhouse_setting_<k> land on one builder key; the pair must not collapse silently. */
+    @Test void serverSettingDefinedThroughBothPrefixesIsRejected() {
+        ValidationException ex = assertThrows(ValidationException.class,
+                () -> ClickHouseDynamicTableSinkFactory.checkServerSettingDefinedOnce(
+                        Map.of("clickhouse_setting_async_insert", "0"), Map.of("async_insert", "1")));
+        assertTrue(ex.getMessage().contains("'clickhouse.client.clickhouse_setting_async_insert'"), ex.getMessage());
+        assertTrue(ex.getMessage().contains("'clickhouse.server.async_insert'"), ex.getMessage());
+        ClickHouseDynamicTableSinkFactory.checkServerSettingDefinedOnce(
+                Map.of("clickhouse_setting_max_threads", "2", "socket_timeout", "1000"), Map.of("async_insert", "1"));
+    }
+}

--- a/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkTest.java
+++ b/flink-connector-clickhouse-2.0.0/src/test/java/org/apache/flink/connector/clickhouse/table/ClickHouseDynamicTableSinkTest.java
@@ -1,0 +1,64 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseColumn;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseClientConfig;
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolver;
+import org.apache.flink.connector.clickhouse.table.schema.SchemaResolverOptions;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.ChangelogMode;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.time.ZoneId;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+
+class ClickHouseDynamicTableSinkTest {
+
+    /** Built the way the factory builds it, minus the network. */
+    private static ClickHouseDynamicTableSink sink() {
+        ClickHouseClientConfig config = new ClickHouseClientConfig("http://localhost:1", "u", "", "db", "t",
+                Map.of(), Map.of(), false);
+        RowDataDataMapper mapper = RowDataDataMapper.of(SchemaResolver.resolve(
+                ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT().notNull())),
+                new TableSchema(ClickHouseColumn.parse("id Int64")),
+                new SchemaResolverOptions("db", "t", ZoneId.of("UTC"), false)));
+        return new ClickHouseDynamicTableSink(config, mapper, Configuration.fromMap(Map.of("database", "db", "table", "t")));
+    }
+
+    /** The planner copies the sink per INSERT of a statement set; the copies must not share the config. */
+    @Test void copyIsADistinctSinkWithItsOwnClientConfig() throws Exception {
+        ClickHouseDynamicTableSink original = sink();
+        DynamicTableSink copy = original.copy();
+
+        assertNotSame(original, copy);
+        assertEquals(original.asSummaryString(), copy.asSummaryString());
+        configOf(copy).setEnableJsonSupportAsString(true);
+        assertFalse(configOf(original).getEnableJsonSupportAsString());
+    }
+
+    @Test void summaryNamesTheTargetTable() {
+        assertEquals("ClickHouse[db.t]", sink().asSummaryString());
+    }
+
+    @Test void changelogModeIsInsertOnlyWhateverThePlannerRequests() {
+        assertEquals(ChangelogMode.insertOnly(), sink().getChangelogMode(ChangelogMode.all()));
+        assertEquals(ChangelogMode.insertOnly(), sink().getChangelogMode(ChangelogMode.upsert()));
+    }
+
+    private static ClickHouseClientConfig configOf(DynamicTableSink sink) throws Exception {
+        Field field = ClickHouseDynamicTableSink.class.getDeclaredField("clientConfig");
+        field.setAccessible(true);
+        return (ClickHouseClientConfig) field.get(sink);
+    }
+}

--- a/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
+++ b/flink-connector-clickhouse-base/src/main/java/com/clickhouse/utils/writer/DataWriter.java
@@ -232,17 +232,21 @@ public class DataWriter {
         }
     }
 
+    /** SimpleAggregateFunction(f, T) is wire-encoded as its inner type T */
+    public static ClickHouseColumn unwrapSimpleAggregateFunction(ClickHouseColumn column) {
+        ClickHouseColumn c = column;
+        while (c.getDataType() == ClickHouseDataType.SimpleAggregateFunction && c.hasNestedColumn()) {
+            c = c.getNestedColumns().get(0);
+        }
+        return c;
+    }
+
     /**
      * Generic dispatcher: routes a Map value to the right typed writer based on
      * {@code column.getDataType()}. Per design spec §8a.
      */
     public void writeValue(Object value, ClickHouseColumn column) throws IOException {
-        // SimpleAggregateFunction(f, T) is wire-encoded identically to its inner type T; recurse on the nested column. See issue #143.
-        if (column.getDataType() == ClickHouseDataType.SimpleAggregateFunction) {
-            // A valid SimpleAggregateFunction has exactly one storage type (ClickHouse rejects more), so nested holds that single inner type.
-            writeValue(value, column.getNestedColumns().get(0));
-            return;
-        }
+        column = unwrapSimpleAggregateFunction(column);
 
         ClickHouseDataType type = column.getDataType();
         boolean nullable = column.isNullable();
@@ -276,8 +280,9 @@ public class DataWriter {
                              column.getPrecision(), column.getScale());
                 break;
             case String:      writeString     ((java.lang.String) value, nullable, type, name); break;
+            // getEstimatedLength() is 1 for Nullable(FixedString(n)); only getPrecision() carries n.
             case FixedString: writeFixedString((java.lang.String) value, nullable, type, name,
-                                               column.getEstimatedLength()); break;
+                                               column.getPrecision()); break;
             case JSON:        writeJSON       ((java.lang.String) value, nullable, type, name); break;
             case UUID:        writeUUID       ((UUID) value, nullable, type, name); break;
             case Date:

--- a/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/data/TypeTags.java
+++ b/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/data/TypeTags.java
@@ -5,6 +5,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -19,6 +20,13 @@ import java.util.UUID;
  * Tag-and-payload serialization for {@code Map<String, Object>} values used
  * inside {@link ClickHousePayload#getData()}. Tag values are documented in
  * the design spec §10c and must remain stable across releases.
+ *
+ * <p>Internal to the connector's checkpoint state serializer — public only so the version
+ * modules can reach it; not a supported API and free to change between releases.
+ *
+ * <p>Strings and map keys are int-length-prefixed UTF-8 (serializer entry marker V3+),
+ * so they are not capped at writeUTF's 64 KB; {@link #read(DataInputStream, int)} with
+ * {@link #V2} decodes the older writeUTF form. Zone IDs are bounded and stay writeUTF in both.
  */
 public final class TypeTags {
 
@@ -42,6 +50,14 @@ public final class TypeTags {
     static final byte MAP = 17;
     static final byte TUPLE = 18;
 
+    /** Entry format whose strings and map keys are writeUTF-encoded (capped at 64 KB). */
+    public static final int V2 = 2;
+    /** Current entry format: strings and map keys are int-length-prefixed UTF-8, unbounded. */
+    public static final int V3 = 3;
+
+    /** Corruption guard for length-prefixed string reads; matches the BYTES bound. */
+    private static final int MAX_STRING_BYTES = 256 * 1024 * 1024;
+
     private TypeTags() {}
 
     /** Writes one tagged value. Throws IOException with a clear key-naming hint if type isn't supported. */
@@ -64,7 +80,7 @@ public final class TypeTags {
             out.writeByte(BIG_DEC); out.writeInt(d.scale());
             out.writeInt(b.length); out.write(b); return;
         }
-        if (value instanceof String)         { out.writeByte(STRING);  out.writeUTF((String) value); return; }
+        if (value instanceof String)         { out.writeByte(STRING);  writeUtf8((String) value, out); return; }
         if (value instanceof byte[]) {
             byte[] b = (byte[]) value;
             out.writeByte(BYTES); out.writeInt(b.length); out.write(b); return;
@@ -105,7 +121,7 @@ public final class TypeTags {
             for (Map.Entry<?, ?> e : map.entrySet()) {
                 if (!(e.getKey() instanceof String))
                     throw new IOException("Map keys must be String, got: " + e.getKey().getClass());
-                out.writeUTF((String) e.getKey()); write(e.getValue(), out);
+                writeUtf8((String) e.getKey(), out); write(e.getValue(), out);
             } return;
         }
         if (value instanceof Object[]) {
@@ -117,8 +133,30 @@ public final class TypeTags {
             + " (allowed types: see design spec §7)");
     }
 
-    /** Reads one tagged value. */
-    public static Object read(DataInputStream in) throws IOException {
+    /** Unbounded UTF-8 with an int length prefix — writeUTF would cap it at 64 KB. */
+    public static void writeUtf8(String s, DataOutputStream out) throws IOException {
+        byte[] b = s.getBytes(StandardCharsets.UTF_8);
+        out.writeInt(b.length); out.write(b);
+    }
+
+    /** A string or map key: int-length-prefixed UTF-8 from {@link #V3}, {@code writeUTF} before. */
+    public static String readString(DataInputStream in, int entryVersion) throws IOException {
+        return entryVersion >= V3 ? readUtf8(in) : in.readUTF();
+    }
+
+    private static String readUtf8(DataInputStream in) throws IOException {
+        int len = in.readInt();
+        if (len < 0 || len > MAX_STRING_BYTES) throw new IOException("Implausible string length: " + len);
+        byte[] b = new byte[len];
+        in.readFully(b);
+        return new String(b, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Reads one tagged value written under the given entry format ({@link #V2} or
+     * {@link #V3}). V1 entries are raw bytes and never contain tagged values.
+     */
+    public static Object read(DataInputStream in, int entryVersion) throws IOException {
         byte tag = in.readByte();
         switch (tag) {
             case NULL:   return null;
@@ -144,7 +182,7 @@ public final class TypeTags {
                 in.readFully(b);
                 return new BigDecimal(new BigInteger(b), scale);
             }
-            case STRING: return in.readUTF();
+            case STRING: return readString(in, entryVersion);
             case BYTES: {
                 int len = in.readInt();
                 if (len < 0 || len > 256 * 1024 * 1024) throw new IOException("Implausible BYTES length: " + len);
@@ -166,21 +204,21 @@ public final class TypeTags {
                 int n = in.readInt();
                 if (n < 0 || n > 1_000_000) throw new IOException("Implausible LIST size: " + n);
                 List<Object> list = new ArrayList<>(n);
-                for (int i = 0; i < n; i++) list.add(read(in));
+                for (int i = 0; i < n; i++) list.add(read(in, entryVersion));
                 return list;
             }
             case MAP: {
                 int n = in.readInt();
                 if (n < 0 || n > 1_000_000) throw new IOException("Implausible MAP size: " + n);
                 Map<String, Object> m = new LinkedHashMap<>(n);
-                for (int i = 0; i < n; i++) m.put(in.readUTF(), read(in));
+                for (int i = 0; i < n; i++) m.put(readString(in, entryVersion), read(in, entryVersion));
                 return m;
             }
             case TUPLE: {
                 int n = in.readInt();
                 if (n < 0 || n > 1_000_000) throw new IOException("Implausible TUPLE size: " + n);
                 Object[] arr = new Object[n];
-                for (int i = 0; i < n; i++) arr[i] = read(in);
+                for (int i = 0; i < n; i++) arr[i] = read(in, entryVersion);
                 return arr;
             }
             default: throw new IOException("Unknown type tag: " + tag);

--- a/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkDefaults.java
+++ b/flink-connector-clickhouse-base/src/main/java/org/apache/flink/connector/clickhouse/sink/ClickHouseSinkDefaults.java
@@ -1,0 +1,14 @@
+package org.apache.flink.connector.clickhouse.sink;
+
+/** Batching/backpressure defaults shared by ClickHouseAsyncSinkBuilder and the SQL connector options. */
+public final class ClickHouseSinkDefaults {
+
+    public static final int MAX_BATCH_SIZE = 500;
+    public static final int MAX_IN_FLIGHT_REQUESTS = 50;
+    public static final int MAX_BUFFERED_REQUESTS = 10_000;
+    public static final long MAX_BATCH_SIZE_IN_BYTES = 5L * 1024 * 1024;
+    public static final long MAX_TIME_IN_BUFFER_MS = 5_000;
+    public static final long MAX_RECORD_SIZE_IN_BYTES = 1L * 1024 * 1024;
+
+    private ClickHouseSinkDefaults() {}
+}

--- a/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/com/clickhouse/utils/writer/DataWriterDispatchTest.java
@@ -73,6 +73,12 @@ class DataWriterDispatchTest {
         assertTrue(r.length >= 5);
     }
 
+    @Test void dispatchNullableFixedStringWritesFullWidth() throws IOException {
+        // Sizing must come from getPrecision(): getEstimatedLength() is 1 for Nullable(FixedString(n)).
+        byte[] r = serialize("12345", ClickHouseColumn.of("c", "Nullable(FixedString(5))"));
+        assertArrayEquals(new byte[]{0, '1', '2', '3', '4', '5'}, r);
+    }
+
     @Test void dispatchUUID() throws IOException {
         byte[] r = serialize(UUID.randomUUID(), ClickHouseColumn.of("c", "UUID"));
         assertTrue(r.length >= 16);
@@ -98,6 +104,18 @@ class DataWriterDispatchTest {
                 ClickHouseColumn.of("", "String"));
         byte[] r = serialize(Arrays.asList("a", "b"), col);
         assertTrue(r.length > 0);
+    }
+
+    // Object[] is the tuple shape the Table API mapper produces (toPayloadTuple).
+    @Test void dispatchTupleFromObjectArray() throws IOException {
+        byte[] r = serialize(new Object[]{42, "ab"}, ClickHouseColumn.of("c", "Tuple(Int32, String)"));
+        assertArrayEquals(new byte[]{42, 0, 0, 0, 2, 'a', 'b'}, r);
+    }
+
+    @Test void dispatchArrayNullableElementWritesNullMarker() throws IOException {
+        byte[] r = serialize(Arrays.asList(7, null), ClickHouseColumn.of("c", "Array(Nullable(Int32))"));
+        // varint count, then per element: null marker byte (+ value when non-null).
+        assertArrayEquals(new byte[]{2, 0, 7, 0, 0, 0, 1}, r);
     }
 
     @Test void dispatchBoolean() throws IOException {

--- a/flink-connector-clickhouse-base/src/test/java/org/apache/flink/connector/clickhouse/data/TypeTagsTest.java
+++ b/flink-connector-clickhouse-base/src/test/java/org/apache/flink/connector/clickhouse/data/TypeTagsTest.java
@@ -33,7 +33,7 @@ class TypeTagsTest {
             TypeTags.write(value, out);
         }
         try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
-            return TypeTags.read(in);
+            return TypeTags.read(in, TypeTags.V3);
         }
     }
 
@@ -109,6 +109,39 @@ class TypeTagsTest {
         Map<String, Object> outer = new LinkedHashMap<>();
         outer.put("nested", inner);
         assertEquals(outer, roundTrip(outer));
+    }
+
+    @Test void stringAboveWriteUtfLimitRoundTrips() throws IOException {
+        String v = "é🌍".repeat(15_000) + "tail"; // ~90k UTF-8 bytes, well past writeUTF's 64 KB cap
+        assertEquals(v, roundTrip(v));
+    }
+
+    @Test void mapKeyAboveWriteUtfLimitRoundTrips() throws IOException {
+        Map<String, Object> v = new LinkedHashMap<>();
+        v.put("k".repeat(70_000), "value");
+        assertEquals(v, roundTrip(v));
+    }
+
+    /** Pins the V3 string byte format: tag, int length, UTF-8 bytes. */
+    @Test void stringByteFormat() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(baos)) {
+            TypeTags.write("abc", out);
+        }
+        assertArrayEquals(new byte[]{TypeTags.STRING, 0, 0, 0, 3, 'a', 'b', 'c'}, baos.toByteArray());
+    }
+
+    /** V2 entries (writeUTF strings and map keys) must keep decoding for checkpoint restores. */
+    @Test void readV2DecodesWriteUtfStringsAndMapKeys() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(baos)) {
+            out.writeByte(TypeTags.MAP); out.writeInt(2);
+            out.writeUTF("num"); out.writeByte(TypeTags.INT); out.writeInt(42);
+            out.writeUTF("str"); out.writeByte(TypeTags.STRING); out.writeUTF("hello");
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(baos.toByteArray()))) {
+            assertEquals(Map.of("num", 42, "str", "hello"), TypeTags.read(in, TypeTags.V2));
+        }
     }
 
     @Test void unsupportedTypeFailsClearly() {

--- a/flink-connector-clickhouse-table/build.gradle.kts
+++ b/flink-connector-clickhouse-table/build.gradle.kts
@@ -1,0 +1,45 @@
+/*
+ * Build file of the flink-connector-clickhouse-table submodule.
+ *
+ * Version-independent Table API / SQL support: connector options, the
+ * (Flink LogicalType, ClickHouseColumn) type matrix, schema resolution and the
+ * RowData -> Map DataMapper.
+ *
+ * Owns the source but does not ship it: each version module adds src/main/java to its
+ * own sourceSet and compiles it against its own Flink. The compile here is the floor
+ * check against the oldest supported flink-table-common; the version modules' compile
+ * tasks depend on it, so every CI and publish path runs it.
+ */
+
+// No publishing/signing plugins: this module ships no artifact (see header).
+plugins {
+    java
+}
+
+val clickhouseVersion: String by rootProject.extra
+
+// Pinned on purpose: this is the floor of the supported range. The version modules
+// cross-compile the same source against their own Flink.
+val flinkTableCommonVersion = "1.17.2"
+
+dependencies {
+    api(project(":flink-connector-clickhouse-base"))
+
+    // ClickHouseColumn & co. — the base module does not export them.
+    // Exclude the client's external lz4: the ':all' jar embeds it, and from client 0.10 the
+    // at.yawk.lz4 fork capability-clashes with Flink's org.lz4:lz4-java (#160).
+    implementation("com.clickhouse:client-v2:${clickhouseVersion}:all") {
+        exclude(group = "org.lz4", module = "lz4-java")
+        exclude(group = "at.yawk.lz4", module = "lz4-java")
+    }
+
+    // Provided by the Flink distribution at runtime — never bundled.
+    compileOnly("org.apache.flink:flink-table-common:$flinkTableCommonVersion")
+
+    testImplementation("org.apache.flink:flink-table-common:$flinkTableCommonVersion")
+}
+
+// Compile floor check only — the version modules execute these same tests against their own Flink.
+tasks.test {
+    enabled = false
+}

--- a/flink-connector-clickhouse-table/src/integrationTest/java/org/apache/flink/connector/clickhouse/table/ClickHouseTableApiIntegrationTests.java
+++ b/flink-connector-clickhouse-table/src/integrationTest/java/org/apache/flink/connector/clickhouse/table/ClickHouseTableApiIntegrationTests.java
@@ -1,0 +1,1404 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.ServerException;
+import com.clickhouse.client.api.query.GenericRecord;
+
+import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseServerForTests;
+import org.apache.flink.connector.test.embedded.clickhouse.ClickHouseTestHelpers;
+import org.apache.flink.core.execution.JobClient;
+import org.apache.flink.table.api.EnvironmentSettings;
+import org.apache.flink.table.api.TableEnvironment;
+import org.apache.flink.util.ExceptionUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Locale;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** End-to-end Flink SQL round trips against a real ClickHouse, plus a planning-time rejection. */
+public class ClickHouseTableApiIntegrationTests {
+
+    @BeforeAll
+    public static void setUp() throws Exception {
+        ClickHouseServerForTests.setUp();
+    }
+
+    @AfterAll
+    public static void tearDown() {
+        ClickHouseServerForTests.tearDown();
+    }
+
+    private static TableEnvironment tableEnvironment() {
+        return TableEnvironment.create(EnvironmentSettings.inStreamingMode());
+    }
+
+    /** One subtask everywhere the DDL does not say otherwise, so INSERT counts are deterministic. */
+    private static TableEnvironment singleParallelismEnvironment() {
+        TableEnvironment env = tableEnvironment();
+        env.getConfig().set("table.exec.resource.default-parallelism", "1");
+        return env;
+    }
+
+    private static String valuesList(int rows) {
+        return IntStream.rangeClosed(1, rows).mapToObj(i -> "(" + i + ")").collect(Collectors.joining(", "));
+    }
+
+    /** {@code parsed} is omitted by the Flink schema, so the server evaluates its DEFAULT per row. */
+    private static void createTableWithParsedDefault(String table) throws Exception {
+        createTable(table, "id Int64, src String, parsed Int32 DEFAULT toInt32(src)");
+    }
+
+    private static String sinkDdl(String flinkTable, String clickHouseTable, String columns) {
+        return sinkDdl(flinkTable, clickHouseTable, columns, "");
+    }
+
+    private static String sinkDdl(String flinkTable, String clickHouseTable, String columns,
+                                  String extraOptions) {
+        return String.format(
+                "CREATE TABLE %s (%s) WITH ("
+                        + "'connector' = 'clickhouse',"
+                        + "'url' = '%s',"
+                        + "'username' = '%s',"
+                        + "'password' = '%s',"
+                        + "'database' = '%s',"
+                        + "'table' = '%s'%s)",
+                flinkTable, columns,
+                ClickHouseServerForTests.getURL(),
+                ClickHouseServerForTests.getUsername(),
+                ClickHouseServerForTests.getPassword(),
+                ClickHouseServerForTests.getDatabase(),
+                clickHouseTable, extraOptions);
+    }
+
+    /** {@code CREATE TABLE} in the test database; the default engine clause is {@code MergeTree() ORDER BY id}. */
+    private static void createTable(String table, String columns) throws Exception {
+        createTable(table, columns, "MergeTree() ORDER BY id");
+    }
+
+    private static void createTable(String table, String columns, String engineClause) throws Exception {
+        ClickHouseServerForTests.executeSql(String.format("CREATE TABLE `%s`.`%s` (%s) ENGINE = %s",
+                ClickHouseServerForTests.getDatabase(), table, columns, engineClause));
+    }
+
+    /** Asserts the call fails with every needle somewhere in the exception chain; returns the exception. */
+    private static Exception assertFailsWith(Executable call, String... needles) {
+        Exception e = Assertions.assertThrows(Exception.class, call);
+        for (String needle : needles) {
+            Assertions.assertTrue(exceptionChainContains(e, needle), "Unexpected failure: " + e);
+        }
+        return e;
+    }
+
+    @Test
+    void sqlInsertRoundTripsThroughClickHouse() throws Exception {
+        String table = "table_api_events";
+        createTable(table,
+                "id Int64, name String, amount Decimal(18, 4), created_at DateTime64(3), uid UUID, "
+                        + "event_day Date, is_active Bool, score Float64, tags Array(String), "
+                        + "props Map(String, String), category LowCardinality(String), code FixedString(4)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_events", table,
+                "id BIGINT NOT NULL,"
+                        + "name STRING NOT NULL,"
+                        + "amount DECIMAL(18, 4) NOT NULL,"
+                        + "created_at TIMESTAMP(3) NOT NULL,"
+                        + "uid STRING NOT NULL,"
+                        + "event_day DATE NOT NULL,"
+                        + "is_active BOOLEAN NOT NULL,"
+                        + "score DOUBLE NOT NULL,"
+                        + "tags ARRAY<STRING NOT NULL> NOT NULL,"
+                        + "props MAP<STRING, STRING NOT NULL> NOT NULL,"
+                        + "category STRING NOT NULL,"
+                        + "code STRING NOT NULL"));
+
+        String insert = "INSERT INTO ch_events VALUES "
+                + "(1, 'alice', CAST(12.5 AS DECIMAL(18, 4)), TIMESTAMP '2026-01-02 03:04:05.678', "
+                + "'f47ac10b-58cc-4372-a567-0e02b2c3d479', DATE '2026-01-02', true, 99.25, "
+                + "ARRAY['a', 'b'], MAP['k1', 'v1'], 'gold', 'AB12'), "
+                + "(2, 'bob', CAST(7 AS DECIMAL(18, 4)), TIMESTAMP '2026-01-02 03:04:06', "
+                + "'123e4567-e89b-12d3-a456-426614174000', DATE '1970-01-01', false, -1.5, "
+                + "ARRAY['x'], MAP['k2', 'v2'], 'silver', 'ZZ99')";
+
+        // EXPLAIN re-invokes the factory; the INSERT below plans again and re-introspects.
+        Assertions.assertFalse(env.explainSql(insert).isEmpty());
+        env.executeSql(insert).await();
+
+        List<GenericRecord> rows = readBack(
+                "id, name, amount, toString(created_at) AS created_at_s, toString(uid) AS uid_s, "
+                        + "toString(event_day) AS day_s, is_active, score, toString(tags) AS tags_s, "
+                        + "toString(props) AS props_s, category, toString(code) AS code_s",
+                table, "id", 2);
+
+        Assertions.assertEquals(2, rows.size());
+        GenericRecord first = rows.get(0);
+        Assertions.assertEquals(1L, first.getLong("id"));
+        Assertions.assertEquals("alice", first.getString("name"));
+        Assertions.assertEquals(0, new BigDecimal("12.5").compareTo(first.getBigDecimal("amount")));
+        Assertions.assertEquals("2026-01-02 03:04:05.678", first.getString("created_at_s"));
+        Assertions.assertEquals("f47ac10b-58cc-4372-a567-0e02b2c3d479", first.getString("uid_s"));
+        Assertions.assertEquals("2026-01-02", first.getString("day_s"));
+        Assertions.assertTrue(first.getBoolean("is_active"));
+        Assertions.assertEquals(99.25, first.getDouble("score"));
+        Assertions.assertEquals("['a','b']", first.getString("tags_s"));
+        Assertions.assertEquals("{'k1':'v1'}", first.getString("props_s"));
+        Assertions.assertEquals("gold", first.getString("category"));
+        Assertions.assertEquals("AB12", first.getString("code_s"));
+
+        GenericRecord second = rows.get(1);
+        Assertions.assertEquals(2L, second.getLong("id"));
+        Assertions.assertEquals("2026-01-02 03:04:06.000", second.getString("created_at_s"));
+        Assertions.assertEquals("1970-01-01", second.getString("day_s"));
+        Assertions.assertFalse(second.getBoolean("is_active"));
+        Assertions.assertEquals("['x']", second.getString("tags_s"));
+        Assertions.assertEquals("silver", second.getString("category"));
+        Assertions.assertEquals("ZZ99", second.getString("code_s"));
+    }
+
+    /**
+     * One column per writable scalar type, two rows holding each column's bounds: the converter,
+     * the writer's wire encoding and the server must agree at the extremes. Values are read back
+     * as ClickHouse prints them, so the expectations are the server's own rendering.
+     */
+    @Test
+    void everyScalarColumnTypeRoundTripsAtItsBounds() throws Exception {
+        String[][] columns = {
+                // ClickHouse type   Flink type         low (Flink SQL)                                                       printed                                    high (Flink SQL)                                                     printed
+                {"Bool",             "BOOLEAN",         "false",                                                              "false",                                   "true",                                                              "true"},
+                {"Int8",             "TINYINT",         "CAST(-128 AS TINYINT)",                                              "-128",                                    "CAST(127 AS TINYINT)",                                              "127"},
+                {"Int16",            "SMALLINT",        "CAST(-32768 AS SMALLINT)",                                           "-32768",                                  "CAST(32767 AS SMALLINT)",                                           "32767"},
+                {"Int32",            "INT",             "CAST(-2147483648 AS INT)",                                           "-2147483648",                             "CAST(2147483647 AS INT)",                                           "2147483647"},
+                {"Int64",            "BIGINT",          "CAST('-9223372036854775808' AS BIGINT)",                             "-9223372036854775808",                    "CAST('9223372036854775807' AS BIGINT)",                             "9223372036854775807"},
+                {"Int128",           "DECIMAL(38, 0)",  "CAST('-99999999999999999999999999999999999999' AS DECIMAL(38, 0))", "-99999999999999999999999999999999999999", "CAST('99999999999999999999999999999999999999' AS DECIMAL(38, 0))", "99999999999999999999999999999999999999"},
+                {"Int256",           "DECIMAL(38, 0)",  "CAST('-99999999999999999999999999999999999999' AS DECIMAL(38, 0))", "-99999999999999999999999999999999999999", "CAST('99999999999999999999999999999999999999' AS DECIMAL(38, 0))", "99999999999999999999999999999999999999"},
+                {"UInt8",            "SMALLINT",        "CAST(0 AS SMALLINT)",                                                "0",                                       "CAST(255 AS SMALLINT)",                                             "255"},
+                {"UInt16",           "INT",             "0",                                                                  "0",                                       "65535",                                                             "65535"},
+                {"UInt32",           "BIGINT",          "CAST(0 AS BIGINT)",                                                  "0",                                       "CAST(4294967295 AS BIGINT)",                                        "4294967295"},
+                {"UInt64",           "DECIMAL(20, 0)",  "CAST(0 AS DECIMAL(20, 0))",                                          "0",                                       "CAST('18446744073709551615' AS DECIMAL(20, 0))",                    "18446744073709551615"},
+                {"UInt128",          "DECIMAL(38, 0)",  "CAST(0 AS DECIMAL(38, 0))",                                          "0",                                       "CAST('99999999999999999999999999999999999999' AS DECIMAL(38, 0))",  "99999999999999999999999999999999999999"},
+                {"UInt256",          "DECIMAL(38, 0)",  "CAST(0 AS DECIMAL(38, 0))",                                          "0",                                       "CAST('99999999999999999999999999999999999999' AS DECIMAL(38, 0))",  "99999999999999999999999999999999999999"},
+                // Flink folds FLOAT literals to 7 significant digits, so the bound is stated that way (two ULPs below
+                // Float32's max); read back widened to Float64, since toString(Float32) rounds to 7 digits as well
+                {"Float32",          "FLOAT",           "CAST('-3.402823E38' AS FLOAT)",                                      "-3.4028230607370965e38",                  "CAST('3.402823E38' AS FLOAT)",                                      "3.4028230607370965e38"},
+                {"Float64",          "DOUBLE",          "CAST('-1.7976931348623157E308' AS DOUBLE)",                          "-1.7976931348623157e308",                 "CAST('1.7976931348623157E308' AS DOUBLE)",                          "1.7976931348623157e308"},
+                {"Decimal(9, 2)",    "DECIMAL(9, 2)",   "CAST('-9999999.99' AS DECIMAL(9, 2))",                               "-9999999.99",                             "CAST('9999999.99' AS DECIMAL(9, 2))",                               "9999999.99"},
+                {"Decimal(18, 4)",   "DECIMAL(18, 4)",  "CAST('-99999999999999.9999' AS DECIMAL(18, 4))",                     "-99999999999999.9999",                    "CAST('99999999999999.9999' AS DECIMAL(18, 4))",                     "99999999999999.9999"},
+                {"Decimal(38, 10)",  "DECIMAL(38, 10)", "CAST('-9999999999999999999999999999.9999999999' AS DECIMAL(38, 10))", "-9999999999999999999999999999.9999999999", "CAST('9999999999999999999999999999.9999999999' AS DECIMAL(38, 10))", "9999999999999999999999999999.9999999999"},
+                {"String",           "STRING",          "''",                                                                 "",                                        "'héllo wörld 日本'",                                                 "héllo wörld 日本"},
+                {"FixedString(8)",   "STRING",          "'abcdefgh'",                                                         "abcdefgh",                                "'日本ab'",                                                           "日本ab"},
+                {"UUID",             "STRING",          "'00000000-0000-0000-0000-000000000000'",                             "00000000-0000-0000-0000-000000000000",    "'ffffffff-ffff-ffff-ffff-ffffffffffff'",                            "ffffffff-ffff-ffff-ffff-ffffffffffff"},
+                {"Date",             "DATE",            "DATE '1970-01-01'",                                                  "1970-01-01",                              "DATE '2149-06-06'",                                                 "2149-06-06"},
+                {"Date32",           "DATE",            "DATE '1900-01-01'",                                                  "1900-01-01",                              "DATE '2299-12-31'",                                                 "2299-12-31"},
+                {"DateTime",         "TIMESTAMP(0)",    "TIMESTAMP '1970-01-01 00:00:00'",                                    "1970-01-01 00:00:00",                     "TIMESTAMP '2106-02-07 06:28:15'",                                   "2106-02-07 06:28:15"},
+                {"DateTime64(3)",    "TIMESTAMP(3)",    "TIMESTAMP '1900-01-01 00:00:00.000'",                                "1900-01-01 00:00:00.000",                 "TIMESTAMP '2299-12-31 23:59:59.999'",                               "2299-12-31 23:59:59.999"},
+                // the connector caps DateTime64(9) where the last whole second's ticks still fit Int64
+                {"DateTime64(9)",    "TIMESTAMP(9)",    "TIMESTAMP '1900-01-01 00:00:00.000000000'",                          "1900-01-01 00:00:00.000000000",           "TIMESTAMP '2262-04-11 23:47:15.999999999'",                         "2262-04-11 23:47:15.999999999"},
+        };
+        roundTripAtBounds("table_api_bounds", "ch_bounds", columns);
+    }
+
+    /**
+     * Every pair whose Flink type is not the column's own counterpart, two rows at the bounds the pair
+     * admits: signed widening, signed narrowing and unsigned targets (range-checked), Decimal rescaling
+     * and each Decimal spelling, DECIMAL(p, 0) into integers, FLOAT into Float64, CHAR/VARCHAR sources
+     * and timestamp precision widening for wall clocks and instants.
+     */
+    @Test
+    void everyConvertingPairRoundTripsAtItsBounds() throws Exception {
+        String[][] columns = {
+                // ClickHouse type   Flink type          low (Flink SQL)                                                       printed                                     high (Flink SQL)                                                     printed
+                // signed widening: the value takes the wider column's Java type on the wire
+                {"Int16",            "TINYINT",          "CAST(-128 AS TINYINT)",                                              "-128",                                     "CAST(127 AS TINYINT)",                                              "127"},
+                {"Int32",            "SMALLINT",         "CAST(-32768 AS SMALLINT)",                                           "-32768",                                   "CAST(32767 AS SMALLINT)",                                           "32767"},
+                {"Int64",            "INT",              "CAST(-2147483648 AS INT)",                                           "-2147483648",                              "CAST(2147483647 AS INT)",                                           "2147483647"},
+                {"Int128",           "BIGINT",           "CAST('-9223372036854775808' AS BIGINT)",                             "-9223372036854775808",                     "CAST('9223372036854775807' AS BIGINT)",                             "9223372036854775807"},
+                {"Int256",           "TINYINT",          "CAST(-128 AS TINYINT)",                                              "-128",                                     "CAST(127 AS TINYINT)",                                              "127"},
+                // signed narrowing: range-checked per record, here at the column's bounds
+                {"Int8",             "SMALLINT",         "CAST(-128 AS SMALLINT)",                                             "-128",                                     "CAST(127 AS SMALLINT)",                                             "127"},
+                {"Int8",             "BIGINT",           "CAST(-128 AS BIGINT)",                                               "-128",                                     "CAST(127 AS BIGINT)",                                               "127"},
+                {"Int16",            "INT",              "CAST(-32768 AS INT)",                                                "-32768",                                   "CAST(32767 AS INT)",                                                "32767"},
+                {"Int32",            "BIGINT",           "CAST(-2147483648 AS BIGINT)",                                        "-2147483648",                              "CAST(2147483647 AS BIGINT)",                                        "2147483647"},
+                // unsigned targets: range-checked per record, up to whichever of the two ranges ends first
+                {"UInt8",            "TINYINT",          "CAST(0 AS TINYINT)",                                                 "0",                                        "CAST(127 AS TINYINT)",                                              "127"},
+                {"UInt8",            "BIGINT",           "CAST(0 AS BIGINT)",                                                  "0",                                        "CAST(255 AS BIGINT)",                                               "255"},
+                {"UInt16",           "SMALLINT",         "CAST(0 AS SMALLINT)",                                                "0",                                        "CAST(32767 AS SMALLINT)",                                           "32767"},
+                {"UInt16",           "BIGINT",           "CAST(0 AS BIGINT)",                                                  "0",                                        "CAST(65535 AS BIGINT)",                                             "65535"},
+                {"UInt32",           "INT",              "CAST(0 AS INT)",                                                     "0",                                        "CAST(2147483647 AS INT)",                                           "2147483647"},
+                {"UInt64",           "BIGINT",           "CAST(0 AS BIGINT)",                                                  "0",                                        "CAST('9223372036854775807' AS BIGINT)",                             "9223372036854775807"},
+                {"UInt128",          "BIGINT",           "CAST(0 AS BIGINT)",                                                  "0",                                        "CAST('9223372036854775807' AS BIGINT)",                             "9223372036854775807"},
+                {"UInt256",          "TINYINT",          "CAST(0 AS TINYINT)",                                                 "0",                                        "CAST(127 AS TINYINT)",                                              "127"},
+                // Decimal rescaling and each Decimal spelling; the server prints no trailing zeros
+                {"Decimal(18, 4)",   "DECIMAL(9, 2)",    "CAST('-9999999.99' AS DECIMAL(9, 2))",                               "-9999999.99",                              "CAST('9999999.99' AS DECIMAL(9, 2))",                               "9999999.99"},
+                {"Decimal(38, 10)",  "DECIMAL(9, 0)",    "CAST(-999999999 AS DECIMAL(9, 0))",                                  "-999999999",                               "CAST(999999999 AS DECIMAL(9, 0))",                                  "999999999"},
+                {"Decimal32(2)",     "DECIMAL(9, 2)",    "CAST('-9999999.99' AS DECIMAL(9, 2))",                               "-9999999.99",                              "CAST('9999999.99' AS DECIMAL(9, 2))",                               "9999999.99"},
+                {"Decimal64(4)",     "DECIMAL(18, 4)",   "CAST('-99999999999999.9999' AS DECIMAL(18, 4))",                     "-99999999999999.9999",                     "CAST('99999999999999.9999' AS DECIMAL(18, 4))",                     "99999999999999.9999"},
+                {"Decimal128(10)",   "DECIMAL(38, 10)",  "CAST('-9999999999999999999999999999.9999999999' AS DECIMAL(38, 10))", "-9999999999999999999999999999.9999999999", "CAST('9999999999999999999999999999.9999999999' AS DECIMAL(38, 10))", "9999999999999999999999999999.9999999999"},
+                {"Decimal256(20)",   "DECIMAL(38, 10)",  "CAST('-9999999999999999999999999999.9999999999' AS DECIMAL(38, 10))", "-9999999999999999999999999999.9999999999", "CAST('9999999999999999999999999999.9999999999' AS DECIMAL(38, 10))", "9999999999999999999999999999.9999999999"},
+                // DECIMAL(p, 0) into integers: below the digit boundary unchecked, at it or into unsigned range-checked
+                {"Int8",             "DECIMAL(3, 0)",    "CAST(-128 AS DECIMAL(3, 0))",                                        "-128",                                     "CAST(127 AS DECIMAL(3, 0))",                                        "127"},
+                {"Int16",            "DECIMAL(5, 0)",    "CAST(-32768 AS DECIMAL(5, 0))",                                      "-32768",                                   "CAST(32767 AS DECIMAL(5, 0))",                                      "32767"},
+                {"Int32",            "DECIMAL(9, 0)",    "CAST(-999999999 AS DECIMAL(9, 0))",                                  "-999999999",                               "CAST(999999999 AS DECIMAL(9, 0))",                                  "999999999"},
+                {"Int64",            "DECIMAL(19, 0)",   "CAST('-9223372036854775808' AS DECIMAL(19, 0))",                     "-9223372036854775808",                     "CAST('9223372036854775807' AS DECIMAL(19, 0))",                     "9223372036854775807"},
+                {"UInt32",           "DECIMAL(10, 0)",   "CAST(0 AS DECIMAL(10, 0))",                                          "0",                                        "CAST(4294967295 AS DECIMAL(10, 0))",                                "4294967295"},
+                // FLOAT widens exactly
+                {"Float64",          "FLOAT",            "CAST('-3.402823E38' AS FLOAT)",                                      "-3.4028230607370965e38",                   "CAST('3.402823E38' AS FLOAT)",                                      "3.4028230607370965e38"},
+                // CHAR/VARCHAR sources; a short value is zero-padded into FixedString, UUID text may be upper case
+                {"String",           "CHAR(4)",          "CAST('AB12' AS CHAR(4))",                                            "AB12",                                     "CAST('ZZ99' AS CHAR(4))",                                           "ZZ99"},
+                {"FixedString(4)",   "CHAR(4)",          "CAST('AB12' AS CHAR(4))",                                            "AB12",                                     "CAST('ZZ99' AS CHAR(4))",                                           "ZZ99"},
+                {"FixedString(4)",   "VARCHAR(4)",       "CAST('ab' AS VARCHAR(4))",                                           "ab",                                       "CAST('ZZ99' AS VARCHAR(4))",                                        "ZZ99"},
+                {"UUID",             "VARCHAR(36)",      "'123E4567-E89B-12D3-A456-426614174000'",                             "123e4567-e89b-12d3-a456-426614174000",     "'ffffffff-ffff-ffff-ffff-ffffffffffff'",                            "ffffffff-ffff-ffff-ffff-ffffffffffff"},
+                // timestamp precision widening, for wall clocks and for instants
+                {"DateTime64(3)",    "TIMESTAMP(0)",     "TIMESTAMP '1970-01-01 00:00:00'",                                    "1970-01-01 00:00:00.000",                  "TIMESTAMP '2299-12-31 23:59:59'",                                   "2299-12-31 23:59:59.000"},
+                {"DateTime64(9)",    "TIMESTAMP(3)",     "TIMESTAMP '1900-01-01 00:00:00.000'",                                "1900-01-01 00:00:00.000000000",            "TIMESTAMP '2026-01-02 03:04:05.678'",                               "2026-01-02 03:04:05.678000000"},
+                {"DateTime",         "TIMESTAMP_LTZ(0)", "CAST(TO_TIMESTAMP_LTZ(0, 3) AS TIMESTAMP_LTZ(0))",                   "1970-01-01 00:00:00",                      "CAST(TO_TIMESTAMP_LTZ(4294967295000, 3) AS TIMESTAMP_LTZ(0))",      "2106-02-07 06:28:15"},
+                {"DateTime64(9)",    "TIMESTAMP_LTZ(3)", "TO_TIMESTAMP_LTZ(" + epochMillis("1900-01-01T00:00:00Z") + ", 3)",   "1900-01-01 00:00:00.000000000",            "TO_TIMESTAMP_LTZ(" + epochMillis("2026-01-02T03:04:05.678Z") + ", 3)", "2026-01-02 03:04:05.678000000"},
+        };
+        roundTripAtBounds("table_api_conversions", "ch_conversions", columns);
+    }
+
+    /** Writes each column's two values through the sink and asserts the server prints them back as given. */
+    private static void roundTripAtBounds(String table, String flinkTable, String[][] columns) throws Exception {
+        StringBuilder clickHouseColumns = new StringBuilder("id Int64");
+        StringBuilder flinkColumns = new StringBuilder("id BIGINT NOT NULL");
+        StringBuilder lows = new StringBuilder("(1");
+        StringBuilder highs = new StringBuilder("(2");
+        StringBuilder readColumns = new StringBuilder("id");
+        for (int i = 0; i < columns.length; i++) {
+            clickHouseColumns.append(", c").append(i).append(' ').append(columns[i][0]);
+            flinkColumns.append(", c").append(i).append(' ').append(columns[i][1]).append(" NOT NULL");
+            lows.append(", ").append(columns[i][2]);
+            highs.append(", ").append(columns[i][4]);
+            readColumns.append(", ").append(printed(columns[i][0], "c" + i)).append(" AS s").append(i);
+        }
+        createTable(table, clickHouseColumns.toString());
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl(flinkTable, table, flinkColumns.toString()));
+        env.executeSql("INSERT INTO " + flinkTable + " VALUES " + lows + "), " + highs + ")").await();
+
+        List<GenericRecord> rows = readBack(readColumns.toString(), table, "id", 2);
+        Assertions.assertEquals(2, rows.size());
+        for (int i = 0; i < columns.length; i++) {
+            Assertions.assertEquals(columns[i][3], rows.get(0).getString("s" + i), columns[i][0] + " low");
+            Assertions.assertEquals(columns[i][5], rows.get(1).getString("s" + i), columns[i][0] + " high");
+        }
+    }
+
+    /** Float32 is widened so toString does not round it to 7 digits; FixedString drops its zero padding. */
+    private static String printed(String clickHouseType, String column) {
+        if (clickHouseType.equals("Float32")) {
+            return "toString(toFloat64(" + column + "))";
+        }
+        if (clickHouseType.startsWith("FixedString")) {
+            return "replaceAll(toString(" + column + "), '\\x00', '')";
+        }
+        return "toString(" + column + ")";
+    }
+
+    private static long epochMillis(String instant) {
+        return Instant.parse(instant).toEpochMilli();
+    }
+
+    /** The same conversions inside composites, plus integer and FixedString map keys restored from their text (24.3 has no Decimal keys). */
+    @Test
+    void conversionsHoldInsideCompositesAndTypedMapKeysRoundTrip() throws Exception {
+        String table = "table_api_nested_conversions";
+        createTable(table,
+                "id Int64, wide Array(Int128), unsigned Array(UInt64), floats Array(Float64), "
+                        + "money Array(Decimal(18, 4)), days Array(Date32), narrow Tuple(Int8, UInt16), "
+                        + "stamped Tuple(DateTime64(3), UUID), maybe Array(Nullable(UInt8)), "
+                        + "by_int Map(Int32, String), by_big Map(Int128, UInt8), by_fixed Map(FixedString(2), Int32)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_nested_conversions", table,
+                "id BIGINT NOT NULL,"
+                        + "wide ARRAY<BIGINT NOT NULL> NOT NULL,"
+                        + "unsigned ARRAY<BIGINT NOT NULL> NOT NULL,"
+                        + "floats ARRAY<FLOAT NOT NULL> NOT NULL,"
+                        + "money ARRAY<DECIMAL(9, 2) NOT NULL> NOT NULL,"
+                        + "days ARRAY<DATE NOT NULL> NOT NULL,"
+                        + "narrow ROW<a SMALLINT NOT NULL, b INT NOT NULL> NOT NULL,"
+                        + "stamped ROW<stamp TIMESTAMP(3) NOT NULL, uid STRING NOT NULL> NOT NULL,"
+                        + "maybe ARRAY<SMALLINT> NOT NULL,"
+                        + "by_int MAP<INT, STRING NOT NULL> NOT NULL,"
+                        + "by_big MAP<DECIMAL(38, 0), SMALLINT NOT NULL> NOT NULL,"
+                        + "by_fixed MAP<STRING, INT NOT NULL> NOT NULL"));
+        env.executeSql("INSERT INTO ch_nested_conversions VALUES (1, "
+                + "ARRAY[CAST('-9223372036854775808' AS BIGINT), CAST('9223372036854775807' AS BIGINT)], "
+                + "ARRAY[CAST(0 AS BIGINT), CAST('9223372036854775807' AS BIGINT)], "
+                + "ARRAY[CAST(1.5 AS FLOAT)], "
+                + "ARRAY[CAST('12.5' AS DECIMAL(9, 2))], "
+                + "ARRAY[DATE '1900-01-01', DATE '2299-12-31'], "
+                + "ROW(CAST(-128 AS SMALLINT), 65535), "
+                + "ROW(TIMESTAMP '2026-01-02 03:04:05.678', '123e4567-e89b-12d3-a456-426614174000'), "
+                + "ARRAY[CAST(NULL AS SMALLINT), CAST(255 AS SMALLINT)], "
+                + "MAP[-7, 'neg', 2147483647, 'max'], "
+                + "MAP[CAST('99999999999999999999999999999999999999' AS DECIMAL(38, 0)), CAST(255 AS SMALLINT)], "
+                + "MAP['ab', 1])").await();
+
+        List<GenericRecord> rows = readBack(
+                "id, toString(wide) AS wide_s, toString(unsigned) AS unsigned_s, toString(floats) AS floats_s, "
+                        + "toString(money) AS money_s, toString(days) AS days_s, toString(narrow) AS narrow_s, "
+                        + "toString(stamped) AS stamped_s, toString(maybe) AS maybe_s, "
+                        + "by_int[-7] AS neg, by_int[2147483647] AS max, "
+                        + "toString(by_big) AS by_big_s, toString(by_fixed) AS by_fixed_s",
+                table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        GenericRecord row = rows.get(0);
+        Assertions.assertEquals("[-9223372036854775808,9223372036854775807]", row.getString("wide_s"));
+        Assertions.assertEquals("[0,9223372036854775807]", row.getString("unsigned_s"));
+        Assertions.assertEquals("[1.5]", row.getString("floats_s"));
+        Assertions.assertEquals("[12.5]", row.getString("money_s"));
+        Assertions.assertEquals("['1900-01-01','2299-12-31']", row.getString("days_s"));
+        Assertions.assertEquals("(-128,65535)", row.getString("narrow_s"));
+        Assertions.assertEquals("('2026-01-02 03:04:05.678','123e4567-e89b-12d3-a456-426614174000')",
+                row.getString("stamped_s"));
+        Assertions.assertEquals("[NULL,255]", row.getString("maybe_s"));
+        Assertions.assertEquals("neg", row.getString("neg"));
+        Assertions.assertEquals("max", row.getString("max"));
+        Assertions.assertEquals("{99999999999999999999999999999999999999:255}", row.getString("by_big_s"));
+        Assertions.assertEquals("{'ab':1}", row.getString("by_fixed_s"));
+    }
+
+    @Test
+    void replanningAfterAlterSeesTheCurrentSchema() throws Exception {
+        String table = "table_api_alter";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_alter_before", table, "id BIGINT NOT NULL"));
+        // Introspect once pre-ALTER, so a schema memo (were one to exist) would be populated.
+        Assertions.assertFalse(env.explainSql("INSERT INTO ch_alter_before VALUES (1)").isEmpty());
+
+        ClickHouseServerForTests.executeSql(String.format(
+                "ALTER TABLE `%s`.`%s` ADD COLUMN label String",
+                ClickHouseServerForTests.getDatabase(), table));
+
+        // Same-JVM re-planning must see the post-ALTER schema and accept the new column.
+        env.executeSql(sinkDdl("ch_alter_after", table, "id BIGINT NOT NULL, label STRING NOT NULL"));
+        env.executeSql("INSERT INTO ch_alter_after VALUES (7, 'post-alter')").await();
+
+        List<GenericRecord> rows = readBack("id, label", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(7L, rows.get(0).getLong("id"));
+        Assertions.assertEquals("post-alter", rows.get(0).getString("label"));
+    }
+
+    @Test
+    void unreachableServerFailsPlanningFastWhateverSinkMaxRetries() {
+        TableEnvironment env = tableEnvironment();
+        // Port 1 never listens, so the planning DESCRIBE fails at once with connection refused.
+        env.executeSql(
+                "CREATE TABLE ch_unreachable (id BIGINT NOT NULL) WITH ("
+                        + "'connector' = 'clickhouse',"
+                        + "'url' = 'http://localhost:1',"
+                        + "'username' = 'default',"
+                        + "'password' = '',"
+                        + "'database' = 'default',"
+                        + "'table' = 'whatever',"
+                        + "'sink.max-retries' = '100000')");
+
+        long start = System.nanoTime();
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_unreachable VALUES (1)"),
+                "Could not read the schema", "Connection refused");
+        long elapsedMs = (System.nanoTime() - start) / 1_000_000;
+
+        // sink.max-retries governs batch retries only; 100 000 attempts here would block for days.
+        Assertions.assertTrue(elapsedMs < 60_000,
+                "Planning blocked for " + elapsedMs + "ms — is sink.max-retries driving it?");
+    }
+
+    @Test
+    void negativeBigIntIntoUInt32FailsNamingTheColumn() throws Exception {
+        String table = "table_api_unsigned";
+        createTable(table, "id Int64, hits UInt32");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_unsigned", table, "id BIGINT NOT NULL, hits BIGINT NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_unsigned VALUES (1, -1)").await(),
+                "Column 'hits': value -1 is outside the UInt32 range");
+    }
+
+    @Test
+    void strictNumericMappingRejectsARangeCheckedPairAtPlanning() throws Exception {
+        String table = "table_api_strict";
+        createTable(table, "id Int64, hits UInt32");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_strict", table, "id BIGINT NOT NULL, hits BIGINT NOT NULL",
+                ", 'sink.strict-numeric-mapping' = 'true'"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_strict VALUES (1, 1)"),
+                "Column 'hits'", "UInt32 range", "'sink.strict-numeric-mapping'");
+    }
+
+    @Test
+    void outOfRangeDate32FailsNamingTheColumn() throws Exception {
+        String table = "table_api_date32";
+        createTable(table, "id Int64, event_day Date32");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_date32", table, "id BIGINT NOT NULL, event_day DATE NOT NULL"));
+
+        // Pre-fix this was written raw and stored as a different date, with no error anywhere.
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_date32 VALUES (1, DATE '9999-12-31')").await(),
+                "Column 'event_day': DATE value 9999-12-31 is outside the ClickHouse Date32 range");
+    }
+
+    @Test
+    void unknownFlinkColumnFailsAtPlanningWithPreciseMessage() throws Exception {
+        String table = "table_api_reject";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_reject", table,
+                "id BIGINT NOT NULL, nickname STRING NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_reject VALUES (1, 'nick')"),
+                "Column 'nickname' declared in the Flink schema does not exist in");
+    }
+
+    @Test
+    void nullValuesRoundTripIntoNullableColumns() throws Exception {
+        String table = "table_api_nullable";
+        createTable(table, "id Int64, name Nullable(String), score Nullable(Float64), event_day Nullable(Date)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_nullable", table,
+                "id BIGINT NOT NULL, name STRING, score DOUBLE, event_day DATE"));
+        env.executeSql("INSERT INTO ch_nullable VALUES "
+                + "(1, 'alice', 99.5, DATE '2026-01-02'), "
+                + "(2, CAST(NULL AS STRING), CAST(NULL AS DOUBLE), CAST(NULL AS DATE))").await();
+
+        List<GenericRecord> rows = readBack(
+                "id, ifNull(name, '<null>') AS name_s, ifNull(toString(score), '<null>') AS score_s, "
+                        + "ifNull(toString(event_day), '<null>') AS day_s",
+                table, "id", 2);
+
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals("alice", rows.get(0).getString("name_s"));
+        Assertions.assertEquals("99.5", rows.get(0).getString("score_s"));
+        Assertions.assertEquals("2026-01-02", rows.get(0).getString("day_s"));
+        Assertions.assertEquals("<null>", rows.get(1).getString("name_s"));
+        Assertions.assertEquals("<null>", rows.get(1).getString("score_s"));
+        Assertions.assertEquals("<null>", rows.get(1).getString("day_s"));
+    }
+
+    @Test
+    void multisetRoundTripsIntoUInt64CountMap() throws Exception {
+        String table = "table_api_multiset";
+        createTable(table, "id Int64, tags Map(String, UInt64)");
+
+        // Flink SQL has no MULTISET literal; COLLECT in batch mode emits final, insert-only rows.
+        TableEnvironment env = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+        env.executeSql(sinkDdl("ch_multiset", table,
+                "id BIGINT NOT NULL, tags MULTISET<STRING NOT NULL> NOT NULL"));
+        env.executeSql("INSERT INTO ch_multiset "
+                + "SELECT id, COLLECT(tag) FROM ("
+                + "  SELECT CAST(id AS BIGINT) AS id, CAST(tag AS STRING) AS tag "
+                + "  FROM (VALUES (1, 'a'), (1, 'a'), (1, 'b'), (2, 'z')) AS t(id, tag)"
+                + ") GROUP BY id").await();
+
+        // Map entry order is not deterministic, so probe by key instead of comparing strings.
+        List<GenericRecord> rows = readBack(
+                "id, toInt64(tags['a']) AS a_cnt, toInt64(tags['b']) AS b_cnt, "
+                        + "toInt64(tags['z']) AS z_cnt, toInt64(length(tags)) AS n_keys",
+                table, "id", 2);
+
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals(2L, rows.get(0).getLong("a_cnt"));
+        Assertions.assertEquals(1L, rows.get(0).getLong("b_cnt"));
+        Assertions.assertEquals(2L, rows.get(0).getLong("n_keys"));
+        Assertions.assertEquals(1L, rows.get(1).getLong("z_cnt"));
+        Assertions.assertEquals(1L, rows.get(1).getLong("n_keys"));
+    }
+
+    @Test
+    void rowsWriteIntoTuplesAtEveryNestingAndNullArrayElementsRoundTrip() throws Exception {
+        String table = "table_api_tuple";
+        createTable(table,
+                "id Int64, pair Tuple(Int32, String), nums Array(Nullable(Int32)), "
+                        + "pairs Array(Tuple(Int32, String)), nested Tuple(Int32, Tuple(Int32, String))");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_tuple", table,
+                "id BIGINT NOT NULL,"
+                        + "pair ROW<a INT NOT NULL, b STRING NOT NULL> NOT NULL,"
+                        + "nums ARRAY<INT> NOT NULL,"
+                        + "pairs ARRAY<ROW<a INT NOT NULL, b STRING NOT NULL> NOT NULL> NOT NULL,"
+                        + "nested ROW<a INT NOT NULL, b ROW<c INT NOT NULL, d STRING NOT NULL> NOT NULL> NOT NULL"));
+        env.executeSql("INSERT INTO ch_tuple VALUES "
+                + "(1, ROW(7, 'x'), ARRAY[1, CAST(NULL AS INT), 3], "
+                + "ARRAY[ROW(1, 'p'), ROW(2, 'q')], ROW(5, ROW(6, 'z')))").await();
+
+        List<GenericRecord> rows = readBack(
+                "id, toString(pair) AS pair_s, toString(nums) AS nums_s, "
+                        + "toString(pairs) AS pairs_s, toString(nested) AS nested_s",
+                table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("(7,'x')", rows.get(0).getString("pair_s"));
+        Assertions.assertEquals("[1,NULL,3]", rows.get(0).getString("nums_s"));
+        Assertions.assertEquals("[(1,'p'),(2,'q')]", rows.get(0).getString("pairs_s"));
+        Assertions.assertEquals("(5,(6,'z'))", rows.get(0).getString("nested_s"));
+    }
+
+    /** DESCRIBE pretty-prints named Tuples across lines by default; the insert header must carry the canonical type. */
+    @Test
+    void namedTuplesAtEveryNestingRoundTrip() throws Exception {
+        String table = "table_api_named_tuple";
+        createTable(table,
+                "id Int64, pair Tuple(a Int32, b String), pairs Array(Tuple(a Int32, b String)), "
+                        + "by_key Map(String, Tuple(a Int32, b String))");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_named_tuple", table,
+                "id BIGINT NOT NULL,"
+                        + "pair ROW<a INT NOT NULL, b STRING NOT NULL> NOT NULL,"
+                        + "pairs ARRAY<ROW<a INT NOT NULL, b STRING NOT NULL> NOT NULL> NOT NULL,"
+                        + "by_key MAP<STRING, ROW<a INT NOT NULL, b STRING NOT NULL> NOT NULL> NOT NULL"));
+        env.executeSql("INSERT INTO ch_named_tuple VALUES "
+                + "(1, ROW(7, 'x'), ARRAY[ROW(1, 'p'), ROW(2, 'q')], MAP['k', ROW(5, 'z')])").await();
+
+        List<GenericRecord> rows = readBack(
+                "id, toString(pair) AS pair_s, toString(pairs) AS pairs_s, toString(by_key['k']) AS k_s",
+                table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("(7,'x')", rows.get(0).getString("pair_s"));
+        Assertions.assertEquals("[(1,'p'),(2,'q')]", rows.get(0).getString("pairs_s"));
+        Assertions.assertEquals("(5,'z')", rows.get(0).getString("k_s"));
+    }
+
+    /** Planning admits a nullable value into a NOT NULL nested field; the write must fail, not store zeros. */
+    @Test
+    void nullNestedValueFailsNamingTheColumnInsteadOfWritingZeros() throws Exception {
+        String table = "table_api_nested_null";
+        createTable(table, "id Int64, pair Tuple(Int32, String), nums Array(Int32)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_nested_null", table,
+                "id BIGINT NOT NULL,"
+                        + "pair ROW<a INT NOT NULL, b STRING NOT NULL> NOT NULL,"
+                        + "nums ARRAY<INT NOT NULL> NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql(
+                "INSERT INTO ch_nested_null VALUES (1, ROW(CAST(NULL AS INT), 'x'), ARRAY[1])").await(),
+                "Column 'pair': null ROW field 1");
+        assertFailsWith(() -> env.executeSql(
+                "INSERT INTO ch_nested_null VALUES (2, ROW(7, 'x'), ARRAY[1, CAST(NULL AS INT)])").await(),
+                "Column 'nums': null array element 2");
+        Assertions.assertEquals(0, readBack("id", table, "id", 0).size());
+    }
+
+    @Test
+    void simpleAggregateFunctionColumnAcceptsItsInnerType() throws Exception {
+        String table = "table_api_simple_agg";
+        createTable(table, "id Int64, total SimpleAggregateFunction(sum, Int64)", "AggregatingMergeTree() ORDER BY id");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_simple_agg", table, "id BIGINT NOT NULL, total BIGINT NOT NULL"));
+        env.executeSql("INSERT INTO ch_simple_agg VALUES (1, 10), (2, 20)").await();
+
+        List<GenericRecord> rows = readBack("id, toInt64(total) AS total_v", table, "id", 2);
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals(10L, rows.get(0).getLong("total_v"));
+        Assertions.assertEquals(20L, rows.get(1).getLong("total_v"));
+    }
+
+    @Test
+    void updatingSourceIsRejectedAtPlanningAsInsertOnly() throws Exception {
+        String table = "table_api_insert_only";
+        createTable(table, "name String, cnt Int64", "MergeTree() ORDER BY name");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_insert_only", table, "name STRING NOT NULL, cnt BIGINT NOT NULL"));
+
+        // A streaming GROUP BY emits updates; the insert-only sink must reject the plan (#148).
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_insert_only "
+                        + "SELECT name, COUNT(*) FROM (VALUES ('a'), ('a'), ('b')) AS t(name) "
+                        + "GROUP BY name"),
+                "doesn't support consuming update changes");
+    }
+
+    @Test
+    void omittedClickHouseColumnsWithDefaultsAreBackfilled() throws Exception {
+        String table = "table_api_defaults";
+        createTable(table, "id Int64, note Nullable(String), tag String DEFAULT 'none'");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_defaults", table, "id BIGINT NOT NULL"));
+        env.executeSql("INSERT INTO ch_defaults VALUES (5)").await();
+
+        List<GenericRecord> rows = readBack("id, ifNull(note, '<null>') AS note_s, tag", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(5L, rows.get(0).getLong("id"));
+        Assertions.assertEquals("<null>", rows.get(0).getString("note_s"));
+        Assertions.assertEquals("none", rows.get(0).getString("tag"));
+    }
+
+    @Test
+    void omittedNoDefaultColumnIsFilledWithTheTypeDefault() throws Exception {
+        String table = "table_api_no_default";
+        createTable(table, "id Int64, req String, tags Array(String)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_no_default", table, "id BIGINT NOT NULL"));
+        env.executeSql("INSERT INTO ch_no_default VALUES (1)").await();
+
+        List<GenericRecord> rows = readBack("id, req, length(tags) AS tags_len", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(1L, rows.get(0).getLong("id"));
+        Assertions.assertEquals("", rows.get(0).getString("req"));
+        Assertions.assertEquals(0L, rows.get(0).getLong("tags_len"));
+    }
+
+    @Test
+    void statementSetInsertsIntoTheSameSinkTwice() throws Exception {
+        String table = "table_api_stmt_set";
+        createTable(table, "id Int64, src String");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_stmt_set", table, "id BIGINT NOT NULL, src STRING NOT NULL"));
+
+        // Two INSERTs into one sink table: the planner copies the sink, exercising copy()'s deep copy.
+        env.createStatementSet()
+                .addInsertSql("INSERT INTO ch_stmt_set VALUES (1, 'first'), (2, 'first')")
+                .addInsertSql("INSERT INTO ch_stmt_set VALUES (3, 'second'), (4, 'second')")
+                .execute()
+                .await();
+
+        List<GenericRecord> rows = readBack("id, src", table, "id", 4);
+        Assertions.assertEquals(4, rows.size());
+        Assertions.assertEquals("first", rows.get(0).getString("src"));
+        Assertions.assertEquals("first", rows.get(1).getString("src"));
+        Assertions.assertEquals("second", rows.get(2).getString("src"));
+        Assertions.assertEquals("second", rows.get(3).getString("src"));
+    }
+
+    @Test
+    void columnsMapByNameNotPosition() throws Exception {
+        String table = "table_api_permuted";
+        createTable(table, "a Int64, b String, c Float64", "MergeTree() ORDER BY a");
+
+        TableEnvironment env = tableEnvironment();
+        // Deliberately not the ClickHouse order; positional mapping could not even plan this.
+        env.executeSql(sinkDdl("ch_permuted", table,
+                "c DOUBLE NOT NULL, a BIGINT NOT NULL, b STRING NOT NULL"));
+        env.executeSql("INSERT INTO ch_permuted VALUES (1.5, 7, 'x')").await();
+
+        List<GenericRecord> rows = readBack("a, b, c", table, "a", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(7L, rows.get(0).getLong("a"));
+        Assertions.assertEquals("x", rows.get(0).getString("b"));
+        Assertions.assertEquals(1.5, rows.get(0).getDouble("c"));
+    }
+
+    @Test
+    void typeMismatchFailsAtPlanningNamingColumnAndBothTypes() throws Exception {
+        String table = "table_api_mismatch";
+        createTable(table, "id Int64, label Int64");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_mismatch", table, "id BIGINT NOT NULL, label STRING NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_mismatch VALUES (1, 'nope')"),
+                "Column 'label': Flink type STRING NOT NULL cannot be written to ClickHouse column 'label Int64'");
+    }
+
+    @Test
+    void ignoredUnknownFlinkColumnIsSkippedAtWriteTime() throws Exception {
+        String table = "table_api_ignore_unknown";
+        createTable(table, "id Int64, name String");
+
+        TableEnvironment env = tableEnvironment();
+        // 'extra' sits between the mapped columns, so the surviving accessors must keep their indices.
+        env.executeSql(sinkDdl("ch_ignore_unknown", table,
+                "id BIGINT NOT NULL, extra STRING NOT NULL, name STRING NOT NULL",
+                ", 'sink.ignore-unknown-flink-columns' = 'true'"));
+        env.executeSql("INSERT INTO ch_ignore_unknown VALUES (3, 'dropped', 'carol')").await();
+
+        List<GenericRecord> rows = readBack("id, name", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(3L, rows.get(0).getLong("id"));
+        Assertions.assertEquals("carol", rows.get(0).getString("name"));
+    }
+
+    @Test
+    void computedColumnsAreExcludedFromTheSinkSchema() throws Exception {
+        String table = "table_api_computed";
+        createTable(table, "id Int64, name String");
+
+        TableEnvironment env = tableEnvironment();
+        // 'id_plus' has no ClickHouse counterpart and must never reach schema resolution.
+        env.executeSql(sinkDdl("ch_computed", table,
+                "id BIGINT NOT NULL, name STRING NOT NULL, id_plus AS id + 1"));
+        env.executeSql("INSERT INTO ch_computed VALUES (1, 'x')").await();
+
+        List<GenericRecord> rows = readBack("id, name", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(1L, rows.get(0).getLong("id"));
+        Assertions.assertEquals("x", rows.get(0).getString("name"));
+    }
+
+    @Test
+    void primaryKeyIsAcceptedAndIgnored() throws Exception {
+        String table = "table_api_primary_key";
+        createTable(table, "id Int64, v String");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_primary_key", table,
+                "id BIGINT NOT NULL, v STRING NOT NULL, PRIMARY KEY (id) NOT ENFORCED"));
+        // Same key twice: the sink appends both — no silent upsert until #148 makes it a choice.
+        env.executeSql("INSERT INTO ch_primary_key VALUES (1, 'first'), (1, 'second')").await();
+
+        List<GenericRecord> rows = readBack("id, v", table, "v", 2);
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals("first", rows.get(0).getString("v"));
+        Assertions.assertEquals("second", rows.get(1).getString("v"));
+    }
+
+    @Test
+    void sinkTimezoneInterpretsWallClockTimestamps() throws Exception {
+        String table = "table_api_sink_timezone";
+        createTable(table, "id Int64, ts DateTime64(3)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_sink_tz", table,
+                "id BIGINT NOT NULL, ts TIMESTAMP(3) NOT NULL",
+                ", 'sink.timezone' = 'Asia/Tokyo'"));
+        env.executeSql("INSERT INTO ch_sink_tz VALUES (1, TIMESTAMP '2026-01-02 09:00:00')").await();
+
+        // 09:00 Tokyo wall clock is midnight UTC; compare instants, not rendered strings.
+        List<GenericRecord> rows = readBack("id, toUnixTimestamp64Milli(ts) AS ts_ms", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(Instant.parse("2026-01-02T00:00:00Z").toEpochMilli(),
+                rows.get(0).getLong("ts_ms"));
+    }
+
+    @Test
+    void timestampLtzWritesTheInstantRegardlessOfZones() throws Exception {
+        String table = "table_api_ltz";
+        createTable(table, "id Int64, ts DateTime64(3)");
+
+        TableEnvironment env = tableEnvironment();
+        // The session zone fixes the instant at CAST time; sink.timezone must not shift it again.
+        env.getConfig().setLocalTimeZone(ZoneId.of("Asia/Tokyo"));
+        env.executeSql(sinkDdl("ch_ltz", table,
+                "id BIGINT NOT NULL, ts TIMESTAMP_LTZ(3) NOT NULL",
+                ", 'sink.timezone' = 'America/New_York'"));
+        env.executeSql("INSERT INTO ch_ltz VALUES "
+                + "(1, CAST(TIMESTAMP '2026-01-02 09:00:00' AS TIMESTAMP_LTZ(3)))").await();
+
+        List<GenericRecord> rows = readBack("id, toUnixTimestamp64Milli(ts) AS ts_ms", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(Instant.parse("2026-01-02T00:00:00Z").toEpochMilli(),
+                rows.get(0).getLong("ts_ms"));
+    }
+
+    @Test
+    void jsonColumnAcceptsJsonStrings() throws Exception {
+        String table = "table_api_json";
+        try {
+            createTable(table, "id Int64, j JSON");
+        } catch (Exception e) {
+            // Probe, don't pin versions: the modern JSON type is GA from 25.3. Only the server's own
+            // "no JSON type" answer may skip; a connection or DDL problem must fail the test.
+            Assumptions.assumeFalse(lacksJsonType(e), "Server lacks the JSON type: " + e.getMessage());
+            throw e;
+        }
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_json", table, "id BIGINT NOT NULL, j STRING NOT NULL"));
+        env.executeSql("INSERT INTO ch_json VALUES (1, '{\"k\": \"v\", \"n\": 42}')").await();
+
+        List<GenericRecord> rows = readBack(
+                "id, toString(getSubcolumn(j, 'k')) AS k_s, toInt64(getSubcolumn(j, 'n')) AS n_v",
+                table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("v", rows.get(0).getString("k_s"));
+        Assertions.assertEquals(42L, rows.get(0).getLong("n_v"));
+    }
+
+    /**
+     * Fails when client-v2 learns to quote table names (clickhouse-java#3089) — then remove
+     * SchemaResolverOptions#requireUnquotedTableName, its unit test, and this canary.
+     */
+    @Test
+    void clientV2StillCannotDescribeTableNamesNeedingQuotes() throws Exception {
+        createTable("table-api-canary", "id Int64");
+        try (Client client = fixtureClient()) {
+            Exception e = Assertions.assertThrows(Exception.class, () -> client.getTableSchema(
+                    "table-api-canary", ClickHouseServerForTests.getDatabase()));
+            // Unquoted, the name parses as `table - api - canary`: a server SYNTAX_ERROR (62), not
+            // some other DESCRIBE failure such as the 26.8 header-format break.
+            ServerException server = ExceptionUtils.findThrowable(e, ServerException.class)
+                    .orElseThrow(() -> new AssertionError("expected a server-side syntax error, got: " + e, e));
+            Assertions.assertEquals(62, server.getCode(), server.getMessage());
+        }
+    }
+
+    @Test
+    void passthroughOptionsReachTheClientAndTheInsert() throws Exception {
+        String table = "table_api_passthrough";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = tableEnvironment();
+        // The client option must survive validation and client construction; the server setting is
+        // recorded per query, so the insert's query_log row proves it travelled with the INSERT.
+        env.executeSql(sinkDdl("ch_passthrough", table, "id BIGINT NOT NULL",
+                ", 'clickhouse.client.socket_timeout' = '30000'"
+                        + ", 'clickhouse.server.max_insert_block_size' = '777777'"));
+        env.executeSql("INSERT INTO ch_passthrough VALUES (1)").await();
+
+        Assertions.assertEquals(1, readBack("id", table, "id", 1).size());
+        Assertions.assertTrue(insertsRecordedWithSetting(table, "max_insert_block_size", "777777") >= 1,
+                "no query_log INSERT into " + table + " carries max_insert_block_size=777777");
+    }
+
+    @Test
+    void barePassthroughPrefixIsRejectedAtPlanning() {
+        TableEnvironment env = tableEnvironment();
+        // The bare prefix passes FactoryUtil's prefix skip; it must fail here, not reach the server as '?=1'.
+        env.executeSql(sinkDdl("ch_bare_prefix", "does_not_exist", "id BIGINT NOT NULL",
+                ", 'clickhouse.server.' = '1'"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_bare_prefix VALUES (1)"),
+                "Option 'clickhouse.server.' has no key after the prefix");
+    }
+
+    @Test
+    void zeroScaleDecimalsWriteIntoTheIntegersTheirDigitsCover() throws Exception {
+        String table = "table_api_decimal_ints";
+        createTable(table, "id Int64, small UInt8, big Int64");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_decimal_ints", table,
+                "id BIGINT NOT NULL, small DECIMAL(3, 0) NOT NULL, big DECIMAL(18, 0) NOT NULL"));
+        env.executeSql("INSERT INTO ch_decimal_ints VALUES "
+                + "(1, CAST(255 AS DECIMAL(3, 0)), CAST(123456789012345678 AS DECIMAL(18, 0)))").await();
+
+        List<GenericRecord> rows = readBack("id, small, big", table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals(255, rows.get(0).getInteger("small"));
+        Assertions.assertEquals(123456789012345678L, rows.get(0).getLong("big"));
+    }
+
+    @Test
+    void doubleIntoFloat32IsRejectedAtPlanning() throws Exception {
+        String table = "table_api_double_float32";
+        createTable(table, "id Int64, ratio Float32");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_double_float32", table, "id BIGINT NOT NULL, ratio DOUBLE NOT NULL"));
+
+        // Rounding a double to single precision changes the value, so the pair is refused in every mode.
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_double_float32 VALUES (1, 0.1)"),
+                "Column 'ratio'", "Float32 would round DOUBLE values", "CAST the value to FLOAT");
+    }
+
+    @Test
+    void overlongStringIntoFixedStringFailsNamingTheColumn() throws Exception {
+        String table = "table_api_fixed_string";
+        createTable(table, "id Int64, code FixedString(4)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_fixed_string", table, "id BIGINT NOT NULL, code STRING NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_fixed_string VALUES (1, 'ABCDE')").await(),
+                "Column 'code': value of 5 bytes does not fit FixedString(4)");
+        Assertions.assertEquals(0, readBack("id", table, "id", 0).size());
+    }
+
+    /** The option gates numeric range checks only; date, timestamp, UUID and FixedString values are still checked per record. */
+    @Test
+    void strictNumericMappingLeavesValueCheckedPairsAlone() throws Exception {
+        String table = "table_api_strict_values";
+        createTable(table, "id Int64, event_day Date, ts DateTime64(3), uid UUID, code FixedString(4)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_strict_values", table,
+                "id BIGINT NOT NULL, event_day DATE NOT NULL, ts TIMESTAMP(3) NOT NULL, "
+                        + "uid STRING NOT NULL, code STRING NOT NULL",
+                ", 'sink.strict-numeric-mapping' = 'true'"));
+        env.executeSql("INSERT INTO ch_strict_values VALUES (1, DATE '2026-01-02', TIMESTAMP '2026-01-02 03:04:05.678', "
+                + "'123e4567-e89b-12d3-a456-426614174000', 'AB12')").await();
+
+        List<GenericRecord> rows = readBack(
+                "id, toString(event_day) AS day_s, toString(ts) AS ts_s, toString(uid) AS uid_s, toString(code) AS code_s",
+                table, "id", 1);
+        Assertions.assertEquals(1, rows.size());
+        Assertions.assertEquals("2026-01-02", rows.get(0).getString("day_s"));
+        Assertions.assertEquals("2026-01-02 03:04:05.678", rows.get(0).getString("ts_s"));
+        Assertions.assertEquals("123e4567-e89b-12d3-a456-426614174000", rows.get(0).getString("uid_s"));
+        Assertions.assertEquals("AB12", rows.get(0).getString("code_s"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_strict_values VALUES (2, DATE '2026-01-02', "
+                        + "TIMESTAMP '2026-01-02 03:04:05.678', 'not-a-uuid', 'AB12')").await(),
+                "Column 'uid': value is not a valid UUID: not-a-uuid");
+    }
+
+    @Test
+    void nullableUnsignedColumnsAreRejectedAtPlanning() throws Exception {
+        String table = "table_api_nullable_unsigned";
+        createTable(table, "id Int64, hits Nullable(UInt32)");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_nullable_unsigned", table, "id BIGINT NOT NULL, hits BIGINT"));
+
+        // DataWriter writes a null into Nullable(UInt*) as 0 (issue #144), so planning refuses the pair.
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_nullable_unsigned VALUES (1, 1)"),
+                "Column 'hits'", "issue #144");
+    }
+
+    @Test
+    void defaultTimestampPrecisionIsRejectedForDateTime64Of3() throws Exception {
+        String table = "table_api_ts_precision";
+        createTable(table, "id Int64, ts DateTime64(3)");
+
+        TableEnvironment env = tableEnvironment();
+        // Flink's TIMESTAMP defaults to precision 6, which DateTime64(3) would truncate.
+        env.executeSql(sinkDdl("ch_ts_precision", table, "id BIGINT NOT NULL, ts TIMESTAMP NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_ts_precision VALUES (1, TIMESTAMP '2026-01-02 03:04:05')"),
+                "Column 'ts'", "precision 6 exceeds the column's scale 3");
+    }
+
+    @Test
+    void sinkParallelismSplitsTheInsertAcrossThatManyWriters() throws Exception {
+        String table = "table_api_parallelism";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = singleParallelismEnvironment();
+        // Each writer subtask flushes its share once at end of input, so the INSERT count is the
+        // writer count; the interval is pinned high so a slow run cannot add a timer flush.
+        env.executeSql(sinkDdl("ch_parallel", table, "id BIGINT NOT NULL",
+                ", 'sink.parallelism' = '2', 'sink.buffer-flush.interval' = '10 min'"));
+        env.executeSql("INSERT INTO ch_parallel VALUES " + valuesList(10)).await();
+
+        Assertions.assertEquals(10, readBack("id", table, "id", 10).size());
+        Assertions.assertEquals(2, finishedInserts(table, "", 2),
+                "expected exactly one INSERT per writer subtask");
+    }
+
+    @Test
+    void bufferFlushIntervalFlushesAnUnboundedStreamOnTime() throws Exception {
+        String table = "table_api_interval";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = singleParallelismEnvironment();
+        env.executeSql("CREATE TABLE gen (id BIGINT NOT NULL) WITH ("
+                + "'connector' = 'datagen', 'rows-per-second' = '10')");
+        // Rows and bytes can never trigger a flush here, so only the 1 s timer moves data.
+        env.executeSql(sinkDdl("ch_interval", table, "id BIGINT NOT NULL",
+                ", 'sink.buffer-flush.interval' = '1s', 'sink.buffer-flush.max-rows' = '5000'"));
+
+        JobClient job = env.executeSql("INSERT INTO ch_interval SELECT id FROM gen")
+                .getJobClient().orElseThrow(() -> new AssertionError("no job client"));
+        try {
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(90);
+            int rows = ClickHouseServerForTests.countRows(table);
+            while (rows < 40 && System.nanoTime() < deadline) {
+                Thread.sleep(250);
+                rows = ClickHouseServerForTests.countRows(table);
+            }
+            Assertions.assertTrue(rows >= 40, "only " + rows + " rows landed within 90 s");
+        } finally {
+            job.cancel().get(60, TimeUnit.SECONDS);
+        }
+        // At 10 rows/s a 1 s timer lands ~10 rows per INSERT; the 5 s default would have put the
+        // first ~50 rows into a single INSERT.
+        long inserts = finishedInserts(table, "", 2);
+        Assertions.assertTrue(inserts >= 2, "40 rows arrived in " + inserts + " INSERT(s)");
+    }
+
+    @Test
+    void singleInFlightRequestSerialisesTheInserts() throws Exception {
+        String table = "table_api_in_flight";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = singleParallelismEnvironment();
+        // One row per batch gives 20 INSERTs; the default of 50 in flight would overlap them.
+        env.executeSql(sinkDdl("ch_in_flight", table, "id BIGINT NOT NULL",
+                ", 'sink.buffer-flush.max-rows' = '1', 'sink.max-in-flight-requests' = '1'"));
+        env.executeSql("INSERT INTO ch_in_flight VALUES " + valuesList(20)).await();
+
+        Assertions.assertEquals(20, readBack("id", table, "id", 20).size());
+        Assertions.assertEquals(20, finishedInserts(table, "", 20));
+        if (!ClickHouseServerForTests.isCloud()) {
+            // Replicas keep separate clocks, so only a single server can time-order the INSERTs.
+            Assertions.assertEquals(0, overlappingInserts(table), "INSERTs overlapped on the server");
+        }
+    }
+
+    @Test
+    void twoEntryBufferBackpressuresWithoutLosingRows() throws Exception {
+        String table = "table_api_tiny_buffer";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = singleParallelismEnvironment();
+        // With one row per batch and one request in flight, the third row must block until the
+        // first INSERT is acknowledged; the job has to drain instead of hanging or dropping rows.
+        env.executeSql(sinkDdl("ch_tiny_buffer", table, "id BIGINT NOT NULL",
+                ", 'sink.buffer-flush.max-rows' = '1', 'sink.max-in-flight-requests' = '1'"
+                        + ", 'sink.max-buffered-requests' = '2'"));
+        env.executeSql("INSERT INTO ch_tiny_buffer VALUES " + valuesList(20)).await();
+
+        List<GenericRecord> rows = readBack("id", table, "id", 20);
+        Assertions.assertEquals(20, rows.size());
+        Assertions.assertEquals(20L, rows.get(19).getLong("id"));
+    }
+
+    @Test
+    void oversizedRecordFailsNamingTheRecordLimit() throws Exception {
+        String table = "table_api_record_bytes";
+        createTable(table, "id Int64, payload String");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_record_bytes", table, "id BIGINT NOT NULL, payload STRING NOT NULL",
+                ", 'sink.record.max-bytes' = '64b'"));
+        // A 13-byte RowBinary row fits; a 200-char payload is rejected by the AsyncSink writer.
+        env.executeSql("INSERT INTO ch_record_bytes VALUES (1, 'tiny')").await();
+        Assertions.assertEquals(1, readBack("id", table, "id", 1).size());
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_record_bytes VALUES (2, REPEAT('x', 200))").await(),
+                "maxRecordSizeInBytes was set to [64]");
+    }
+
+    @Test
+    void dropBatchStrategyKeepsGoodBatchesAndDropsTheRejectedOne() throws Exception {
+        String table = "table_api_drop_batch";
+        createTableWithParsedDefault(table);
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_drop_batch", table, "id BIGINT NOT NULL, src STRING NOT NULL",
+                ", 'sink.batch-failure-strategy' = 'drop-batch', 'sink.buffer-flush.max-rows' = '1'"));
+        // The server's parse failure (code 6) is data corruption, so the middle batch is dropped.
+        env.executeSql("INSERT INTO ch_drop_batch VALUES (1, '10'), (2, 'not-a-number'), (3, '30')").await();
+
+        List<GenericRecord> rows = readBack("id, parsed", table, "id", 2);
+        Assertions.assertEquals(2, rows.size());
+        Assertions.assertEquals(1L, rows.get(0).getLong("id"));
+        Assertions.assertEquals(10, rows.get(0).getInteger("parsed"));
+        Assertions.assertEquals(3L, rows.get(1).getLong("id"));
+        Assertions.assertEquals(30, rows.get(1).getInteger("parsed"));
+    }
+
+    @Test
+    void stopFlinkStrategyFailsTheJobOnARejectedBatch() throws Exception {
+        String table = "table_api_stop_flink";
+        createTableWithParsedDefault(table);
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_stop_flink", table, "id BIGINT NOT NULL, src STRING NOT NULL",
+                ", 'sink.batch-failure-strategy' = 'stop-flink', 'sink.buffer-flush.max-rows' = '1'"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_stop_flink VALUES (1, '10'), (2, 'not-a-number')").await(),
+                "not-a-number");
+    }
+
+    @Test
+    void ephemeralColumnsAreRejectedAtPlanning() throws Exception {
+        String table = "table_api_ephemeral";
+        createTable(table, "id Int64, payload String EPHEMERAL, norm String DEFAULT lower(payload)");
+
+        TableEnvironment env = tableEnvironment();
+        // The sink's INSERT carries no column list, so a header naming 'payload' would be dropped silently.
+        env.executeSql(sinkDdl("ch_ephemeral", table, "id BIGINT NOT NULL, payload STRING NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_ephemeral VALUES (1, 'X')"),
+                "is EPHEMERAL", "without a column list");
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Rejections: every pair the matrix refuses at planning, and every check it defers to
+    // write time. Both are tables so a rule that stops firing shows up as a named row rather
+    // than as a silently accepted insert.
+    // ------------------------------------------------------------------------------------
+
+    /** Splits the {@code ~}-separated needle cell of the rejection tables below. */
+    private static String[] needles(String cell) {
+        return cell.split("~");
+    }
+
+    /** Fails the row by name rather than by index when a table-driven rejection stops firing. */
+    private static void assertRejectedWith(String description, Executable insert, String... needles) {
+        Exception failure = Assertions.assertThrows(Exception.class, insert, description + " was accepted");
+        for (String needle : needles) {
+            Assertions.assertTrue(exceptionChainContains(failure, needle),
+                    description + ": no '" + needle + "' in " + failure);
+        }
+    }
+
+    /** One ClickHouse column {@code c} of the given type, plus {@code id}; table name per row. */
+    private static String rejectionTable(String prefix, int index, String clickHouseType) throws Exception {
+        String table = String.format("table_api_%s_%02d", prefix, index);
+        createTable(table, "id Int64, c " + clickHouseType);
+        return table;
+    }
+
+    /**
+     * Every pair rejected at planning: the scalar matrix cells, the structural composite rules
+     * (element/key/value/field nullability, Tuple arity and named-Tuple order, unsupported map
+     * keys) and the strict-mapping paths, scalar and nested. The inserted value is always valid —
+     * these fail on the types alone, before a record exists.
+     */
+    @Test
+    void everyRejectedPairFailsAtPlanningWithItsReason() throws Exception {
+        String strict = ", 'sink.strict-numeric-mapping' = 'true'";
+        String[][] pairs = {
+            // ClickHouse type | Flink type of column 'c' | a valid value | options | expected message fragments
+            // --- ClickHouse targets the sink has no write path for
+            {"Enum8('a' = 1, 'b' = 2)", "STRING NOT NULL", "'a'", "",
+             "is not yet supported by the sink~issue #43"},
+            {"Array(SimpleAggregateFunction(sum, Int64))", "ARRAY<BIGINT NOT NULL> NOT NULL",
+             "ARRAY[CAST(1 AS BIGINT)]", "", "SimpleAggregateFunction is only writable as a top-level column"},
+            // --- Decimal: the four ways a Decimal source can fail to fit
+            {"Decimal(10, 2)", "DECIMAL(10, 4) NOT NULL", "CAST('1.2345' AS DECIMAL(10, 4))", "",
+             "Column 'c'~scale 4 exceeds the column's scale 2"},
+            {"Decimal(10, 2)", "DECIMAL(12, 2) NOT NULL", "CAST('1.23' AS DECIMAL(12, 2))", "",
+             "10 integer digits exceed the column's 8 integer digits"},
+            {"Int32", "DECIMAL(9, 2) NOT NULL", "CAST('1.23' AS DECIMAL(9, 2))", "",
+             "only DECIMAL(p, 0) can be written to an integer column"},
+            {"Int32", "DECIMAL(11, 0) NOT NULL", "CAST(1 AS DECIMAL(11, 0))", "",
+             "precision 11 exceeds Int32's 10 digits"},
+            // --- no conversion at all between the two type families
+            {"Bool", "INT NOT NULL", "CAST(1 AS INT)", "", "no supported conversion~for INT NOT NULL: Int8..Int256, UInt8..UInt256"},
+            {"Int64", "BOOLEAN NOT NULL", "TRUE", "", "supported ClickHouse types for BOOLEAN NOT NULL: Bool"},
+            {"String", "DATE NOT NULL", "DATE '2026-01-02'", "", "supported ClickHouse types for DATE NOT NULL: Date, Date32"},
+            {"Date", "TIMESTAMP(3) NOT NULL", "TIMESTAMP '2026-01-02 03:04:05.678'", "",
+             "DateTime, DateTime64(s) with s >= the Flink precision"},
+            // --- nullability, at the column and at every nested position
+            {"Int64", "BIGINT", "CAST(1 AS BIGINT)", "",
+             "Column 'c'~is nullable but ClickHouse column 'c Int64' is not Nullable"},
+            {"Array(Int32)", "ARRAY<INT> NOT NULL", "ARRAY[CAST(1 AS INT)]", "",
+             "the Flink array element type INT is nullable but the ClickHouse element type Int32 is not Nullable"},
+            {"Map(String, Int32)", "MAP<STRING NOT NULL, INT> NOT NULL", "MAP['k', CAST(1 AS INT)]", "",
+             "the Flink map value type INT is nullable but the ClickHouse type Int32 is not Nullable"},
+            {"Tuple(Int32, String)", "ROW<a INT, b STRING NOT NULL> NOT NULL", "ROW(CAST(1 AS INT), 'x')", "",
+             "the Flink ROW field 'a' is nullable but the ClickHouse type Int32 is not Nullable"},
+            // --- composite structure
+            {"Tuple(Int32, String)", "ROW<a INT NOT NULL> NOT NULL", "ROW(CAST(1 AS INT))", "",
+             "ROW has 1 fields but the Tuple has 2 elements"},
+            {"Tuple(a Int32, b String)", "ROW<b INT NOT NULL, a STRING NOT NULL> NOT NULL",
+             "ROW(CAST(1 AS INT), 'x')", "", "bind to Tuple elements by position, but the Tuple names them"},
+            // --- map keys are checkpointed as strings, so only types that parse back are allowed
+            {"Map(UInt64, String)", "MAP<DECIMAL(20, 0) NOT NULL, STRING NOT NULL> NOT NULL",
+             "MAP[CAST(1 AS DECIMAL(20, 0)), 'v']", "",
+             "Map keys of type UInt64 are not supported~use an Int64 or UInt128 key column instead"},
+            {"Map(UUID, String)", "MAP<STRING NOT NULL, STRING NOT NULL> NOT NULL", "MAP['k', 'v']", "",
+             "Map key type UUID is not supported~cannot be restored from a string"},
+            // --- strict numeric mapping, on each path that would otherwise range-check per record
+            {"UInt32", "BIGINT NOT NULL", "CAST(1 AS BIGINT)", strict,
+             "Column 'c'~UInt32 range~'sink.strict-numeric-mapping'"},
+            {"Int32", "DECIMAL(10, 0) NOT NULL", "CAST(1 AS DECIMAL(10, 0))", strict,
+             "Column 'c'~Int32 range~'sink.strict-numeric-mapping'"},
+            {"Array(UInt64)", "ARRAY<BIGINT NOT NULL> NOT NULL", "ARRAY[CAST(1 AS BIGINT)]", strict,
+             "Column 'c'~array element~UInt64 range~'sink.strict-numeric-mapping'"},
+            {"Map(String, UInt32)", "MAP<STRING NOT NULL, BIGINT NOT NULL> NOT NULL",
+             "MAP['k', CAST(1 AS BIGINT)]", strict, "Column 'c'~map value~UInt32 range~'sink.strict-numeric-mapping'"},
+            {"Tuple(a UInt8, b String)", "ROW<a BIGINT NOT NULL, b STRING NOT NULL> NOT NULL",
+             "ROW(CAST(1 AS BIGINT), 'x')", strict, "Column 'c'~ROW field 'a'~UInt8 range~'sink.strict-numeric-mapping'"},
+        };
+
+        TableEnvironment env = tableEnvironment();
+        for (int i = 0; i < pairs.length; i++) {
+            String table = rejectionTable("reject", i, pairs[i][0]);
+            String flinkTable = "ch_reject_pair_" + i;
+            String value = pairs[i][2];
+            env.executeSql(sinkDdl(flinkTable, table, "id BIGINT NOT NULL, c " + pairs[i][1], pairs[i][3]));
+
+            String description = pairs[i][0] + " <- " + pairs[i][1] + pairs[i][3];
+            assertRejectedWith(description,
+                    () -> env.executeSql("INSERT INTO " + flinkTable + " VALUES (1, " + value + ")"),
+                    needles(pairs[i][4]));
+        }
+    }
+
+    /** Flink SQL has no MULTISET literal, so this one pair needs COLLECT rather than the table above. */
+    @Test
+    void multisetIntoANonUInt64MapValueIsRejectedAtPlanning() throws Exception {
+        String table = "table_api_multiset_reject";
+        createTable(table, "id Int64, tags Map(String, Int64)");
+
+        TableEnvironment env = TableEnvironment.create(EnvironmentSettings.inBatchMode());
+        env.executeSql(sinkDdl("ch_multiset_reject", table,
+                "id BIGINT NOT NULL, tags MULTISET<STRING NOT NULL> NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_multiset_reject "
+                        + "SELECT CAST(id AS BIGINT), COLLECT(CAST(tag AS STRING)) "
+                        + "FROM (VALUES (1, 'a')) AS t(id, tag) GROUP BY id"),
+                "Column 'tags'", "MULTISET counts require a Map value type of exactly UInt64, found Int64");
+    }
+
+    /**
+     * Every check the sink defers to write time, at one step past the bound: the value the types
+     * alone cannot rule out fails per record, naming the column — and, inside a composite, the
+     * path within it ({@code c element}, {@code c value}, {@code c.a}).
+     */
+    @Test
+    void everyDeferredValueCheckFailsPerRecordNamingItsPath() throws Exception {
+        String[][] cases = {
+            // ClickHouse column type | Flink type of 'c' | out-of-range value | expected message fragments
+            {"Date", "DATE NOT NULL", "DATE '1969-12-31'",
+             "Column 'c': DATE value 1969-12-31 is outside the ClickHouse Date range"},
+            {"DateTime", "TIMESTAMP(0) NOT NULL", "TIMESTAMP '2106-02-07 06:28:16'",
+             "Column 'c'~is outside the ClickHouse DateTime range"},
+            {"DateTime64(3)", "TIMESTAMP(3) NOT NULL", "TIMESTAMP '1899-12-31 23:59:59.999'",
+             "Column 'c'~is outside the ClickHouse DateTime64 range"},
+            {"UInt8", "BIGINT NOT NULL", "CAST(256 AS BIGINT)", "Column 'c': value 256 is outside the UInt8 range"},
+            {"UInt64", "DECIMAL(20, 0) NOT NULL", "CAST('-1' AS DECIMAL(20, 0))",
+             "Column 'c': value -1 is negative and cannot be written to the unsigned type UInt64"},
+            {"Int32", "DECIMAL(10, 0) NOT NULL", "CAST(2147483648 AS DECIMAL(10, 0))",
+             "Column 'c': value 2147483648 is outside the Int32 range"},
+            {"FixedString(2)", "STRING NOT NULL", "'abc'", "Column 'c': value of 3 bytes does not fit FixedString(2)"},
+            {"UUID", "STRING NOT NULL", "'not-a-uuid'", "Column 'c': value is not a valid UUID: not-a-uuid"},
+            // the same checks, reached through each composite position
+            {"Array(UInt64)", "ARRAY<BIGINT NOT NULL> NOT NULL", "ARRAY[CAST(-1 AS BIGINT)]",
+             "Column 'c element': value -1 is outside the UInt64 range"},
+            {"Array(FixedString(2))", "ARRAY<STRING NOT NULL> NOT NULL", "ARRAY['abc']",
+             "Column 'c element': value of 3 bytes does not fit FixedString(2)"},
+            {"Map(String, UInt32)", "MAP<STRING NOT NULL, BIGINT NOT NULL> NOT NULL", "MAP['k', CAST(-1 AS BIGINT)]",
+             "Column 'c value': value -1 is outside the UInt32 range"},
+            {"Tuple(a UInt8, b String)", "ROW<a BIGINT NOT NULL, b STRING NOT NULL> NOT NULL",
+             "ROW(CAST(256 AS BIGINT), 'x')", "Column 'c.a': value 256 is outside the UInt8 range"},
+            // nulls the header cannot encode inside a composite
+            {"Map(String, Int32)", "MAP<STRING NOT NULL, INT NOT NULL> NOT NULL", "MAP['k', CAST(NULL AS INT)]",
+             "Column 'c': null map value cannot be written to a non-Nullable ClickHouse Map value type"},
+            {"Map(String, Int32)", "MAP<STRING NOT NULL, INT NOT NULL> NOT NULL", "MAP[CAST(NULL AS STRING), 1]",
+             "Column 'c': null map key cannot be written to ClickHouse"},
+        };
+
+        TableEnvironment env = tableEnvironment();
+        for (int i = 0; i < cases.length; i++) {
+            String table = rejectionTable("value_check", i, cases[i][0]);
+            String flinkTable = "ch_value_check_" + i;
+            String value = cases[i][2];
+            env.executeSql(sinkDdl(flinkTable, table, "id BIGINT NOT NULL, c " + cases[i][1]));
+
+            String description = cases[i][0] + " <- " + cases[i][1] + " value " + value;
+            assertRejectedWith(description,
+                    () -> env.executeSql("INSERT INTO " + flinkTable + " VALUES (1, " + value + ")").await(),
+                    needles(cases[i][3]));
+            // The check runs in the sink, so the statement planned and nothing reached the table.
+            Assertions.assertEquals(0, readBack("id", table, "id", 0).size(), description + " wrote a row");
+        }
+    }
+
+    /** The payload map reserves one key name; a sink column colliding with it is refused up front. */
+    @Test
+    void reservedPayloadKeyColumnIsRejectedAtPlanning() throws Exception {
+        String table = "table_api_reserved_key";
+        createTable(table, "id Int64, `__clickhouse_raw__` String");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_reserved_key", table,
+                "id BIGINT NOT NULL, `__clickhouse_raw__` STRING NOT NULL"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_reserved_key VALUES (1, 'x')"),
+                "collides with the connector's reserved payload key");
+    }
+
+    /** Dropping every unknown column leaves nothing to insert, which is a schema error, not an empty write. */
+    @Test
+    void ignoringEveryFlinkColumnLeavesNothingToInsert() throws Exception {
+        String table = "table_api_nothing_to_insert";
+        createTable(table, "id Int64");
+
+        TableEnvironment env = tableEnvironment();
+        env.executeSql(sinkDdl("ch_nothing", table, "nickname STRING NOT NULL",
+                ", 'sink.ignore-unknown-flink-columns' = 'true'"));
+
+        assertFailsWith(() -> env.executeSql("INSERT INTO ch_nothing VALUES ('nick')"),
+                "None of the Flink schema columns map to ClickHouse table", "nothing to insert");
+    }
+
+    /**
+     * Read-back after {@code await()}. On Cloud the replica answering the SELECT may not yet see the
+     * acknowledged insert, so poll (bounded) until the expected row count shows up; one read elsewhere.
+     */
+    private static List<GenericRecord> readBack(String columns, String table, String orderBy, int expectedRows)
+            throws Exception {
+        int attempts = ClickHouseServerForTests.isCloud() ? 30 : 1;
+        List<GenericRecord> rows = ClickHouseServerForTests.extractData(
+                columns, ClickHouseServerForTests.getDatabase(), table, orderBy);
+        for (int i = 1; i < attempts && rows.size() != expectedRows; i++) {
+            Thread.sleep(1000);
+            rows = ClickHouseServerForTests.extractData(
+                    columns, ClickHouseServerForTests.getDatabase(), table, orderBy);
+        }
+        return rows;
+    }
+
+    /** Finished INSERTs into {@code table} whose query_log row recorded {@code setting = value}. */
+    private static long insertsRecordedWithSetting(String table, String setting, String value) throws Exception {
+        return finishedInserts(table, String.format(" AND Settings['%s'] = '%s'", setting, value), 1);
+    }
+
+    /**
+     * Finished INSERTs into {@code table} matching {@code extraWhere}, polled (bounded) until at
+     * least {@code atLeast} are visible — query_log lands asynchronously, and later on Cloud.
+     */
+    private static long finishedInserts(String table, String extraWhere, long atLeast) throws Exception {
+        boolean cloud = ClickHouseServerForTests.isCloud();
+        ClickHouseServerForTests.executeSql(cloud ? "SYSTEM FLUSH LOGS ON CLUSTER 'default'" : "SYSTEM FLUSH LOGS");
+        String sql = "SELECT count() FROM " + finishedInsertsInto(table) + extraWhere;
+        try (Client client = fixtureClient()) {
+            long count = client.queryAll(sql).get(0).getLong(1);
+            for (int i = 1; i < (cloud ? 30 : 5) && count < atLeast; i++) {
+                Thread.sleep(1000);
+                count = client.queryAll(sql).get(0).getLong(1);
+            }
+            return count;
+        }
+    }
+
+    /** Pairs of finished INSERTs into {@code table} where the later one started before the earlier one finished. */
+    private static long overlappingInserts(String table) throws Exception {
+        String sql = String.format(
+                "SELECT count() FROM (SELECT query_start_time_microseconds AS s, event_time_microseconds AS e "
+                        + "FROM %1$s) AS a, (SELECT query_start_time_microseconds AS s FROM %1$s) AS b "
+                        + "WHERE a.s < b.s AND b.s < a.e",
+                finishedInsertsInto(table));
+        try (Client client = fixtureClient()) {
+            return client.queryAll(sql).get(0).getLong(1);
+        }
+    }
+
+    private static String finishedInsertsInto(String table) {
+        return String.format(
+                "clusterAllReplicas('default', system.query_log) WHERE type = 'QueryFinish' "
+                        + "AND query_kind = 'Insert' AND has(tables, '%s.%s')",
+                ClickHouseServerForTests.getDatabase(), table);
+    }
+
+    /** The client the fixture itself uses: 60 s connect timeout, TLS exactly when on Cloud. */
+    private static Client fixtureClient() {
+        return ClickHouseTestHelpers.getClient(
+                ClickHouseServerForTests.getHost(), ClickHouseServerForTests.getPort(),
+                ClickHouseServerForTests.isCloud(),
+                ClickHouseServerForTests.getUsername(), ClickHouseServerForTests.getPassword());
+    }
+
+    /** Only the server's own "JSON type unavailable" answers: an experimental gate (24.x spells it Object('json')) or an unknown type. */
+    private static boolean lacksJsonType(Throwable t) {
+        return ExceptionUtils.findThrowable(t, ServerException.class)
+                .map(e -> e.getMessage().toLowerCase(Locale.ROOT))
+                .filter(m -> m.contains("json") && (m.contains("not allowed") || m.contains("unknown data type")))
+                .isPresent();
+    }
+
+    private static boolean exceptionChainContains(Throwable t, String needle) {
+        return ExceptionUtils.findThrowableWithMessage(t, needle).isPresent();
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseConnectorOptions.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/ClickHouseConnectorOptions.java
@@ -1,0 +1,159 @@
+package org.apache.flink.connector.clickhouse.table;
+
+import com.clickhouse.config.BatchFailureStrategy;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.MemorySize;
+import org.apache.flink.connector.clickhouse.sink.ClickHouseSinkDefaults;
+
+import java.time.Duration;
+import java.util.Locale;
+
+/**
+ * The {@code WITH (...)} options of the {@code 'connector' = 'clickhouse'} SQL sink.
+ *
+ * <p>Keys follow the ecosystem convention ({@code sink.buffer-flush.*}, {@code sink.max-retries});
+ * defaults are identical to {@code ClickHouseAsyncSinkBuilder}/{@code ClickHouseClientConfig},
+ * so SQL and DataStream behave the same. {@code clickhouse.client.<key>} and
+ * {@code clickhouse.server.<key>} are prefix-scanned passthroughs, not enumerated here.
+ */
+public final class ClickHouseConnectorOptions {
+
+    private ClickHouseConnectorOptions() {}
+
+    // ------------------------------------------------------------------------------------
+    // Connection (required; password defaults to '')
+    // ------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> URL = ConfigOptions
+            .key("url")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("ClickHouse HTTP(S) endpoint, e.g. 'http://localhost:8123'.");
+
+    public static final ConfigOption<String> USERNAME = ConfigOptions
+            .key("username")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("ClickHouse user.");
+
+    public static final ConfigOption<String> PASSWORD = ConfigOptions
+            .key("password")
+            .stringType()
+            .defaultValue("")
+            .withDescription("ClickHouse password. Stored verbatim in the catalog table's "
+                    + "options: SHOW CREATE TABLE prints it in cleartext and COMPILE PLAN "
+                    + "embeds it in the plan file unless 'table.plan.compile.catalog-objects' "
+                    + "is lowered from its default 'ALL'.");
+
+    public static final ConfigOption<String> DATABASE = ConfigOptions
+            .key("database")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Target ClickHouse database.");
+
+    public static final ConfigOption<String> TABLE = ConfigOptions
+            .key("table")
+            .stringType()
+            .noDefaultValue()
+            .withDescription("Target ClickHouse table.");
+
+    // ------------------------------------------------------------------------------------
+    // Batching / backpressure
+    // ------------------------------------------------------------------------------------
+
+    public static final ConfigOption<Integer> SINK_BUFFER_FLUSH_MAX_ROWS = ConfigOptions
+            .key("sink.buffer-flush.max-rows")
+            .intType()
+            .defaultValue(ClickHouseSinkDefaults.MAX_BATCH_SIZE)
+            .withDescription("Rows buffered per insert batch before a flush is triggered.");
+
+    public static final ConfigOption<MemorySize> SINK_BUFFER_FLUSH_MAX_BYTES = ConfigOptions
+            .key("sink.buffer-flush.max-bytes")
+            .memoryType()
+            .defaultValue(new MemorySize(ClickHouseSinkDefaults.MAX_BATCH_SIZE_IN_BYTES))
+            .withDescription("Bytes buffered per insert batch before a flush is triggered.");
+
+    public static final ConfigOption<Duration> SINK_BUFFER_FLUSH_INTERVAL = ConfigOptions
+            .key("sink.buffer-flush.interval")
+            .durationType()
+            .defaultValue(Duration.ofMillis(ClickHouseSinkDefaults.MAX_TIME_IN_BUFFER_MS))
+            .withDescription("Longest time a record may sit in the buffer before a flush.");
+
+    public static final ConfigOption<Integer> SINK_MAX_IN_FLIGHT_REQUESTS = ConfigOptions
+            .key("sink.max-in-flight-requests")
+            .intType()
+            .defaultValue(ClickHouseSinkDefaults.MAX_IN_FLIGHT_REQUESTS)
+            .withDescription("Maximum concurrent in-flight insert requests.");
+
+    public static final ConfigOption<Integer> SINK_MAX_BUFFERED_REQUESTS = ConfigOptions
+            .key("sink.max-buffered-requests")
+            .intType()
+            .defaultValue(ClickHouseSinkDefaults.MAX_BUFFERED_REQUESTS)
+            .withDescription("Maximum buffered records before backpressure kicks in.");
+
+    public static final ConfigOption<MemorySize> SINK_RECORD_MAX_BYTES = ConfigOptions
+            .key("sink.record.max-bytes")
+            .memoryType()
+            .defaultValue(new MemorySize(ClickHouseSinkDefaults.MAX_RECORD_SIZE_IN_BYTES))
+            .withDescription("Maximum serialized size of a single record.");
+
+    // sink.parallelism is FactoryUtil.SINK_PARALLELISM — validated via the factory helper.
+
+    // ------------------------------------------------------------------------------------
+    // Reliability
+    // ------------------------------------------------------------------------------------
+
+    /** The one negative {@code sink.max-retries} value: unlimited retries, DataStream's default. */
+    public static final int MAX_RETRIES_UNLIMITED = -1;
+
+    public static final ConfigOption<Integer> SINK_MAX_RETRIES = ConfigOptions
+            .key("sink.max-retries")
+            .intType()
+            .defaultValue(MAX_RETRIES_UNLIMITED)
+            .withDescription("Retries per failed batch; -1 retries forever.");
+
+    public static final ConfigOption<String> SINK_BATCH_FAILURE_STRATEGY = ConfigOptions
+            .key("sink.batch-failure-strategy")
+            .stringType()
+            // Derived from the DataStream default enum so the documented parity cannot drift.
+            .defaultValue(BatchFailureStrategy.STOP_FLINK.name().toLowerCase(Locale.ROOT).replace('_', '-'))
+            .withDescription("What to do when a batch fails non-retriably: 'stop-flink' or 'drop-batch'.");
+
+    // ------------------------------------------------------------------------------------
+    // Type / compatibility
+    // ------------------------------------------------------------------------------------
+
+    public static final ConfigOption<String> SINK_TIMEZONE = ConfigOptions
+            .key("sink.timezone")
+            .stringType()
+            .defaultValue("UTC")
+            .withDescription("Zone in which TIMESTAMP (no time zone) wall-clock values are interpreted. "
+                    + "In a DST-observing zone, wall clocks inside a spring-forward gap are shifted "
+                    + "forward by the gap length, and ambiguous fall-back wall clocks resolve to the "
+                    + "earlier (pre-transition) offset.");
+
+    public static final ConfigOption<Boolean> SINK_IGNORE_UNKNOWN_FLINK_COLUMNS = ConfigOptions
+            .key("sink.ignore-unknown-flink-columns")
+            .booleanType()
+            .defaultValue(false)
+            .withDescription("Drop Flink columns absent from the ClickHouse table instead of failing.");
+
+    public static final ConfigOption<Boolean> SINK_STRICT_NUMERIC_MAPPING = ConfigOptions
+            .key("sink.strict-numeric-mapping")
+            .booleanType()
+            .defaultValue(false)
+            .withDescription("Reject at planning every numeric Flink/ClickHouse type pair whose values may not all fit "
+                    + "the column, instead of range-checking each value at write time. Lossless widening stays allowed.");
+
+    // ------------------------------------------------------------------------------------
+    // Passthrough prefixes (prefix-scanned, not enumerated)
+    // ------------------------------------------------------------------------------------
+
+    /** {@code clickhouse.client.<key>} → client-v2 {@code ClientConfigProperties} options. */
+    public static final String CLIENT_OPTIONS_PREFIX = "clickhouse.client.";
+
+    /** {@code clickhouse.server.<key>} → per-query ClickHouse server settings. */
+    public static final String SERVER_SETTINGS_PREFIX = "clickhouse.server.";
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/data/FieldAccessor.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/data/FieldAccessor.java
@@ -1,0 +1,34 @@
+package org.apache.flink.connector.clickhouse.table.data;
+
+import org.apache.flink.table.data.RowData;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+/**
+ * Serializable pair of a positional {@link RowData.FieldGetter} and a {@link ValueConverter}:
+ * reads one field of a {@link RowData} and converts it to the plain Java value its ClickHouse
+ * column expects. A {@code null} field stays {@code null} — schema resolution has already
+ * guaranteed the target column is {@code Nullable}.
+ */
+public final class FieldAccessor implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private final RowData.FieldGetter fieldGetter;
+    private final ValueConverter converter;
+
+    private FieldAccessor(RowData.FieldGetter fieldGetter, ValueConverter converter) {
+        this.fieldGetter = Objects.requireNonNull(fieldGetter, "fieldGetter");
+        this.converter = Objects.requireNonNull(converter, "converter");
+    }
+
+    public static FieldAccessor of(RowData.FieldGetter fieldGetter, ValueConverter converter) {
+        return new FieldAccessor(fieldGetter, converter);
+    }
+
+    /** Extracts the field's plain Java value from the row, or {@code null}. */
+    public Object get(RowData row) {
+        Object value = fieldGetter.getFieldOrNull(row);
+        return value == null ? null : converter.convert(value);
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/data/RowDataDataMapper.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/data/RowDataDataMapper.java
@@ -1,0 +1,67 @@
+package org.apache.flink.connector.clickhouse.table.data;
+
+import com.clickhouse.data.ClickHouseColumn;
+
+import org.apache.flink.connector.clickhouse.convertor.ColumnBinding;
+import org.apache.flink.connector.clickhouse.convertor.DataMapper;
+import org.apache.flink.connector.clickhouse.table.schema.ResolvedColumnMapping;
+import org.apache.flink.table.data.RowData;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The SQL path's {@link DataMapper}: puts one TypeTags-legal Java value per resolved column into
+ * the payload map, keyed by ClickHouse column name, leaving the state format untouched.
+ *
+ * <p>{@code ClickHouseColumn} has no serialization contract, so the mapper ships
+ * {@code (columnName, typeExpression)} string pairs and {@link #bindings()} re-parses them on
+ * the TaskManager.
+ */
+public class RowDataDataMapper extends DataMapper<RowData> {
+    private static final long serialVersionUID = 1L;
+
+    private final String[] columnNames;
+    private final String[] typeExpressions;
+    private final FieldAccessor[] accessors;
+
+    private RowDataDataMapper(String[] columnNames, String[] typeExpressions,
+                              FieldAccessor[] accessors) {
+        this.columnNames = columnNames;
+        this.typeExpressions = typeExpressions;
+        this.accessors = accessors;
+    }
+
+    /** Builds the mapper from the planning-time schema resolution result. */
+    public static RowDataDataMapper of(List<ResolvedColumnMapping> mappings) {
+        String[] columnNames = new String[mappings.size()];
+        String[] typeExpressions = new String[mappings.size()];
+        FieldAccessor[] accessors = new FieldAccessor[mappings.size()];
+        for (int i = 0; i < mappings.size(); i++) {
+            ResolvedColumnMapping mapping = mappings.get(i);
+            columnNames[i] = mapping.columnName();
+            typeExpressions[i] = mapping.typeExpression();
+            accessors[i] = mapping.accessor;
+        }
+        return new RowDataDataMapper(columnNames, typeExpressions, accessors);
+    }
+
+    @Override
+    public void toMap(RowData row, Map<String, Object> map) {
+        for (int i = 0; i < columnNames.length; i++) {
+            map.put(columnNames[i], accessors[i].get(row));
+        }
+    }
+
+    @Override
+    public List<ColumnBinding> bindings() {
+        List<ColumnBinding> bindings = new ArrayList<>(columnNames.length);
+        for (int i = 0; i < columnNames.length; i++) {
+            bindings.add(ColumnBinding.of(
+                    columnNames[i], columnNames[i],
+                    ClickHouseColumn.of(columnNames[i], typeExpressions[i])));
+        }
+        return bindings;
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/data/ValueConverter.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/data/ValueConverter.java
@@ -1,0 +1,20 @@
+package org.apache.flink.connector.clickhouse.table.data;
+
+import java.io.Serializable;
+
+/**
+ * Converts one non-null Flink-internal value ({@code StringData}, {@code DecimalData}, …) into
+ * the plain, TypeTags-legal Java value the payload {@code Map} carries. Chosen at planning time
+ * per (Flink {@code LogicalType}, {@code ClickHouseColumn}) pair, because the same Flink value
+ * converts differently per target: {@code StringData} → {@code String} for a {@code String}
+ * column, {@code java.util.UUID} for a {@code UUID} column.
+ *
+ * <p>Shipped to TaskManagers, so implementations may only capture serializable,
+ * Flink-version-stable state — never a {@code ClickHouseColumn}.
+ */
+@FunctionalInterface
+public interface ValueConverter extends Serializable {
+
+    /** Converts a non-null Flink-internal value; never invoked with {@code null}. */
+    Object convert(Object value);
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/ClickHouseTypeMapper.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/ClickHouseTypeMapper.java
@@ -1,0 +1,993 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+
+import org.apache.flink.connector.clickhouse.table.data.ValueConverter;
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import static com.clickhouse.utils.writer.DataWriter.unwrapSimpleAggregateFunction;
+
+/**
+ * The (Flink {@code LogicalType}, {@code ClickHouseColumn}) compatibility matrix of the
+ * Table API sink: returns the {@link ValueConverter} that turns a Flink-internal value into
+ * the plain Java value {@code DataWriter} expects, or throws a {@link TypeMappingException}
+ * saying why the pair is rejected.
+ *
+ * <p>Lossless widening is implicit; a pair that would round a value ({@code DOUBLE} into
+ * {@code Float32}, a narrower Decimal scale or timestamp precision) is rejected at planning. A pair
+ * whose values may not all fit the column — a narrower or unsigned integer, {@code DECIMAL(p,0)} at an
+ * integer's digit boundary, the {@code Date}/{@code DateTime} ranges, {@code FixedString} lengths, UUID
+ * text — is checked per record naming the column (the client's writer would fail without it or, for
+ * UInt64 inside composites, wrap the value silently). Under {@code sink.strict-numeric-mapping} the
+ * numeric pairs, which have a wider column to switch to, are rejected at planning instead.
+ *
+ * <p>{@code build*Converter} methods run once per column at planning time; {@code toPayload*}
+ * methods run per record on the TaskManager. Wrapper shedding is shared with the write path
+ * (DataWriter#unwrapSimpleAggregateFunction).
+ */
+public final class ClickHouseTypeMapper {
+
+    /** One matrix row: maps a pair to a converter or throws {@link TypeMappingException}. */
+    @FunctionalInterface
+    private interface TypeMappingRule {
+        ValueConverter apply(LogicalType flinkType, ClickHouseColumn target, TypeMappingOptions options, String columnPathText);
+    }
+
+    /** ClickHouse types the sink can write, after unwrapping transparent wrappers. */
+    // Package-private so the DataWriter cross-check test can pin it against the real dispatch.
+    static final Set<ClickHouseDataType> WRITABLE_TARGETS = EnumSet.of(
+            ClickHouseDataType.Bool,
+            ClickHouseDataType.Int8, ClickHouseDataType.Int16, ClickHouseDataType.Int32,
+            ClickHouseDataType.Int64, ClickHouseDataType.Int128, ClickHouseDataType.Int256,
+            ClickHouseDataType.UInt8, ClickHouseDataType.UInt16, ClickHouseDataType.UInt32,
+            ClickHouseDataType.UInt64, ClickHouseDataType.UInt128, ClickHouseDataType.UInt256,
+            ClickHouseDataType.Float32, ClickHouseDataType.Float64,
+            ClickHouseDataType.Decimal, ClickHouseDataType.Decimal32, ClickHouseDataType.Decimal64,
+            ClickHouseDataType.Decimal128, ClickHouseDataType.Decimal256,
+            ClickHouseDataType.String, ClickHouseDataType.FixedString,
+            ClickHouseDataType.UUID, ClickHouseDataType.JSON,
+            ClickHouseDataType.Date, ClickHouseDataType.Date32,
+            ClickHouseDataType.DateTime, ClickHouseDataType.DateTime64,
+            ClickHouseDataType.Array, ClickHouseDataType.Map, ClickHouseDataType.Tuple);
+
+    /**
+     * Map key types the sink supports: keys are checkpointed as strings (the state format
+     * requires string map keys) and only these types parse back from a string in the
+     * client's serializer (integers via parse*, Decimals via new BigDecimal(String)). UInt64
+     * is absent because client-v2's SerializerUtils hardcodes Long.parseLong for it, so keys
+     * above 2^63-1 fail.
+     */
+    private static final Set<ClickHouseDataType> STRING_RESTORABLE_MAP_KEY_TARGETS = EnumSet.of(
+            ClickHouseDataType.String, ClickHouseDataType.FixedString,
+            ClickHouseDataType.Int8, ClickHouseDataType.Int16, ClickHouseDataType.Int32,
+            ClickHouseDataType.Int64, ClickHouseDataType.Int128, ClickHouseDataType.Int256,
+            ClickHouseDataType.UInt8, ClickHouseDataType.UInt16, ClickHouseDataType.UInt32,
+            ClickHouseDataType.UInt128, ClickHouseDataType.UInt256,
+            ClickHouseDataType.Decimal, ClickHouseDataType.Decimal32, ClickHouseDataType.Decimal64,
+            ClickHouseDataType.Decimal128, ClickHouseDataType.Decimal256);
+
+    // Literal because the client's copies live in deprecated BinaryStreamUtils; DataWriterContractTest pins them.
+
+    static final int UINT8_MAX = 0xFF;
+    static final int UINT16_MAX = 0xFFFF;
+    static final long UINT32_MAX = 0xFFFFFFFFL;
+
+    /** The largest UInt64 itself — 20 digits admit values above it, so writes re-check. */
+    static final BigInteger UINT64_MAX = BigInteger.ONE.shiftLeft(64).subtract(BigInteger.ONE);
+
+    /** ClickHouse {@code Date} is UInt16 epoch days, so 2149-06-06 is its last day. */
+    static final int DATE_MAX_EPOCH_DAY = UINT16_MAX;
+
+    /** ClickHouse {@code Date32} covers 1900-01-01..2299-12-31, as signed epoch days. */
+    static final int DATE32_MIN_EPOCH_DAY = (int) LocalDate.of(1900, 1, 1).toEpochDay();
+    static final int DATE32_MAX_EPOCH_DAY = (int) LocalDate.of(2299, 12, 31).toEpochDay();
+
+    /** ClickHouse {@code DateTime} is UInt32 epoch seconds, ending 2106-02-07T06:28:15Z. */
+    static final long DATETIME_MAX_EPOCH_SECOND = UINT32_MAX;
+
+    /** ClickHouse {@code DateTime64} covers 1900-01-01T00:00:00Z..2299-12-31T23:59:59Z. */
+    static final long DATETIME64_MIN_EPOCH_SECOND =
+            LocalDate.of(1900, 1, 1).atStartOfDay().toEpochSecond(ZoneOffset.UTC);
+    static final long DATETIME64_MAX_EPOCH_SECOND =
+            LocalDate.of(2299, 12, 31).atTime(23, 59, 59).toEpochSecond(ZoneOffset.UTC);
+
+    private static final Map<LogicalTypeRoot, TypeMappingRule> RULES = buildRules();
+
+    private ClickHouseTypeMapper() {}
+
+    // ------------------------------------------------------------------------------------
+    // Entry points
+    // ------------------------------------------------------------------------------------
+
+    /**
+     * Returns the converter for one column pair, or throws {@link TypeMappingException}.
+     *
+     * @param flinkType    the Flink column/field type
+     * @param column       the introspected ClickHouse column (wrappers still attached)
+     * @param options      sink time zone for {@code TIMESTAMP} wall clocks, and the strictness
+     * @param columnPathText column path for runtime error messages (e.g. {@code "props value"})
+     */
+    public static ValueConverter converterFor(LogicalType flinkType, ClickHouseColumn column,
+                                              TypeMappingOptions options, String columnPathText) {
+        ClickHouseColumn target = unwrapSimpleAggregateFunction(column);
+        checkTargetWritable(target);
+        TypeMappingRule rule = RULES.get(flinkType.getTypeRoot());
+        if (rule == null) {
+            // Only reachable on a Flink generation newer than this build's type-root set.
+            throw TypeMappingException.mismatch(
+                    "Flink type root " + flinkType.getTypeRoot() + " is unknown to this connector build");
+        }
+        return rule.apply(flinkType, target, options, columnPathText);
+    }
+
+    /** Roots the matrix covers — the guard test asserts this equals all of {@link LogicalTypeRoot}. */
+    public static Set<LogicalTypeRoot> registeredRoots() {
+        return Collections.unmodifiableSet(RULES.keySet());
+    }
+
+    // ------------------------------------------------------------------------------------
+    // ClickHouse-side whitelist
+    // ------------------------------------------------------------------------------------
+
+    private static void checkTargetWritable(ClickHouseColumn target) {
+        ClickHouseDataType type = target.getDataType();
+        if (WRITABLE_TARGETS.contains(type)) {
+            return;
+        }
+        throw TypeMappingException.targetUnsupported(unsupportedTargetReason(type));
+    }
+
+    private static String unsupportedTargetReason(ClickHouseDataType type) {
+        switch (type) {
+            case Enum8:
+            case Enum16:
+                return "see issue #43";
+            case Variant:
+                return "see issue #60";
+            case Time:
+            case Time64:
+                return "see issue #91";
+            default:
+                return "no write path and no unambiguous Flink counterpart";
+        }
+    }
+
+    /**
+     * The client serializer can wire-encode SimpleAggregateFunction only as a top-level column;
+     * inside a composite it has no case for it and every record would fail on the TaskManager.
+     */
+    private static ClickHouseColumn rejectNestedSimpleAggregateFunction(ClickHouseColumn column,
+                                                                        String position) {
+        if (column.getDataType() == ClickHouseDataType.SimpleAggregateFunction) {
+            throw TypeMappingException.targetUnsupported(String.format(
+                    "SimpleAggregateFunction is only writable as a top-level column; found as %s",
+                    position));
+        }
+        return column;
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Matrix registration — one entry per LogicalTypeRoot
+    // ------------------------------------------------------------------------------------
+
+    private static Map<LogicalTypeRoot, TypeMappingRule> buildRules() {
+        Map<LogicalTypeRoot, TypeMappingRule> rules = new EnumMap<>(LogicalTypeRoot.class);
+
+        rules.put(LogicalTypeRoot.BOOLEAN, ClickHouseTypeMapper::buildBooleanConverter);
+        rules.put(LogicalTypeRoot.TINYINT, ClickHouseTypeMapper::buildIntegerConverter);
+        rules.put(LogicalTypeRoot.SMALLINT, ClickHouseTypeMapper::buildIntegerConverter);
+        rules.put(LogicalTypeRoot.INTEGER, ClickHouseTypeMapper::buildIntegerConverter);
+        rules.put(LogicalTypeRoot.BIGINT, ClickHouseTypeMapper::buildIntegerConverter);
+        rules.put(LogicalTypeRoot.DECIMAL, ClickHouseTypeMapper::buildDecimalConverter);
+        rules.put(LogicalTypeRoot.FLOAT, ClickHouseTypeMapper::buildFloatingPointConverter);
+        rules.put(LogicalTypeRoot.DOUBLE, ClickHouseTypeMapper::buildFloatingPointConverter);
+        rules.put(LogicalTypeRoot.CHAR, ClickHouseTypeMapper::buildStringConverter);
+        rules.put(LogicalTypeRoot.VARCHAR, ClickHouseTypeMapper::buildStringConverter);
+        rules.put(LogicalTypeRoot.DATE, ClickHouseTypeMapper::buildDateConverter);
+        rules.put(LogicalTypeRoot.TIMESTAMP_WITHOUT_TIME_ZONE, ClickHouseTypeMapper::buildTimestampConverter);
+        rules.put(LogicalTypeRoot.TIMESTAMP_WITH_LOCAL_TIME_ZONE, ClickHouseTypeMapper::buildTimestampLtzConverter);
+        rules.put(LogicalTypeRoot.ARRAY, ClickHouseTypeMapper::buildArrayConverter);
+        rules.put(LogicalTypeRoot.MAP, ClickHouseTypeMapper::buildMapConverter);
+        rules.put(LogicalTypeRoot.MULTISET, ClickHouseTypeMapper::buildMultisetConverter);
+        rules.put(LogicalTypeRoot.ROW, ClickHouseTypeMapper::buildRowConverter);
+
+        rules.put(LogicalTypeRoot.BINARY, rejected(
+                "the sink does not yet support binary types (DataWriter lacks a byte[] write path)"));
+        rules.put(LogicalTypeRoot.VARBINARY, rejected(
+                "the sink does not yet support binary types (DataWriter lacks a byte[] write path)"));
+        rules.put(LogicalTypeRoot.TIME_WITHOUT_TIME_ZONE, rejected(
+                "ClickHouse Time/Time64 are still experimental and the sink has no write path yet (see issue #91)"));
+        rules.put(LogicalTypeRoot.TIMESTAMP_WITH_TIME_ZONE, rejected(
+                "TIMESTAMP WITH TIME ZONE is not supported — use TIMESTAMP or TIMESTAMP_LTZ"));
+        rules.put(LogicalTypeRoot.INTERVAL_YEAR_MONTH, rejected(
+                "INTERVAL cannot be a ClickHouse table column"));
+        rules.put(LogicalTypeRoot.INTERVAL_DAY_TIME, rejected(
+                "INTERVAL cannot be a ClickHouse table column"));
+        rules.put(LogicalTypeRoot.NULL, rejected(
+                "the NULL type is a planner artifact — CAST the value to a real type"));
+        rules.put(LogicalTypeRoot.SYMBOL, rejected(
+                "the SYMBOL type is a planner artifact — CAST the value to a real type"));
+        rules.put(LogicalTypeRoot.RAW, rejected(
+                "RAW is opaque Java bytes — CAST the value to a concrete SQL type"));
+        rules.put(LogicalTypeRoot.DISTINCT_TYPE, rejected(
+                "DISTINCT types are not supported — CAST the value to its source type"));
+        rules.put(LogicalTypeRoot.STRUCTURED_TYPE, rejected(
+                "structured types are not supported — use ROW instead"));
+        rules.put(LogicalTypeRoot.UNRESOLVED, rejected(
+                "the type is unresolved — this is a planner inconsistency"));
+
+        // Roots newer than the flink-table-common floor this module compiles against (2.1 adds
+        // both): registered by name so the exhaustiveness guard holds on every Flink generation.
+        registerIfPresent(rules, "VARIANT", rejected(
+                "VARIANT is not supported — ClickHouse Variant has no write path yet (see issue #60)"));
+        registerIfPresent(rules, "DESCRIPTOR", rejected(
+                "DESCRIPTOR is a planner artifact of process table functions and cannot be a column"));
+
+        return rules;
+    }
+
+    private static void registerIfPresent(Map<LogicalTypeRoot, TypeMappingRule> rules, String root, TypeMappingRule rule) {
+        try {
+            rules.put(LogicalTypeRoot.valueOf(root), rule);
+        } catch (IllegalArgumentException e) {
+            // This Flink generation predates the root, so nothing can reach it.
+        }
+    }
+
+    private static TypeMappingRule rejected(String reason) {
+        return (flinkType, target, options, columnPathText) -> {
+            throw TypeMappingException.mismatch(reason);
+        };
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Scalar rows
+    // ------------------------------------------------------------------------------------
+
+    private static ValueConverter buildBooleanConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                       TypeMappingOptions options, String columnPathText) {
+        if (target.getDataType() == ClickHouseDataType.Bool) {
+            return value -> value;
+        }
+        throw noConversion(flinkType, "Bool");
+    }
+
+    /**
+     * TINYINT..BIGINT into any integer column. A column holding the whole source range takes the
+     * value as is; a narrower or unsigned one checks every value, since the wire format would store
+     * an out-of-range value wrapped.
+     */
+    private static ValueConverter buildIntegerConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                        TypeMappingOptions options, String columnPathText) {
+        ClickHouseDataType targetType = target.getDataType();
+        if (!INTEGER_TARGETS.contains(targetType)) {
+            throw noConversion(flinkType, "Int8..Int256, UInt8..UInt256");
+        }
+        int sourceBits = integerBits(flinkType.getTypeRoot());
+        int targetBits = targetType.getByteLength() * 8;
+        if (targetType.isSigned() && targetBits == sourceBits) {
+            return value -> value;
+        }
+        if (targetType.isSigned() && targetBits > sourceBits) {
+            return toDataWriterType(targetType);
+        }
+        return rangeCheckedInteger(targetType, toDataWriterType(targetType), options, columnPathText);
+    }
+
+    private static final Set<ClickHouseDataType> INTEGER_TARGETS = EnumSet.of(
+            ClickHouseDataType.Int8, ClickHouseDataType.Int16, ClickHouseDataType.Int32,
+            ClickHouseDataType.Int64, ClickHouseDataType.Int128, ClickHouseDataType.Int256,
+            ClickHouseDataType.UInt8, ClickHouseDataType.UInt16, ClickHouseDataType.UInt32,
+            ClickHouseDataType.UInt64, ClickHouseDataType.UInt128, ClickHouseDataType.UInt256);
+
+    /** The Java type DataWriter's dispatch takes for each integer column, from any Flink integer. */
+    private static ValueConverter toDataWriterType(ClickHouseDataType target) {
+        switch (target) {
+            case Int8:                           return value -> (byte) ((Number) value).longValue();
+            case Int16:                          return value -> (short) ((Number) value).longValue();
+            case Int32: case UInt8: case UInt16: return value -> (int) ((Number) value).longValue();
+            case Int64: case UInt32:             return value -> ((Number) value).longValue();
+            default:                             return value -> BigInteger.valueOf(((Number) value).longValue());
+        }
+    }
+
+    private static int integerBits(LogicalTypeRoot root) {
+        switch (root) {
+            case TINYINT:  return 8;
+            case SMALLINT: return 16;
+            case INTEGER:  return 32;
+            default:       return 64;
+        }
+    }
+
+    /** The column's bounds clamped to long — only UInt64 and wider exceed it, where only a negative can fail. */
+    private static ValueConverter rangeCheckedInteger(ClickHouseDataType targetType, ValueConverter toTarget,
+                                                      TypeMappingOptions options, String columnPathText) {
+        BigInteger min = integerMin(targetType);
+        BigInteger max = integerMax(targetType);
+        long lowest = min.max(BigInteger.valueOf(Long.MIN_VALUE)).longValue();
+        long highest = max.min(BigInteger.valueOf(Long.MAX_VALUE)).longValue();
+        String range = targetType + " range " + min + ".." + max;
+        if (options.strictNumeric) {
+            throw strictNumericRejects("values outside the " + range);
+        }
+        return value -> {
+            long v = ((Number) value).longValue();
+            if (v < lowest || v > highest) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': value " + v + " is outside the " + range);
+            }
+            return toTarget.convert(value);
+        };
+    }
+
+    private static ValueConverter buildDecimalConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                        TypeMappingOptions options, String columnPathText) {
+        DecimalType decimalType = (DecimalType) flinkType;
+        int precision = decimalType.getPrecision();
+        int scale = decimalType.getScale();
+        switch (target.getDataType()) {
+            case Decimal:
+            case Decimal32:
+            case Decimal64:
+            case Decimal128:
+            case Decimal256:
+                checkDecimalFits(precision, scale, target);
+                return value -> ((DecimalData) value).toBigDecimal();
+            case Int8:
+            case Int16:
+            case Int32:
+            case Int64:
+            case Int128:
+            case Int256:
+            case UInt8:
+            case UInt16:
+            case UInt32:
+            case UInt64:
+            case UInt128:
+            case UInt256:
+                checkDecimalFitsInteger(precision, scale, target);
+                return buildIntegerDecimalConverter(target.getDataType(), precision, options, columnPathText);
+            default:
+                throw noConversion(flinkType,
+                        "Decimal(p,s); with s = 0 also any Int8..Int256 or UInt8..UInt256 whose digits cover p");
+        }
+    }
+
+    private static void checkDecimalFits(int precision, int scale, ClickHouseColumn target) {
+        int targetPrecision = target.getPrecision();
+        int targetScale = target.getScale();
+        if (targetScale < scale) {
+            throw TypeMappingException.mismatch(String.format(
+                    "scale %d exceeds the column's scale %d", scale, targetScale));
+        }
+        if (targetPrecision - targetScale < precision - scale) {
+            throw TypeMappingException.mismatch(String.format(
+                    "%d integer digits exceed the column's %d integer digits",
+                    precision - scale, targetPrecision - targetScale));
+        }
+    }
+
+    private static void checkDecimalFitsInteger(int precision, int scale, ClickHouseColumn target) {
+        if (scale != 0) {
+            throw TypeMappingException.mismatch(String.format(
+                    "scale %d has a fractional part; only DECIMAL(p, 0) can be written to an integer column",
+                    scale));
+        }
+        int maxDigits = target.getDataType().getMaxPrecision();
+        if (precision > maxDigits) {
+            throw TypeMappingException.mismatch(String.format(
+                    "precision %d exceeds %s's %d digits", precision, target.getDataType(), maxDigits));
+        }
+    }
+
+    /**
+     * DECIMAL(p, 0) → integer. The planning gate admits up to the target's digit count, which at
+     * that boundary still lets values overflow (UInt64 ends at 18446744073709551615 within 20
+     * digits), and a sign never fits an unsigned column — so boundary precisions and unsigned
+     * targets are range-checked per record; a narrower signed DECIMAL always fits and is not.
+     */
+    private static ValueConverter buildIntegerDecimalConverter(ClickHouseDataType targetType, int precision,
+                                                               TypeMappingOptions options, String columnPathText) {
+        ValueConverter narrow = integerNarrowing(targetType);
+        if (targetType.isSigned() && precision < targetType.getMaxPrecision()) {
+            return value -> narrow.convert(((DecimalData) value).toBigDecimal().toBigIntegerExact());
+        }
+        BigInteger min = integerMin(targetType);
+        BigInteger max = integerMax(targetType);
+        if (options.strictNumeric) {
+            throw strictNumericRejects("values outside the " + targetType + " range " + min + ".." + max);
+        }
+        return value -> {
+            BigInteger integer = ((DecimalData) value).toBigDecimal().toBigIntegerExact();
+            if (integer.signum() < 0 && !targetType.isSigned()) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': value " + integer
+                        + " is negative and cannot be written to the unsigned type " + targetType);
+            }
+            if (integer.compareTo(min) < 0 || integer.compareTo(max) > 0) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': value " + integer
+                        + " is outside the " + targetType + " range " + min + ".." + max);
+            }
+            return narrow.convert(integer);
+        };
+    }
+
+    private static BigInteger integerMin(ClickHouseDataType type) {
+        return type.isSigned()
+                ? BigInteger.ONE.shiftLeft(type.getByteLength() * 8 - 1).negate()
+                : BigInteger.ZERO;
+    }
+
+    private static BigInteger integerMax(ClickHouseDataType type) {
+        return BigInteger.ONE.shiftLeft(type.getByteLength() * 8 - (type.isSigned() ? 1 : 0))
+                .subtract(BigInteger.ONE);
+    }
+
+    /** Narrows a BigInteger to the Java type DataWriter's dispatch takes for the target. */
+    private static ValueConverter integerNarrowing(ClickHouseDataType type) {
+        switch (type) {
+            case Int8:   return value -> ((BigInteger) value).byteValueExact();
+            case Int16:  return value -> ((BigInteger) value).shortValueExact();
+            case Int32:
+            case UInt8:
+            case UInt16: return value -> ((BigInteger) value).intValueExact();
+            case Int64:
+            case UInt32: return value -> ((BigInteger) value).longValueExact();
+            default:     return value -> value;
+        }
+    }
+
+    /** FLOAT into Float32/Float64, DOUBLE into Float64 only: Float32 would round almost every double. */
+    private static ValueConverter buildFloatingPointConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                              TypeMappingOptions options, String columnPathText) {
+        boolean fromDouble = flinkType.getTypeRoot() == LogicalTypeRoot.DOUBLE;
+        switch (target.getDataType()) {
+            case Float64:
+                return fromDouble ? value -> value : value -> ((Float) value).doubleValue();
+            case Float32:
+                if (fromDouble) {
+                    throw TypeMappingException.mismatch("Float32 would round DOUBLE values to single precision — "
+                            + "CAST the value to FLOAT to round it explicitly, or use a Float64 column");
+                }
+                return value -> value;
+            default:
+                throw noConversion(flinkType, fromDouble ? "Float64" : "Float32, Float64");
+        }
+    }
+
+    /** {@code CHAR}/{@code VARCHAR} arrive as {@link StringData}; every target starts from its text. */
+    private static ValueConverter buildStringConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                       TypeMappingOptions options, String columnPathText) {
+        switch (target.getDataType()) {
+            case String:
+            case JSON:
+                return Object::toString;
+            case FixedString:
+                return buildFixedStringConverter(target.getPrecision(), columnPathText);
+            case UUID:
+                return buildUuidConverter(columnPathText);
+            default:
+                throw noConversion(flinkType, "String, FixedString(n), UUID, JSON");
+        }
+    }
+
+    /** Checked whatever the CHAR/VARCHAR length: Flink does not enforce declared lengths by default, and the client's own check throws without the column name. */
+    private static ValueConverter buildFixedStringConverter(int maxBytes, String columnPathText) {
+        return value -> {
+            String text = value.toString();
+            int byteLength = utf8ByteLength(text);
+            if (byteLength > maxBytes) {
+                throw new IllegalArgumentException(String.format(
+                        "Column '%s': value of %d bytes does not fit FixedString(%d): %s",
+                        columnPathText, byteLength, maxBytes, text));
+            }
+            return text;
+        };
+    }
+
+    /** Allocation-free for ASCII (the per-record hot path); the writer re-encodes anyway. */
+    private static int utf8ByteLength(String text) {
+        for (int i = 0; i < text.length(); i++) {
+            if (text.charAt(i) >= 0x80) {
+                return text.getBytes(StandardCharsets.UTF_8).length;
+            }
+        }
+        return text.length();
+    }
+
+    private static ValueConverter buildUuidConverter(String columnPathText) {
+        return value -> {
+            String text = value.toString();
+            // fromString also zero-expands forms like '1-1-1-1-1'; accept only the canonical form.
+            if (!isCanonicalUuid(text)) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': value is not a valid UUID: " + text);
+            }
+            return UUID.fromString(text);
+        };
+    }
+
+    private static boolean isCanonicalUuid(String text) {
+        if (text.length() != 36) {
+            return false;
+        }
+        for (int i = 0; i < 36; i++) {
+            char c = text.charAt(i);
+            if (i == 8 || i == 13 || i == 18 || i == 23) {
+                if (c != '-') {
+                    return false;
+                }
+            } else if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F'))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static ValueConverter buildDateConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                     TypeMappingOptions options, String columnPathText) {
+        switch (target.getDataType()) {
+            case Date32:
+                return rangeCheckedEpochDayConverter(columnPathText, DATE32_MIN_EPOCH_DAY, DATE32_MAX_EPOCH_DAY,
+                        "Date32 range 1900-01-01..2299-12-31");
+            case Date:
+                return rangeCheckedEpochDayConverter(columnPathText, 0, DATE_MAX_EPOCH_DAY,
+                        "Date range 1970-01-01..2149-06-06 — use Date32 for a wider range");
+            default:
+                throw noConversion(flinkType, "Date, Date32");
+        }
+    }
+
+    /** The client writes days as raw UInt16/Int32, so an out-of-range day would be stored wrapped. */
+    private static ValueConverter rangeCheckedEpochDayConverter(String columnPathText, int minEpochDay, int maxEpochDay,
+                                                                String rangeText) {
+        return value -> {
+            int epochDay = (Integer) value;
+            if (epochDay < minEpochDay || epochDay > maxEpochDay) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': DATE value " + LocalDate.ofEpochDay(epochDay)
+                        + " is outside the ClickHouse " + rangeText);
+            }
+            return LocalDate.ofEpochDay(epochDay);
+        };
+    }
+
+    /** A wall-clock value: interpreted in sink.timezone, written instant-exactly. */
+    private static ValueConverter buildTimestampConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                          TypeMappingOptions options, String columnPathText) {
+        checkDateTimeTargetFits(flinkType, target, ((TimestampType) flinkType).getPrecision());
+        ZoneId zone = options.sinkTimezone;   // the converter captures the zone only
+        return rangeCheckedDateTimeConverter(target, columnPathText,
+                value -> ZonedDateTime.of(((TimestampData) value).toLocalDateTime(), zone));
+    }
+
+    /** An instant: the zone cannot change the wire bytes, and UTC keeps the state small. */
+    private static ValueConverter buildTimestampLtzConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                             TypeMappingOptions options, String columnPathText) {
+        checkDateTimeTargetFits(flinkType, target, ((LocalZonedTimestampType) flinkType).getPrecision());
+        return rangeCheckedDateTimeConverter(target, columnPathText,
+                value -> ZonedDateTime.ofInstant(((TimestampData) value).toInstant(), ZoneOffset.UTC));
+    }
+
+    /**
+     * Wraps a timestamp converter with the target's instant range: DateTime is UInt32 epoch
+     * seconds (the client's writer rejects the rest without naming the column) and DateTime64
+     * spans 1900..2299 — less at scale 9, where the client's Int64 tick math wraps silently.
+     */
+    private static ValueConverter rangeCheckedDateTimeConverter(ClickHouseColumn target, String columnPathText,
+                                                                ValueConverter toZonedDateTime) {
+        boolean isDateTime64 = target.getDataType() == ClickHouseDataType.DateTime64;
+        long minEpochSecond = isDateTime64 ? DATETIME64_MIN_EPOCH_SECOND : 0L;
+        long maxEpochSecond = isDateTime64
+                ? Math.min(DATETIME64_MAX_EPOCH_SECOND, maxTickSafeEpochSecond(target.getScale()))
+                : DATETIME_MAX_EPOCH_SECOND;
+        String targetName = isDateTime64 ? "DateTime64" : "DateTime";
+        String range = Instant.ofEpochSecond(minEpochSecond) + ".." + Instant.ofEpochSecond(maxEpochSecond);
+        return value -> {
+            ZonedDateTime converted = (ZonedDateTime) toZonedDateTime.convert(value);
+            long epochSecond = converted.toEpochSecond();
+            if (epochSecond < minEpochSecond || epochSecond > maxEpochSecond) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': TIMESTAMP value " + converted
+                        + " is outside the ClickHouse " + targetName + " range " + range);
+            }
+            return converted;
+        };
+    }
+
+    /** The largest epoch second whose DateTime64 ticks (second × 10^scale + fraction) fit an Int64. */
+    private static long maxTickSafeEpochSecond(int scale) {
+        long pow = 1L;
+        for (int i = 0; i < scale; i++) {
+            pow *= 10L;
+        }
+        return (Long.MAX_VALUE - (pow - 1)) / pow;
+    }
+
+    /** The target must be DateTime (scale 0) or DateTime64(s) with s >= the Flink precision. */
+    private static void checkDateTimeTargetFits(LogicalType flinkType, ClickHouseColumn target,
+                                                int precision) {
+        switch (target.getDataType()) {
+            case DateTime:
+            case DateTime64:
+                int columnScale = target.getDataType() == ClickHouseDataType.DateTime
+                        ? 0 : target.getScale();
+                if (precision > columnScale) {
+                    throw TypeMappingException.mismatch(String.format(
+                            "precision %d exceeds the column's scale %d", precision, columnScale));
+                }
+                return;
+            default:
+                throw noConversion(flinkType, "DateTime, DateTime64(s) with s >= the Flink precision");
+        }
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Composite rows — recursive; nullability is validated structurally
+    // ------------------------------------------------------------------------------------
+
+    private static ValueConverter buildArrayConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                      TypeMappingOptions options, String columnPathText) {
+        requireTargetType(target, ClickHouseDataType.Array, flinkType, "Array(T)");
+        LogicalType elementType = ((ArrayType) flinkType).getElementType();
+        ClickHouseColumn elementColumn = target.getNestedColumns().get(0);
+        checkArrayElementNullability(elementType, elementColumn);
+
+        ArrayData.ElementGetter elementGetter = nullCheckingElementGetter(elementType);
+        ValueConverter elementConverter = buildNestedConverter(
+                elementType, elementColumn, options, columnPathText + " element", "array element");
+        boolean nullableElements = elementColumn.isNullable();
+        return value -> toPayloadList((ArrayData) value, elementGetter, elementConverter,
+                nullableElements, columnPathText);
+    }
+
+    /** {@code Array(Nullable(T))} is the one nested shape that can carry nulls. */
+    private static void checkArrayElementNullability(LogicalType elementType,
+                                                     ClickHouseColumn elementColumn) {
+        if (elementType.isNullable() && !elementColumn.isNullable()) {
+            throw TypeMappingException.mismatch(String.format(
+                    "the Flink array element type %s is nullable but the ClickHouse element type %s "
+                    + "is not Nullable — declare the element NOT NULL%s",
+                    elementType.asSummaryString(), elementColumn.getOriginalTypeName(),
+                    nullableWrapperHint(elementColumn, " or make the element Nullable")));
+        }
+    }
+
+    private static ValueConverter buildMapConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                    TypeMappingOptions options, String columnPathText) {
+        requireTargetType(target, ClickHouseDataType.Map, flinkType, "Map(K, V)");
+        MapType mapType = (MapType) flinkType;
+        LogicalType keyType = mapType.getKeyType();
+        LogicalType valueType = mapType.getValueType();
+        ValueConverter keyConverter = buildMapKeyConverter(keyType, target.getKeyInfo(), options, columnPathText);
+        ValueConverter valueConverter = buildMapValueConverter(valueType, target.getValueInfo(), options, columnPathText);
+        return buildPayloadMapConverter(keyType, keyConverter, valueType, valueConverter, columnPathText);
+    }
+
+    /** MULTISET&lt;T&gt; is a map from T to a non-null int count, matched against {@code Map(T', UInt64)}. */
+    private static ValueConverter buildMultisetConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                         TypeMappingOptions options, String columnPathText) {
+        requireTargetType(target, ClickHouseDataType.Map, flinkType, "Map(T, UInt64)");
+        checkMultisetCountTarget(target);
+        LogicalType elementType = ((MultisetType) flinkType).getElementType();
+        LogicalType countType = new IntType(false);
+        ValueConverter keyConverter = buildMapKeyConverter(elementType, target.getKeyInfo(), options, columnPathText);
+        // DataWriter's UInt64 write path takes a Long; the count getter yields an Integer.
+        ValueConverter countConverter = buildMultisetCountConverter(columnPathText);
+        return buildPayloadMapConverter(elementType, keyConverter, countType, countConverter, columnPathText);
+    }
+
+    /** Counts are non-negative by definition; a corrupt negative count must not wrap into UInt64. */
+    private static ValueConverter buildMultisetCountConverter(String columnPathText) {
+        return count -> {
+            int value = (Integer) count;
+            if (value < 0) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': MULTISET count " + value
+                        + " is negative and cannot be written to UInt64");
+            }
+            return (long) value;
+        };
+    }
+
+    private static void checkMultisetCountTarget(ClickHouseColumn target) {
+        ClickHouseColumn valueColumn = rejectNestedSimpleAggregateFunction(
+                target.getValueInfo(), "the MULTISET count value");
+        if (valueColumn.getDataType() != ClickHouseDataType.UInt64 || valueColumn.isNullable()) {
+            throw TypeMappingException.mismatch(String.format(
+                    "MULTISET counts require a Map value type of exactly UInt64, found %s",
+                    target.getValueInfo().getOriginalTypeName()));
+        }
+    }
+
+    /** Shared by MAP and MULTISET: both arrive as {@code MapData} and target a ClickHouse {@code Map}. */
+    private static ValueConverter buildPayloadMapConverter(LogicalType keyType, ValueConverter keyConverter,
+                                                      LogicalType valueType, ValueConverter valueConverter,
+                                                      String columnPathText) {
+        ArrayData.ElementGetter keyGetter = nullCheckingElementGetter(keyType);
+        ArrayData.ElementGetter valueGetter = nullCheckingElementGetter(valueType);
+        return value -> toPayloadMap((MapData) value, keyGetter, valueGetter,
+                keyConverter, valueConverter, columnPathText);
+    }
+
+    /**
+     * Keys become the payload map's string keys, so the converter stringifies them and the
+     * client's serializer parses them back.
+     */
+    private static ValueConverter buildMapKeyConverter(LogicalType keyType, ClickHouseColumn keyColumn,
+                                                       TypeMappingOptions options, String columnPathText) {
+        checkMapKeyNullability(keyColumn);
+        checkMapKeyIsRestorableFromString(keyColumn);
+        ValueConverter keyConverter = buildNestedConverter(
+                keyType, keyColumn, options, columnPathText + " key", "map key");
+        return value -> String.valueOf(keyConverter.convert(value));
+    }
+
+    /**
+     * ClickHouse Map keys can never be Nullable. Flink SQL marks every MAP key type nullable, so
+     * the Flink side is exempt and a null key value fails in {@link #toPayloadMap} instead.
+     */
+    private static void checkMapKeyNullability(ClickHouseColumn keyColumn) {
+        if (keyColumn.isNullable()) {
+            throw TypeMappingException.mismatch("ClickHouse Map keys cannot be Nullable");
+        }
+    }
+
+    private static void checkMapKeyIsRestorableFromString(ClickHouseColumn keyColumn) {
+        if (STRING_RESTORABLE_MAP_KEY_TARGETS.contains(keyColumn.getDataType())) {
+            return;
+        }
+        if (keyColumn.getDataType() == ClickHouseDataType.UInt64) {
+            throw TypeMappingException.mismatch(
+                    "ClickHouse Map keys of type UInt64 are not supported by the sink — map keys "
+                    + "are checkpointed as strings and the client serializer restores them with a "
+                    + "signed-long parse, which fails for the upper half of the UInt64 range; "
+                    + "use an Int64 or UInt128 key column instead");
+        }
+        throw TypeMappingException.mismatch(String.format(
+                "ClickHouse Map key type %s is not supported by the sink — map keys are "
+                + "checkpointed as strings and %s cannot be restored from a string",
+                keyColumn.getOriginalTypeName(), keyColumn.getDataType()));
+    }
+
+    private static ValueConverter buildMapValueConverter(LogicalType valueType, ClickHouseColumn valueColumn,
+                                                         TypeMappingOptions options, String columnPathText) {
+        checkNestedNullability(valueType, valueColumn,
+                "Map values (" + valueColumn.getOriginalTypeName() + ")",
+                "the Flink map value type " + valueType.asSummaryString());
+        return buildNestedConverter(valueType, valueColumn, options, columnPathText + " value", "map value");
+    }
+
+    /**
+     * Neither side may be nullable: the client's serializer never writes a nested value's
+     * non-null marker, so a Nullable Map value or Tuple element cannot be written byte-exactly.
+     */
+    private static void checkNestedNullability(LogicalType flinkType, ClickHouseColumn target,
+                                               String targetElements, String flinkElement) {
+        if (target.isNullable()) {
+            throw TypeMappingException.mismatch(String.format(
+                    "Nullable %s are not supported by the sink's serializer — use a non-Nullable type",
+                    targetElements));
+        }
+        if (flinkType.isNullable()) {
+            throw TypeMappingException.mismatch(String.format(
+                    "%s is nullable but the ClickHouse type %s is not Nullable — declare it NOT NULL",
+                    flinkElement, target.getOriginalTypeName()));
+        }
+    }
+
+    /**
+     * Converts every entry of a {@code MAP}/{@code MULTISET} into the string-keyed {@code Map} the
+     * payload carries. Nulls have nowhere to go here, so they fail naming the column.
+     */
+    private static Map<String, Object> toPayloadMap(MapData map,
+                                                        ArrayData.ElementGetter keyGetter,
+                                                        ArrayData.ElementGetter valueGetter,
+                                                        ValueConverter keyConverter,
+                                                        ValueConverter valueConverter,
+                                                        String columnPathText) {
+        ArrayData keys = map.keyArray();
+        ArrayData values = map.valueArray();
+        int size = map.size();
+        // initialCapacity is a bucket count, not an entry count — undershoot forces a rehash.
+        Map<String, Object> result = new LinkedHashMap<>((int) (size / 0.75f) + 1);
+        for (int i = 0; i < size; i++) {
+            Object key = keyGetter.getElementOrNull(keys, i);
+            if (key == null) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': null map key cannot be written to ClickHouse");
+            }
+            Object value = valueGetter.getElementOrNull(values, i);
+            if (value == null) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': null map value cannot be written to a non-Nullable "
+                        + "ClickHouse Map value type");
+            }
+            result.put((String) keyConverter.convert(key), valueConverter.convert(value));
+        }
+        return result;
+    }
+
+    /**
+     * Converts every element of an {@code ARRAY} into the plain {@code List} the payload carries.
+     * Only {@code Array(Nullable(T))} can take a null element; elsewhere it fails naming the column.
+     */
+    private static List<Object> toPayloadList(ArrayData array, ArrayData.ElementGetter getter,
+                                                    ValueConverter elementConverter,
+                                                    boolean nullableElements, String columnPathText) {
+        int size = array.size();
+        List<Object> result = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            Object element = getter.getElementOrNull(array, i);
+            if (element == null) {
+                if (!nullableElements) {
+                    throw new IllegalArgumentException(
+                            "Column '" + columnPathText + "': null array element " + (i + 1)
+                            + " cannot be written to a non-Nullable ClickHouse Array element type");
+                }
+                result.add(null);
+            } else {
+                result.add(elementConverter.convert(element));
+            }
+        }
+        return result;
+    }
+
+    /** ROW fields match Tuple elements positionally. */
+    private static ValueConverter buildRowConverter(LogicalType flinkType, ClickHouseColumn target,
+                                                    TypeMappingOptions options, String columnPathText) {
+        requireTargetType(target, ClickHouseDataType.Tuple, flinkType, "Tuple(...)");
+        RowType rowType = (RowType) flinkType;
+        List<ClickHouseColumn> elements = target.getNestedColumns();
+        checkRowFieldCountMatchesTuple(rowType, elements);
+        checkNamedTupleOrder(rowType, elements);
+
+        RowData.FieldGetter[] fieldGetters = new RowData.FieldGetter[rowType.getFieldCount()];
+        ValueConverter[] fieldConverters = new ValueConverter[rowType.getFieldCount()];
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            RowType.RowField field = rowType.getFields().get(i);
+            fieldGetters[i] = nullCheckingFieldGetter(field.getType(), i);
+            fieldConverters[i] = buildRowFieldConverter(field, elements.get(i), i, options, columnPathText);
+        }
+        return value -> toPayloadTuple((RowData) value, fieldGetters, fieldConverters, columnPathText);
+    }
+
+    private static void checkRowFieldCountMatchesTuple(RowType rowType, List<ClickHouseColumn> elements) {
+        if (rowType.getFieldCount() != elements.size()) {
+            throw TypeMappingException.mismatch(String.format(
+                    "ROW has %d fields but the Tuple has %d elements",
+                    rowType.getFieldCount(), elements.size()));
+        }
+    }
+
+    /** Binding is positional; the same names as a named Tuple in another order is almost certainly a mistake. */
+    private static void checkNamedTupleOrder(RowType rowType, List<ClickHouseColumn> elements) {
+        List<String> elementNames = new ArrayList<>(elements.size());
+        for (ClickHouseColumn element : elements) {
+            if (element.getColumnName() == null || element.getColumnName().isEmpty()) {
+                return;
+            }
+            elementNames.add(element.getColumnName());
+        }
+        List<String> fieldNames = rowType.getFieldNames();
+        if (!fieldNames.equals(elementNames) && new HashSet<>(fieldNames).equals(new HashSet<>(elementNames))) {
+            throw TypeMappingException.mismatch(String.format(
+                    "ROW fields %s bind to Tuple elements by position, but the Tuple names them %s — "
+                    + "reorder the ROW fields to match",
+                    fieldNames, elementNames));
+        }
+    }
+
+    private static ValueConverter buildRowFieldConverter(RowType.RowField field, ClickHouseColumn element,
+                                                         int position, TypeMappingOptions options, String columnPathText) {
+        checkNestedNullability(field.getType(), element,
+                String.format("Tuple elements (%s at position %d)", element.getOriginalTypeName(), position + 1),
+                "the Flink ROW field '" + field.getName() + "'");
+        return buildNestedConverter(field.getType(), element, options,
+                columnPathText + "." + field.getName(), "ROW field '" + field.getName() + "'");
+    }
+
+    /** Converts every field of a {@code ROW} into the {@code Object[]} tuple the payload carries. */
+    private static Object[] toPayloadTuple(RowData row, RowData.FieldGetter[] getters,
+                                            ValueConverter[] converters, String columnPathText) {
+        Object[] result = new Object[getters.length];
+        for (int i = 0; i < getters.length; i++) {
+            Object field = getters[i].getFieldOrNull(row);
+            if (field == null) {
+                throw new IllegalArgumentException(
+                        "Column '" + columnPathText + "': null ROW field " + (i + 1)
+                        + " cannot be written to a non-Nullable Tuple element");
+            }
+            result[i] = converters[i].convert(field);
+        }
+        return result;
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Shared helpers
+    // ------------------------------------------------------------------------------------
+
+    /** Flink's getters for NOT NULL types skip {@code isNullAt}; only a nullable copy lets the payload null checks fire. */
+    private static ArrayData.ElementGetter nullCheckingElementGetter(LogicalType type) {
+        return ArrayData.createElementGetter(type.copy(true));
+    }
+
+    private static RowData.FieldGetter nullCheckingFieldGetter(LogicalType type, int position) {
+        return RowData.createFieldGetter(type.copy(true), position);
+    }
+
+    /** ClickHouse cannot wrap Array, Map, Tuple or its other nested types in Nullable, so the hint is dropped for them. */
+    static String nullableWrapperHint(ClickHouseColumn column, String hint) {
+        return column.getDataType().isNested() ? "" : hint;
+    }
+
+    private static void requireTargetType(ClickHouseColumn target, ClickHouseDataType expected,
+                                          LogicalType flinkType, String supportedTargetsText) {
+        if (target.getDataType() != expected) {
+            throw noConversion(flinkType, supportedTargetsText);
+        }
+    }
+
+    /** Recurses into a nested pair, prefixing mismatch reasons with the structural context. */
+    private static ValueConverter buildNestedConverter(LogicalType flinkType, ClickHouseColumn column,
+                                                       TypeMappingOptions options, String columnPathText, String context) {
+        // Every composite recursion passes here, so nested SAF can never reach converterFor's unwrap.
+        rejectNestedSimpleAggregateFunction(column, context);
+        try {
+            return converterFor(flinkType, column, options, columnPathText);
+        } catch (TypeMappingException e) {
+            if (e.getKind() == TypeMappingException.Kind.TARGET_UNSUPPORTED) {
+                throw e;
+            }
+            throw TypeMappingException.mismatch(context + ": " + e.getMessage());
+        }
+    }
+
+    /** Under {@code sink.strict-numeric-mapping}, a numeric pair whose values may not all fit is rejected at planning, so no record can fail at write time. */
+    private static TypeMappingException strictNumericRejects(String whatCannotFit) {
+        return TypeMappingException.mismatch(whatCannotFit
+                + " can only be caught per record, which 'sink.strict-numeric-mapping' forbids");
+    }
+
+    private static TypeMappingException noConversion(LogicalType flinkType, String supportedTargetsText) {
+        return TypeMappingException.mismatch(String.format(
+                "no supported conversion; supported ClickHouse types for %s: %s",
+                flinkType.asSummaryString(), supportedTargetsText));
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/ResolvedColumnMapping.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/ResolvedColumnMapping.java
@@ -1,0 +1,35 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import com.clickhouse.data.ClickHouseColumn;
+
+import org.apache.flink.connector.clickhouse.table.data.FieldAccessor;
+
+import java.util.Objects;
+
+/**
+ * One resolved column of the sink: the introspected ClickHouse column (wrappers intact — its
+ * {@code getOriginalTypeName()} is the canonical header type expression) and the accessor that
+ * extracts and converts the physical Flink field's value.
+ *
+ * <p>Planning-time only; {@code RowDataDataMapper} extracts the serializable parts.
+ */
+public final class ResolvedColumnMapping {
+
+    public final ClickHouseColumn column;
+    public final FieldAccessor accessor;
+
+    public ResolvedColumnMapping(ClickHouseColumn column, FieldAccessor accessor) {
+        this.column = Objects.requireNonNull(column, "column");
+        this.accessor = Objects.requireNonNull(accessor, "accessor");
+    }
+
+    /** The ClickHouse column name — also the Flink field name and the payload map key. */
+    public String columnName() {
+        return column.getColumnName();
+    }
+
+    /** The canonical type expression the header writer emits for this column. */
+    public String typeExpression() {
+        return column.getOriginalTypeName();
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/SchemaResolver.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/SchemaResolver.java
@@ -1,0 +1,276 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+
+import org.apache.flink.connector.clickhouse.data.ClickHousePayload;
+import org.apache.flink.connector.clickhouse.table.data.FieldAccessor;
+import org.apache.flink.connector.clickhouse.table.data.ValueConverter;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.RowType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static com.clickhouse.utils.writer.DataWriter.unwrapSimpleAggregateFunction;
+
+/**
+ * Pure function from {@code (ResolvedSchema, ClickHouse TableSchema, options)} to the
+ * ordered {@code List<ResolvedColumnMapping>} driving the typed sink. All planning-time
+ * schema errors are raised here as {@link ValidationException}s.
+ *
+ * <p>Columns match by name, case-sensitively; only physical columns participate; column
+ * order is the Flink schema's order.
+ */
+public final class SchemaResolver {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SchemaResolver.class);
+
+    /**
+     * Targets whose {@code Nullable} form DataWriter cannot write a null to yet (issue #144);
+     * the canary test pins each entry and triggers its removal once the writer is fixed.
+     */
+    static final Set<ClickHouseDataType> NULL_HANDLING_BROKEN_TARGETS = EnumSet.of(
+            ClickHouseDataType.UInt8, ClickHouseDataType.UInt16,
+            ClickHouseDataType.UInt32, ClickHouseDataType.UInt64);
+
+    private SchemaResolver() {}
+
+    public static List<ResolvedColumnMapping> resolve(ResolvedSchema flinkSchema,
+                                                      TableSchema clickHouseSchema,
+                                                      SchemaResolverOptions options) {
+        Map<String, ClickHouseColumn> clickHouseColumns = columnsByName(clickHouseSchema);
+        String qualifiedTable = options.database + "." + options.table;
+        TypeMappingOptions typeMapping = options.typeMapping();
+
+        List<ResolvedColumnMapping> mappings = new ArrayList<>();
+        List<RowType.RowField> fields = physicalRowType(flinkSchema).getFields();
+        for (int i = 0; i < fields.size(); i++) {
+            RowType.RowField field = fields.get(i);
+            ClickHouseColumn column = clickHouseColumns.get(field.getName());
+            if (column == null) {
+                if (options.ignoreUnknownFlinkColumns) {
+                    continue;
+                }
+                throw unknownFlinkColumn(field.getName(), clickHouseColumns, qualifiedTable);
+            }
+            // After the unknown-column skip: a dropped column never becomes a payload key.
+            checkNotReservedName(field.getName());
+            mappings.add(resolveColumn(i, field, column, typeMapping));
+        }
+
+        warnOnOmittedColumnsWithoutDefaults(clickHouseSchema, mappedNames(mappings), qualifiedTable);
+        checkNotEmpty(mappings, qualifiedTable);
+        return mappings;
+    }
+
+    /** True iff any resolved target contains a JSON column — drives the JSON auto-enable. */
+    public static boolean targetsJsonColumn(List<ResolvedColumnMapping> mappings) {
+        return mappings.stream().anyMatch(m -> containsJson(m.column));
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Per-column resolution
+    // ------------------------------------------------------------------------------------
+
+    private static ResolvedColumnMapping resolveColumn(int fieldIndex, RowType.RowField field,
+                                                       ClickHouseColumn column,
+                                                       TypeMappingOptions typeMapping) {
+        checkInsertable(field.getName(), column);
+        ClickHouseColumn effective = unwrapSimpleAggregateFunction(column);
+        ValueConverter converter = converterFor(field, column, typeMapping);
+        checkNullability(field, column, effective);
+        FieldAccessor accessor = FieldAccessor.of(
+                RowData.createFieldGetter(field.getType(), fieldIndex), converter);
+        return new ResolvedColumnMapping(column, accessor);
+    }
+
+    private static ValueConverter converterFor(RowType.RowField field, ClickHouseColumn column,
+                                               TypeMappingOptions typeMapping) {
+        try {
+            return ClickHouseTypeMapper.converterFor(field.getType(), column, typeMapping, field.getName());
+        } catch (TypeMappingException e) {
+            throw asValidationException(e, field, column);
+        }
+    }
+
+    private static ValidationException asValidationException(TypeMappingException e,
+                                                             RowType.RowField field,
+                                                             ClickHouseColumn column) {
+        if (e.getKind() == TypeMappingException.Kind.TARGET_UNSUPPORTED) {
+            return new ValidationException(String.format(
+                    "ClickHouse column '%s %s' is not yet supported by the sink (%s). "
+                    + "Exclude the column from the Flink schema to let the server default apply.",
+                    column.getColumnName(), column.getOriginalTypeName(), e.getMessage()));
+        }
+        return new ValidationException(String.format(
+                "Column '%s': Flink type %s cannot be written to ClickHouse column '%s %s' — %s.",
+                field.getName(), field.getType().asSummaryString(),
+                column.getColumnName(), column.getOriginalTypeName(), e.getMessage()));
+    }
+
+    private static void checkInsertable(String name, ClickHouseColumn column) {
+        if (!isInsertTarget(column)) {
+            throw new ValidationException(String.format(
+                    "Column '%s': ClickHouse column '%s %s' is %s — %s. "
+                    + "Exclude the column from the Flink schema.",
+                    name, column.getColumnName(), column.getOriginalTypeName(),
+                    column.getDefaultValue(), notInsertableReason(column.getDefaultValue())));
+        }
+    }
+
+    /**
+     * MATERIALIZED and ALIAS columns are computed by the server. EPHEMERAL columns may be supplied
+     * by an INSERT, but only through an explicit column list, which the sink's
+     * {@code INSERT INTO t FORMAT RowBinaryWithNamesAndTypes} never sends — a header naming one
+     * is silently dropped, so it is rejected here rather than losing data.
+     */
+    private static boolean isInsertTarget(ClickHouseColumn column) {
+        return !column.hasDefault() || column.getDefaultValue() == null
+                || column.getDefaultValue() == ClickHouseColumn.DefaultValue.DEFAULT;
+    }
+
+    private static String notInsertableReason(ClickHouseColumn.DefaultValue kind) {
+        return kind == ClickHouseColumn.DefaultValue.EPHEMERAL
+                ? "the sink inserts without a column list, so the value would be silently dropped"
+                : "the server computes it, so nothing may be sent";
+    }
+
+    private static void checkNullability(RowType.RowField field, ClickHouseColumn column,
+                                         ClickHouseColumn effective) {
+        if (!field.getType().isNullable()) {
+            return;
+        }
+        checkTargetIsNullable(field, column, effective);
+        checkTargetNullHandlingWorks(field, column, effective);
+    }
+
+    /** A byte-exact header cannot carry a null, so the target column must be Nullable. */
+    private static void checkTargetIsNullable(RowType.RowField field, ClickHouseColumn column,
+                                              ClickHouseColumn effective) {
+        if (!effective.isNullable()) {
+            throw new ValidationException(String.format(
+                    "Column '%s': Flink type %s is nullable but ClickHouse column '%s %s' is not "
+                    + "Nullable — a null cannot be written byte-exactly. Declare the Flink column "
+                    + "NOT NULL%s.",
+                    field.getName(), field.getType().asSummaryString(),
+                    column.getColumnName(), column.getOriginalTypeName(),
+                    ClickHouseTypeMapper.nullableWrapperHint(
+                            effective, " or make the ClickHouse column Nullable")));
+        }
+    }
+
+    private static void checkTargetNullHandlingWorks(RowType.RowField field, ClickHouseColumn column,
+                                                     ClickHouseColumn effective) {
+        if (NULL_HANDLING_BROKEN_TARGETS.contains(effective.getDataType())) {
+            throw new ValidationException(String.format(
+                    "Column '%s': nullable Flink type %s cannot be written to ClickHouse column "
+                    + "'%s %s' — null handling for Nullable(UInt8/16/32/64) is broken in the current "
+                    + "DataWriter (see issue #144). Declare the Flink column NOT NULL until the fix lands.",
+                    field.getName(), field.getType().asSummaryString(),
+                    column.getColumnName(), column.getOriginalTypeName()));
+        }
+    }
+
+    /** The payload map key {@code __clickhouse_raw__} is reserved for STRING-mode payloads. */
+    private static void checkNotReservedName(String name) {
+        if (ClickHousePayload.RAW_KEY.equals(name)) {
+            throw new ValidationException(String.format(
+                    "Column '%s' collides with the connector's reserved payload key and cannot be "
+                    + "used as a sink column. Rename the column.", name));
+        }
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Whole-schema checks
+    // ------------------------------------------------------------------------------------
+
+    /**
+     * An omitted ClickHouse column gets its server-side DEFAULT; without one the server still
+     * fills the type default (0/''/empty) because the writer sets
+     * {@code input_format_defaults_for_omitted_fields=1}. That may be unintentional, so warn.
+     * MATERIALIZED/ALIAS/EPHEMERAL columns are exempt.
+     */
+    private static void warnOnOmittedColumnsWithoutDefaults(TableSchema clickHouseSchema,
+                                                            Set<String> mappedNames,
+                                                            String qualifiedTable) {
+        for (ClickHouseColumn column : clickHouseSchema.getColumns()) {
+            if (mappedNames.contains(column.getColumnName()) || !isRequired(column)) {
+                continue;
+            }
+            LOG.warn("ClickHouse column '{} {}' in {} is neither Nullable nor has a DEFAULT "
+                    + "and is missing from the Flink schema — every insert fills it with the "
+                    + "type default (0/''/empty).",
+                    column.getColumnName(), column.getOriginalTypeName(), qualifiedTable);
+        }
+    }
+
+    private static boolean isRequired(ClickHouseColumn column) {
+        if (column.hasDefault()) {
+            return false;
+        }
+        return !unwrapSimpleAggregateFunction(column).isNullable();
+    }
+
+    private static void checkNotEmpty(List<ResolvedColumnMapping> mappings, String qualifiedTable) {
+        if (mappings.isEmpty()) {
+            throw new ValidationException(String.format(
+                    "None of the Flink schema columns map to ClickHouse table %s — nothing to insert.",
+                    qualifiedTable));
+        }
+    }
+
+    private static ValidationException unknownFlinkColumn(String name,
+                                                          Map<String, ClickHouseColumn> clickHouseColumns,
+                                                          String qualifiedTable) {
+        return new ValidationException(String.format(
+                "Column '%s' declared in the Flink schema does not exist in %s. "
+                + "ClickHouse columns: %s. "
+                + "Set 'sink.ignore-unknown-flink-columns' = 'true' to drop it instead.",
+                name, qualifiedTable, String.join(", ", clickHouseColumns.keySet())));
+    }
+
+    // ------------------------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------------------------
+
+    /** Only physical columns participate; computed/metadata columns never reach the sink. */
+    private static RowType physicalRowType(ResolvedSchema flinkSchema) {
+        return (RowType) flinkSchema.toPhysicalRowDataType().getLogicalType();
+    }
+
+    private static Map<String, ClickHouseColumn> columnsByName(TableSchema clickHouseSchema) {
+        // LinkedHashMap keeps the table's column order for error messages.
+        return clickHouseSchema.getColumns().stream().collect(Collectors.toMap(
+                ClickHouseColumn::getColumnName, c -> c,
+                (a, b) -> a, LinkedHashMap::new));
+    }
+
+    private static Set<String> mappedNames(List<ResolvedColumnMapping> mappings) {
+        return mappings.stream().map(ResolvedColumnMapping::columnName).collect(Collectors.toSet());
+    }
+
+    private static boolean containsJson(ClickHouseColumn column) {
+        if (column.getDataType() == ClickHouseDataType.JSON) {
+            return true;
+        }
+        if (column.hasNestedColumn()) {
+            for (ClickHouseColumn nested : column.getNestedColumns()) {
+                if (containsJson(nested)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/SchemaResolverOptions.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/SchemaResolverOptions.java
@@ -1,0 +1,56 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import org.apache.flink.table.api.ValidationException;
+
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/** The connector options schema resolution depends on, plus context for error messages. */
+public final class SchemaResolverOptions {
+
+    /** Names ClickHouse SQL accepts without backquotes. */
+    private static final Pattern UNQUOTED_IDENTIFIER = Pattern.compile("[a-zA-Z_][a-zA-Z0-9_]*");
+
+    public final String database;
+    public final String table;
+    public final ZoneId sinkTimezone;
+    public final boolean ignoreUnknownFlinkColumns;
+    /** {@code sink.strict-numeric-mapping}: reject at planning every numeric pair whose values would need a per-record range check. */
+    public final boolean strictNumericMapping;
+
+    public SchemaResolverOptions(String database, String table, ZoneId sinkTimezone,
+                                 boolean ignoreUnknownFlinkColumns) {
+        this(database, table, sinkTimezone, ignoreUnknownFlinkColumns, false);
+    }
+
+    public SchemaResolverOptions(String database, String table, ZoneId sinkTimezone,
+                                 boolean ignoreUnknownFlinkColumns, boolean strictNumericMapping) {
+        this.database = Objects.requireNonNull(database, "database");
+        this.table = requireUnquotedTableName(table);
+        this.sinkTimezone = Objects.requireNonNull(sinkTimezone, "sinkTimezone");
+        this.ignoreUnknownFlinkColumns = ignoreUnknownFlinkColumns;
+        this.strictNumericMapping = strictNumericMapping;
+    }
+
+    public TypeMappingOptions typeMapping() {
+        return new TypeMappingOptions(sinkTimezone, strictNumericMapping);
+    }
+
+    /**
+     * client-v2 concatenates the table name unquoted into DESCRIBE TABLE and INSERT INTO
+     * (https://github.com/ClickHouse/clickhouse-java/issues/3089); the database travels as
+     * a request setting and needs no check.
+     */
+    private static String requireUnquotedTableName(String table) {
+        Objects.requireNonNull(table, "table");
+        if (UNQUOTED_IDENTIFIER.matcher(table).matches()) {
+            return table;
+        }
+        throw new ValidationException(String.format(
+                "The 'table' option value '%s' needs quoting in SQL, which the connector does not "
+                + "support: the ClickHouse client concatenates the table name unquoted into "
+                + "DESCRIBE TABLE and INSERT INTO statements, so only names matching "
+                + "[a-zA-Z_][a-zA-Z0-9_]* can be used.", table));
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/TypeMappingException.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/TypeMappingException.java
@@ -1,0 +1,37 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+/**
+ * A single (Flink {@code LogicalType}, {@code ClickHouseColumn}) pair failed to map.
+ * Carries only the reason; {@link SchemaResolver} wraps it into a
+ * {@code ValidationException} naming the column and both types.
+ */
+public class TypeMappingException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
+    /** How the resolver should phrase the failure. */
+    public enum Kind {
+        /** The Flink type and the ClickHouse type cannot be paired. */
+        MISMATCH,
+        /** The ClickHouse type has no write path at all, whatever the Flink type. */
+        TARGET_UNSUPPORTED
+    }
+
+    private final Kind kind;
+
+    private TypeMappingException(Kind kind, String reason) {
+        super(reason);
+        this.kind = kind;
+    }
+
+    public static TypeMappingException mismatch(String reason) {
+        return new TypeMappingException(Kind.MISMATCH, reason);
+    }
+
+    public static TypeMappingException targetUnsupported(String reason) {
+        return new TypeMappingException(Kind.TARGET_UNSUPPORTED, reason);
+    }
+
+    public Kind getKind() {
+        return kind;
+    }
+}

--- a/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/TypeMappingOptions.java
+++ b/flink-connector-clickhouse-table/src/main/java/org/apache/flink/connector/clickhouse/table/schema/TypeMappingOptions.java
@@ -1,0 +1,20 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import java.time.ZoneId;
+import java.util.Objects;
+
+/**
+ * What the type matrix needs from the connector options: the zone {@code TIMESTAMP} wall clocks
+ * are interpreted in, and whether a numeric pair that would need a per-record range check is rejected
+ * at planning ({@code sink.strict-numeric-mapping}).
+ */
+public final class TypeMappingOptions {
+
+    public final ZoneId sinkTimezone;
+    public final boolean strictNumeric;
+
+    public TypeMappingOptions(ZoneId sinkTimezone, boolean strictNumeric) {
+        this.sinkTimezone = Objects.requireNonNull(sinkTimezone, "sinkTimezone");
+        this.strictNumeric = strictNumeric;
+    }
+}

--- a/flink-connector-clickhouse-table/src/test/java/org/apache/flink/connector/clickhouse/table/schema/ClickHouseTypeMapperTest.java
+++ b/flink-connector-clickhouse-table/src/test/java/org/apache/flink/connector/clickhouse/table/schema/ClickHouseTypeMapperTest.java
@@ -1,0 +1,748 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import com.clickhouse.data.ClickHouseColumn;
+
+import org.apache.flink.connector.clickhouse.table.data.ValueConverter;
+import org.apache.flink.core.memory.MemorySegmentFactory;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.data.binary.BinaryArrayData;
+import org.apache.flink.table.data.binary.BinaryMapData;
+import org.apache.flink.table.data.binary.BinaryRowData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.BigIntType;
+import org.apache.flink.table.types.logical.DateType;
+import org.apache.flink.table.types.logical.FloatType;
+import org.apache.flink.table.types.logical.CharType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.DoubleType;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.MultisetType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.SmallIntType;
+import org.apache.flink.table.types.logical.TinyIntType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.utils.LogicalTypeParser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins the type matrix of the Table API sink. The matrix itself is {@link #MATRIX}, tested cell by
+ * cell against every ClickHouse scalar column; composite types recurse into it and have their
+ * structural and nullability rules tested separately below.
+ */
+class ClickHouseTypeMapperTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+    private static final TypeMappingOptions LENIENT = new TypeMappingOptions(UTC, false);
+    private static final TypeMappingOptions STRICT_NUMERIC = new TypeMappingOptions(UTC, true);
+
+    private static TypeMappingOptions lenientIn(ZoneId sinkTimezone) {
+        return new TypeMappingOptions(sinkTimezone, false);
+    }
+
+    private static ClickHouseColumn col(String type) {
+        return ClickHouseColumn.of("c", type);
+    }
+
+    /**
+     * The type matrix, one row per Flink type. <b>planning check</b>: the types alone prove every
+     * value fits. <b>numeric range check</b>: each value is range-checked at write time, and
+     * {@code sink.strict-numeric-mapping} rejects the pair at planning because a wider column exists.
+     * <b>value check</b>: each value is checked at write time whatever the options, since no column
+     * could take every value. Every column not named in a row is rejected either way.
+     */
+    private static final String[] MATRIX = {
+        //Flink type       | planning check                          | numeric range check; rejected when strict           | value check
+        "BOOLEAN          | Bool                                    |                                                     | ",
+        "TINYINT          | Int8 Int16 Int32 Int64 Int128 Int256    | UInt8 UInt16 UInt32 UInt64 UInt128 UInt256          | ",
+        "SMALLINT         | Int16 Int32 Int64 Int128 Int256         | Int8 UInt8 UInt16 UInt32 UInt64 UInt128 UInt256     | ",
+        "INT              | Int32 Int64 Int128 Int256               | Int8 Int16 UInt8 UInt16 UInt32 UInt64 UInt128 UInt256 | ",
+        "BIGINT           | Int64 Int128 Int256                     | Int8 Int16 Int32 UInt8 UInt16 UInt32 UInt64 UInt128 UInt256 | ",
+        // DECIMAL(p, s): a Decimal needs scale >= s and integer digits >= p - s; with s = 0, an Int with more
+        // digits than p needs no check, one with exactly p digits or any UInt whose digits cover p is checked
+        "DECIMAL(9,0)     | Int32 Int64 Int128 Int256 Decimal(18,4) | UInt32 UInt64 UInt128 UInt256                       | ",
+        "DECIMAL(10,2)    | Decimal(10,2) Decimal(18,4)             |                                                     | ",
+        "FLOAT            | Float32 Float64                         |                                                     | ",
+        // DOUBLE into Float32 would round, so it is rejected outright
+        "DOUBLE           | Float64                                 |                                                     | ",
+        // FixedString(m) is checked whatever the CHAR/VARCHAR length: Flink does not enforce declared lengths by default
+        "CHAR(4)          | String JSON                             |                                                     | FixedString(4) FixedString(16) UUID",
+        "STRING           | String JSON                             |                                                     | FixedString(4) FixedString(16) UUID",
+        "DATE             |                                         |                                                     | Date Date32",
+        "TIMESTAMP(0)     |                                         |                                                     | DateTime DateTime64(3) DateTime64(9)",
+        "TIMESTAMP(3)     |                                         |                                                     | DateTime64(3) DateTime64(9)",
+        "TIMESTAMP_LTZ(3) |                                         |                                                     | DateTime64(3) DateTime64(9)",
+    };
+
+    /** Every ClickHouse scalar column the matrix is checked against. */
+    private static final List<String> TARGETS = List.of((
+            "Bool Int8 Int16 Int32 Int64 Int128 Int256 UInt8 UInt16 UInt32 UInt64 UInt128 UInt256 "
+            + "Float32 Float64 Decimal(10,2) Decimal(18,4) String FixedString(4) FixedString(16) UUID JSON "
+            + "Date Date32 DateTime DateTime64(3) DateTime64(9)").split(" "));
+
+    enum Outcome { PLANNING_CHECK, NUMERIC_RANGE_CHECK, VALUE_CHECK, REJECTED }
+
+    private static Stream<Arguments> matrix() {
+        return Arrays.stream(MATRIX).flatMap(row -> {
+            String[] cells = row.split("\\|", -1);
+            String flinkType = cells[0].trim();
+            Set<String> planningCheck = names(cells[1]);
+            Set<String> numericRangeCheck = names(cells[2]);
+            Set<String> valueCheck = names(cells[3]);
+            return TARGETS.stream().map(target -> Arguments.of(flinkType, target,
+                    planningCheck.contains(target) ? Outcome.PLANNING_CHECK
+                            : numericRangeCheck.contains(target) ? Outcome.NUMERIC_RANGE_CHECK
+                            : valueCheck.contains(target) ? Outcome.VALUE_CHECK : Outcome.REJECTED));
+        });
+    }
+
+    private static Set<String> names(String cell) {
+        return cell.isBlank() ? Set.of() : Set.of(cell.trim().split("\\s+"));
+    }
+
+    private static LogicalType type(String sql) {
+        return LogicalTypeParser.parse(sql + " NOT NULL", ClickHouseTypeMapperTest.class.getClassLoader());
+    }
+
+    /** A typo in the table must fail here, not pass as "rejected". */
+    @Test
+    void theMatrixNamesOnlyKnownColumnsAndEachOnce() {
+        for (String row : MATRIX) {
+            String[] cells = row.split("\\|", -1);
+            Set<String> planningCheck = names(cells[1]);
+            Set<String> numericRangeCheck = names(cells[2]);
+            Set<String> valueCheck = names(cells[3]);
+            assertTrue(TARGETS.containsAll(planningCheck), row);
+            assertTrue(TARGETS.containsAll(numericRangeCheck), row);
+            assertTrue(TARGETS.containsAll(valueCheck), row);
+            assertTrue(planningCheck.stream().noneMatch(numericRangeCheck::contains), row);
+            assertTrue(planningCheck.stream().noneMatch(valueCheck::contains), row);
+            assertTrue(numericRangeCheck.stream().noneMatch(valueCheck::contains), row);
+        }
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}: {2}")
+    @MethodSource("matrix")
+    void everyScalarPairHasItsDocumentedOutcome(String flinkType, String target, Outcome outcome) {
+        switch (outcome) {
+            case PLANNING_CHECK:
+            case VALUE_CHECK:
+                ClickHouseTypeMapper.converterFor(type(flinkType), col(target), LENIENT, "c");
+                ClickHouseTypeMapper.converterFor(type(flinkType), col(target), STRICT_NUMERIC, "c");
+                break;
+            case NUMERIC_RANGE_CHECK:
+                ClickHouseTypeMapper.converterFor(type(flinkType), col(target), LENIENT, "c");
+                TypeMappingException strict = assertThrows(TypeMappingException.class,
+                        () -> ClickHouseTypeMapper.converterFor(type(flinkType), col(target), STRICT_NUMERIC, "c"));
+                assertTrue(strict.getMessage().contains("'sink.strict-numeric-mapping'"), strict.getMessage());
+                break;
+            case REJECTED:
+                assertThrows(TypeMappingException.class,
+                        () -> ClickHouseTypeMapper.converterFor(type(flinkType), col(target), LENIENT, "c"));
+                assertThrows(TypeMappingException.class,
+                        () -> ClickHouseTypeMapper.converterFor(type(flinkType), col(target), STRICT_NUMERIC, "c"));
+                break;
+        }
+    }
+
+    private static Stream<Arguments> acceptedCells() {
+        return matrix().filter(cell -> cell.get()[2] != Outcome.REJECTED);
+    }
+
+    /** Every accepted cell converts one sample value into the Java type DataWriter's dispatch takes for the column. */
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("acceptedCells")
+    void everyAcceptedPairConvertsASampleValue(String flinkType, String target, Outcome outcome) {
+        Object converted = ClickHouseTypeMapper.converterFor(type(flinkType), col(target), LENIENT, "c")
+                .convert(sample(flinkType, target));
+        if (converted instanceof ZonedDateTime) {
+            // TIMESTAMP arrives zoned in sink.timezone, TIMESTAMP_LTZ in UTC; the instant is what the writer encodes.
+            assertEquals(Instant.parse("2020-01-01T00:00:00Z"), ((ZonedDateTime) converted).toInstant());
+        } else {
+            assertEquals(expectedSample(flinkType, target), converted);
+        }
+    }
+
+    /** 7 (or 7.5, 7.25) for numbers, abcd or a UUID for text, 2020-01-01 for dates and timestamps. */
+    private static Object sample(String flinkType, String target) {
+        switch (flinkType) {
+            case "BOOLEAN":       return true;
+            case "TINYINT":       return (byte) 7;
+            case "SMALLINT":      return (short) 7;
+            case "INT":           return 7;
+            case "BIGINT":        return 7L;
+            case "DECIMAL(9,0)":  return decimalData("7", 9, 0);
+            case "DECIMAL(10,2)": return decimalData("7.25", 10, 2);
+            case "FLOAT":         return 7.5f;
+            case "DOUBLE":        return 7.5d;
+            case "DATE":          return day(2020, 1, 1);
+            case "CHAR(4)":
+            case "STRING":        return str(target.equals("UUID") ? SOME_UUID.toString() : "abcd");
+            default:              return ts(2020, 1, 1, 0, 0, 0);   // TIMESTAMP(p), TIMESTAMP_LTZ(p)
+        }
+    }
+
+    private static Object expectedSample(String flinkType, String target) {
+        switch (target) {
+            case "Bool":    return true;
+            case "Int8":    return (byte) 7;
+            case "Int16":   return (short) 7;
+            case "Int32": case "UInt8": case "UInt16":  return 7;
+            case "Int64": case "UInt32":                return 7L;
+            case "Int128": case "Int256": case "UInt64": case "UInt128": case "UInt256":
+                            return BigInteger.valueOf(7);
+            case "Float32": return 7.5f;
+            case "Float64": return 7.5d;
+            case "Decimal(10,2)": case "Decimal(18,4)":
+                            return new BigDecimal(flinkType.equals("DECIMAL(10,2)") ? "7.25" : "7");
+            case "UUID":    return SOME_UUID;
+            case "Date": case "Date32":
+                            return LocalDate.of(2020, 1, 1);
+            default:        return "abcd";   // String, JSON, FixedString
+        }
+    }
+
+    /** Runtime-check pairs: the column's bounds convert, one step beyond fails naming the column and the range. */
+    private static Stream<Arguments> runtimeCheckProbes() {
+        return Stream.of(
+                probe("TINYINT", "UInt8", in((byte) 0, 0, (byte) 127, 127), out((byte) -1, "UInt8 range 0..255")),
+                probe("SMALLINT", "Int8", in((short) -128, (byte) -128, (short) 127, (byte) 127),
+                        out((short) -129, "Int8 range -128..127", (short) 128, "Int8 range -128..127")),
+                probe("SMALLINT", "UInt8", in((short) 0, 0, (short) 255, 255),
+                        out((short) -1, "UInt8 range 0..255", (short) 256, "UInt8 range 0..255")),
+                probe("SMALLINT", "UInt16", in((short) 32767, 32767), out((short) -1, "UInt16 range 0..65535")),
+                probe("INT", "Int16", in(-32768, (short) -32768, 32767, (short) 32767),
+                        out(-32769, "Int16 range -32768..32767", 32768, "Int16 range -32768..32767")),
+                probe("INT", "UInt16", in(0, 0, 65535, 65535), out(-1, "UInt16 range 0..65535", 65536, "UInt16 range 0..65535")),
+                probe("INT", "UInt32", in(Integer.MAX_VALUE, (long) Integer.MAX_VALUE), out(-1, "UInt32 range 0..4294967295")),
+                probe("BIGINT", "Int32", in((long) Integer.MIN_VALUE, Integer.MIN_VALUE, (long) Integer.MAX_VALUE, Integer.MAX_VALUE),
+                        out(Integer.MIN_VALUE - 1L, "Int32 range -2147483648..2147483647", Integer.MAX_VALUE + 1L, "Int32 range -2147483648..2147483647")),
+                probe("BIGINT", "UInt32", in(0L, 0L, 4294967295L, 4294967295L),
+                        out(-1L, "UInt32 range 0..4294967295", 4294967296L, "UInt32 range 0..4294967295")),
+                probe("BIGINT", "UInt64", in(0L, BigInteger.ZERO, Long.MAX_VALUE, BigInteger.valueOf(Long.MAX_VALUE)),
+                        out(-1L, "UInt64 range 0..18446744073709551615")),
+                probe("BIGINT", "UInt256", in(Long.MAX_VALUE, BigInteger.valueOf(Long.MAX_VALUE)), out(-1L, "UInt256 range 0..")),
+                // 20 digits pass the planning precision check but reach past UInt64's maximum
+                probe("DECIMAL(20,0)", "UInt64", in(decimal("18446744073709551615"), new BigInteger("18446744073709551615")),
+                        out(decimal("99999999999999999999"), "UInt64 range", decimal("-1"), "unsigned type UInt64")),
+                probe("DECIMAL(19,0)", "Int64", in(decimal("9223372036854775807"), Long.MAX_VALUE, decimal("-9223372036854775808"), Long.MIN_VALUE),
+                        out(decimal("9223372036854775808"), "Int64 range -9223372036854775808..9223372036854775807")),
+                probe("DECIMAL(3,0)", "Int8", in(decimal("-128"), (byte) -128), out(decimal("128"), "Int8 range -128..127")),
+                probe("DECIMAL(3,0)", "UInt8", in(decimal("255"), 255),
+                        out(decimal("-1"), "unsigned type UInt8", decimal("256"), "UInt8 range 0..255")),
+                // three characters but six UTF-8 bytes: the limit is bytes
+                probe("STRING", "FixedString(4)", in(str("abcd"), "abcd", str("ab"), "ab"), out(str("ééé"), "FixedString(4)")),
+                // a CHAR(4) value may still exceed four characters: Flink does not enforce declared lengths by default
+                probe("CHAR(4)", "FixedString(16)", in(str("abcd"), "abcd"), out(str("abcdefghijklmnopq"), "FixedString(16)")),
+                // UUID.fromString would zero-expand 1-1-1-1-1 silently; only canonical text passes, in either case
+                probe("STRING", "UUID", in(str(SOME_UUID.toString()), SOME_UUID, str(SOME_UUID.toString().toUpperCase()), SOME_UUID),
+                        out(str("1-1-1-1-1"), "not a valid UUID")),
+                probe("DATE", "Date", in(day(1970, 1, 1), LocalDate.of(1970, 1, 1), day(2149, 6, 6), LocalDate.of(2149, 6, 6)),
+                        out(day(1969, 12, 31), "Date range", day(2149, 6, 7), "Date range")),
+                probe("DATE", "Date32", in(day(1900, 1, 1), LocalDate.of(1900, 1, 1), day(2299, 12, 31), LocalDate.of(2299, 12, 31)),
+                        out(day(1899, 12, 31), "Date32 range", day(9999, 12, 31), "Date32 range 1900-01-01..2299-12-31")),
+                probe("TIMESTAMP(0)", "DateTime", in(ts(1970, 1, 1, 0, 0, 0), null, ts(2106, 2, 7, 6, 28, 15), null),
+                        out(ts(1969, 12, 31, 23, 0, 0), "DateTime range", ts(2106, 2, 7, 6, 28, 16), "DateTime range")),
+                probe("TIMESTAMP(3)", "DateTime64(3)", in(ts(1900, 1, 1, 0, 0, 0), null, ts(2299, 12, 31, 23, 59, 59), null),
+                        out(ts(1899, 12, 31, 23, 59, 0), "DateTime64 range", ts(9999, 12, 31, 0, 0, 0), "DateTime64 range")),
+                // inside the documented 2299 bound, but scale-9 ticks overflow Int64 after 2262-04-11
+                probe("TIMESTAMP(9)", "DateTime64(9)", in(ts(2262, 4, 11, 0, 0, 0), null),
+                        out(ts(2263, 1, 1, 0, 0, 0), "DateTime64 range")));
+    }
+
+    @ParameterizedTest(name = "{0} -> {1}")
+    @MethodSource("runtimeCheckProbes")
+    void runtimeCheckPairsAcceptTheirBoundsAndRejectJustBeyond(String flinkType, String target,
+                                                               Object[][] inRange, Object[][] outOfRange) {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(type(flinkType), col(target), LENIENT, "c");
+        for (Object[] inputAndExpected : inRange) {
+            Object converted = converter.convert(inputAndExpected[0]);
+            if (inputAndExpected[1] != null) {
+                assertEquals(inputAndExpected[1], converted, target + " <- " + inputAndExpected[0]);
+            }
+        }
+        for (Object[] inputAndFragment : outOfRange) {
+            assertRangeError(() -> converter.convert(inputAndFragment[0]), (String) inputAndFragment[1]);
+        }
+    }
+
+    private static final UUID SOME_UUID = UUID.fromString("123e4567-e89b-12d3-a456-426614174000");
+
+    private static Arguments probe(String flinkType, String target, Object[][] inRange, Object[][] outOfRange) {
+        return Arguments.of(flinkType, target, inRange, outOfRange);
+    }
+
+    /** (input, expected) pairs; a null expected only asserts the value converts. */
+    private static Object[][] in(Object... inputAndExpected) {
+        return pairs(inputAndExpected);
+    }
+
+    /** (input, message fragment) pairs. */
+    private static Object[][] out(Object... inputAndFragment) {
+        return pairs(inputAndFragment);
+    }
+
+    private static Object[][] pairs(Object[] flat) {
+        Object[][] pairs = new Object[flat.length / 2][];
+        for (int i = 0; i < pairs.length; i++) {
+            pairs[i] = new Object[]{flat[2 * i], flat[2 * i + 1]};
+        }
+        return pairs;
+    }
+
+    private static DecimalData decimalData(String text, int precision, int scale) {
+        return DecimalData.fromBigDecimal(new BigDecimal(text), precision, scale);
+    }
+
+    private static StringData str(String text) {
+        return StringData.fromString(text);
+    }
+
+    private static int day(int year, int month, int dayOfMonth) {
+        return (int) LocalDate.of(year, month, dayOfMonth).toEpochDay();
+    }
+
+    private static TimestampData ts(int year, int month, int day, int hour, int minute, int second) {
+        return TimestampData.fromLocalDateTime(LocalDateTime.of(year, month, day, hour, minute, second));
+    }
+
+    /**
+     * Guard: every Flink type root is either mapped or explicitly rejected, so a root
+     * added by a future Flink can never fall through silently.
+     */
+    @Test
+    void everyLogicalTypeRootIsMappedOrExplicitlyRejected() {
+        assertEquals(EnumSet.allOf(LogicalTypeRoot.class),
+                EnumSet.copyOf(ClickHouseTypeMapper.registeredRoots()));
+    }
+
+    @Test
+    void enumTargetIsExplicitlyUnsupported() {
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new VarCharType(false, VarCharType.MAX_LENGTH),
+                        col("Enum8('new' = 1, 'done' = 2)"), LENIENT, "c"));
+        assertEquals(TypeMappingException.Kind.TARGET_UNSUPPORTED, e.getKind());
+        assertTrue(e.getMessage().contains("issue #43"), e.getMessage());
+    }
+
+    @Test
+    void timestampPrecisionMayNotExceedColumnScale() {
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new TimestampType(false, 9), col("DateTime64(3)"), LENIENT, "c"));
+        assertEquals("precision 9 exceeds the column's scale 3", e.getMessage());
+    }
+
+    @Test
+    void timestampIsInterpretedInTheSinkTimezone() {
+        ZoneId tokyo = ZoneId.of("Asia/Tokyo");
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new TimestampType(false, 3), col("DateTime64(3)"), lenientIn(tokyo), "c");
+        LocalDateTime wallClock = LocalDateTime.of(2026, 1, 2, 3, 4, 5, 678_000_000);
+        assertEquals(ZonedDateTime.of(wallClock, tokyo),
+                converter.convert(TimestampData.fromLocalDateTime(wallClock)));
+    }
+
+    @Test
+    void dstGapAndOverlapResolveAsDocumented() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new TimestampType(false, 3), col("DateTime64(3)"),
+                lenientIn(ZoneId.of("America/New_York")), "c");
+        // 02:30 does not exist on 2026-03-08 (spring forward): shifted an hour ahead.
+        ZonedDateTime gap = (ZonedDateTime) converter.convert(
+                TimestampData.fromLocalDateTime(LocalDateTime.of(2026, 3, 8, 2, 30)));
+        assertEquals(Instant.parse("2026-03-08T07:30:00Z"), gap.toInstant());
+        // 01:30 occurs twice on 2026-11-01 (fall back): the earlier (-04:00) pass wins.
+        ZonedDateTime overlap = (ZonedDateTime) converter.convert(
+                TimestampData.fromLocalDateTime(LocalDateTime.of(2026, 11, 1, 1, 30)));
+        assertEquals(Instant.parse("2026-11-01T05:30:00Z"), overlap.toInstant());
+    }
+
+    @Test
+    void simpleAggregateFunctionIsTransparentForMatching() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new IntType(false), col("SimpleAggregateFunction(max, Int32)"), LENIENT, "c");
+        assertEquals(41, converter.convert(41));
+    }
+
+    /** Nested SAF has no wire encoding — it must be rejected at planning, never unwrapped. */
+    @Test
+    void nestedSimpleAggregateFunctionIsRejectedAtPlanning() {
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new ArrayType(false, new IntType(false)),
+                        col("Array(SimpleAggregateFunction(max, Int32))"), LENIENT, "c"));
+        assertEquals(TypeMappingException.Kind.TARGET_UNSUPPORTED, e.getKind());
+        assertTrue(e.getMessage().contains("top-level column"), e.getMessage());
+    }
+
+    @Test
+    void multisetWritesElementCountsAsLongs() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                multisetOfString(), col("Map(String, UInt64)"), LENIENT, "c");
+        Map<Object, Object> counts = new LinkedHashMap<>();
+        counts.put(StringData.fromString("a"), 2);
+        assertEquals(Map.of("a", 2L), converter.convert(new GenericMapData(counts)));
+    }
+
+    @Test
+    void multisetRequiresUInt64CountColumns() {
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        multisetOfString(), col("Map(String, UInt32)"), LENIENT, "c"));
+        assertTrue(e.getMessage().contains("exactly UInt64"), e.getMessage());
+    }
+
+    @Test
+    void decimalsWiderThanTheIntegerAreRejectedAtPlanning() {
+        TypeMappingException e = assertThrows(TypeMappingException.class, () -> decimalTo(20, "Int64"));
+        assertTrue(e.getMessage().contains("precision 20 exceeds Int64's 19 digits"), e.getMessage());
+        e = assertThrows(TypeMappingException.class, () -> decimalTo(4, "UInt8"));
+        assertTrue(e.getMessage().contains("precision 4 exceeds UInt8's 3 digits"), e.getMessage());
+        e = assertThrows(TypeMappingException.class, () -> decimalTo(21, "UInt64"));
+        assertTrue(e.getMessage().contains("precision 21 exceeds UInt64's 20 digits"), e.getMessage());
+    }
+
+    @Test
+    void nestedUnsignedValuesAreRangeCheckedToo() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new ArrayType(false, new BigIntType(false)), col("Array(UInt32)"), LENIENT, "c");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> converter.convert(new GenericArrayData(new long[]{1L, -1L})));
+        assertTrue(e.getMessage().contains("Column 'c element'"), e.getMessage());
+    }
+
+    /** Strictness reaches every nesting level: a range-checked numeric pair is rejected at planning inside composites too. */
+    @Test
+    void strictNumericMappingRejectsRangeCheckedPairsInsideComposites() {
+        LogicalType bigint = new BigIntType(false);
+        VarCharType string = new VarCharType(false, VarCharType.MAX_LENGTH);
+        assertStrictRejects(new ArrayType(false, bigint), "Array(UInt32)", "array element");
+        assertStrictRejects(new MapType(false, bigint, string), "Map(UInt32, String)", "map key");
+        assertStrictRejects(new MapType(false, string, bigint), "Map(String, UInt32)", "map value");
+        assertStrictRejects(new MultisetType(false, bigint), "Map(UInt32, UInt64)", "map key");
+        assertStrictRejects(rowOf(bigint), "Tuple(UInt32)", "ROW field 'f0'");
+    }
+
+    private static void assertStrictRejects(LogicalType flinkType, String target, String context) {
+        ClickHouseTypeMapper.converterFor(flinkType, col(target), LENIENT, "c");
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(flinkType, col(target), STRICT_NUMERIC, "c"));
+        assertTrue(e.getMessage().startsWith(context + ": "), e.getMessage());
+        assertTrue(e.getMessage().contains("'sink.strict-numeric-mapping'"), e.getMessage());
+    }
+
+    @Test
+    void doubleIntoFloat32IsRejectedBecauseItRounds() {
+        for (TypeMappingOptions options : List.of(LENIENT, STRICT_NUMERIC)) {
+            TypeMappingException e = assertThrows(TypeMappingException.class,
+                    () -> ClickHouseTypeMapper.converterFor(new DoubleType(false), col("Float32"), options, "c"));
+            assertTrue(e.getMessage().contains("CAST the value to FLOAT"), e.getMessage());
+        }
+    }
+
+    @Test
+    void rowWritesToTupleWithPositionalFields() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                rowOf(new IntType(false), new VarCharType(false, VarCharType.MAX_LENGTH)),
+                col("Tuple(Int32, String)"), LENIENT, "c");
+        Object[] tuple = (Object[]) converter.convert(
+                GenericRowData.of(7, StringData.fromString("x")));
+        assertArrayEquals(new Object[]{7, "x"}, tuple);
+    }
+
+    @Test
+    void rowFieldCountMustMatchTupleElementCount() {
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        rowOf(new IntType(false)), col("Tuple(Int32, String)"), LENIENT, "c"));
+        assertEquals("ROW has 1 fields but the Tuple has 2 elements", e.getMessage());
+    }
+
+    @Test
+    void nullableTupleElementsAreRejectedOnEitherSide() {
+        TypeMappingException flinkSide = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        rowOf(new IntType(true)), col("Tuple(Int32)"), LENIENT, "c"));
+        assertTrue(flinkSide.getMessage().contains("the Flink ROW field 'f0' is nullable"),
+                flinkSide.getMessage());
+        assertTrue(flinkSide.getMessage().contains("declare it NOT NULL"), flinkSide.getMessage());
+
+        TypeMappingException clickHouseSide = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        rowOf(new IntType(false)), col("Tuple(Nullable(Int32))"), LENIENT, "c"));
+        assertTrue(clickHouseSide.getMessage().contains("Nullable Tuple elements (Nullable(Int32) at position 1)"),
+                clickHouseSide.getMessage());
+    }
+
+    @Test
+    void nullableMapValuesAreRejectedOnEitherSide() {
+        VarCharType key = new VarCharType(false, VarCharType.MAX_LENGTH);
+        TypeMappingException flinkSide = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new MapType(false, key, new IntType(true)), col("Map(String, Int32)"), LENIENT, "c"));
+        assertTrue(flinkSide.getMessage().contains("the Flink map value type INT is nullable"),
+                flinkSide.getMessage());
+        assertTrue(flinkSide.getMessage().contains("declare it NOT NULL"), flinkSide.getMessage());
+
+        TypeMappingException clickHouseSide = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new MapType(false, key, new IntType(false)), col("Map(String, Nullable(Int32))"), LENIENT, "c"));
+        assertTrue(clickHouseSide.getMessage().contains("Nullable Map values (Nullable(Int32))"),
+                clickHouseSide.getMessage());
+    }
+
+    /** Binding is positional; the same names in another order is almost certainly a mistake. */
+    @Test
+    void rowFieldNamesMatchingANamedTupleInAnotherOrderAreRejected() {
+        RowType swapped = new RowType(false, List.of(
+                new RowType.RowField("lon", new DoubleType(false)),
+                new RowType.RowField("lat", new DoubleType(false))));
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(swapped, col("Tuple(lat Float64, lon Float64)"), LENIENT, "c"));
+        assertTrue(e.getMessage().contains("[lon, lat]"), e.getMessage());
+        assertTrue(e.getMessage().contains("[lat, lon]"), e.getMessage());
+
+        // The same order, different names, or unnamed elements keep the positional contract.
+        ClickHouseTypeMapper.converterFor(swapped, col("Tuple(lon Float64, lat Float64)"), LENIENT, "c");
+        ClickHouseTypeMapper.converterFor(swapped, col("Tuple(x Float64, y Float64)"), LENIENT, "c");
+        ClickHouseTypeMapper.converterFor(swapped, col("Tuple(Float64, Float64)"), LENIENT, "c");
+    }
+
+    @Test
+    void nullRowFieldFailsNamingTheColumn() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                rowOf(new IntType(false), new VarCharType(false, VarCharType.MAX_LENGTH)),
+                col("Tuple(Int32, String)"), LENIENT, "c");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> converter.convert(GenericRowData.of(7, null)));
+        assertTrue(e.getMessage().contains("Column 'c'"), e.getMessage());
+        assertTrue(e.getMessage().contains("null ROW field 2"), e.getMessage());
+        IllegalArgumentException first = assertThrows(IllegalArgumentException.class,
+                () -> converter.convert(GenericRowData.of(null, StringData.fromString("x"))));
+        assertTrue(first.getMessage().contains("null ROW field 1"), first.getMessage());
+    }
+
+    /** Flink's NOT NULL getters skip isNullAt, so a binary row's null slot would read back as 0. */
+    @Test
+    void nullRowFieldInABinaryRowFailsInsteadOfWritingZero() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                rowOf(new IntType(false), new IntType(false)), col("Tuple(Int32, Int32)"), LENIENT, "c");
+        int size = BinaryRowData.calculateFixPartSizeInBytes(2);
+        BinaryRowData row = new BinaryRowData(2);
+        row.pointTo(MemorySegmentFactory.wrap(new byte[size]), 0, size);
+        row.setNullAt(0);
+        row.setInt(1, 5);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> converter.convert(row));
+        assertTrue(e.getMessage().contains("Column 'c'"), e.getMessage());
+        assertTrue(e.getMessage().contains("null ROW field 1"), e.getMessage());
+    }
+
+    @Test
+    void nullArrayElementFailsForNonNullableElementsNamingTheColumn() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new ArrayType(false, new IntType(false)), col("Array(Int32)"), LENIENT, "c");
+        BinaryArrayData binary = BinaryArrayData.fromPrimitiveArray(new int[]{1, 2});
+        binary.setNullInt(0);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> converter.convert(binary));
+        assertTrue(e.getMessage().contains("Column 'c'"), e.getMessage());
+        assertTrue(e.getMessage().contains("null array element 1"), e.getMessage());
+        assertThrows(IllegalArgumentException.class,
+                () -> converter.convert(new GenericArrayData(new Object[]{null, 2})));
+    }
+
+    @Test
+    void nullArrayElementsAreForwardedIntoNullableElements() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new ArrayType(false, new IntType(true)), col("Array(Nullable(Int32))"), LENIENT, "c");
+        BinaryArrayData binary = BinaryArrayData.fromPrimitiveArray(new int[]{1, 2});
+        binary.setNullInt(0);
+        assertEquals(Arrays.asList(null, 2), converter.convert(binary));
+    }
+
+    @Test
+    void nullMapValueInABinaryMapFailsNamingTheColumn() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                new MapType(false, new IntType(false), new IntType(false)), col("Map(Int32, Int32)"), LENIENT, "c");
+        BinaryArrayData values = BinaryArrayData.fromPrimitiveArray(new int[]{9});
+        values.setNullInt(0);
+        BinaryMapData map = BinaryMapData.valueOf(BinaryArrayData.fromPrimitiveArray(new int[]{7}), values);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> converter.convert(map));
+        assertTrue(e.getMessage().contains("Column 'c'"), e.getMessage());
+        assertTrue(e.getMessage().contains("null map value"), e.getMessage());
+    }
+
+    /** Nullable(Array(...)) is invalid in ClickHouse, so the hint must not suggest it for composite elements. */
+    @Test
+    void nullableElementHintIsDroppedForCompositeElements() {
+        TypeMappingException scalar = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new ArrayType(false, new IntType(true)), col("Array(Int32)"), LENIENT, "c"));
+        assertTrue(scalar.getMessage().contains("or make the element Nullable"), scalar.getMessage());
+        TypeMappingException composite = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new ArrayType(false, new ArrayType(true, new IntType(false))),
+                        col("Array(Array(Int32))"), LENIENT, "c"));
+        assertTrue(composite.getMessage().contains("declare the element NOT NULL"), composite.getMessage());
+        assertFalse(composite.getMessage().contains("make the element Nullable"), composite.getMessage());
+    }
+
+    @Test
+    void rowFieldRangeChecksNameTheFieldPath() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                rowOf(new SmallIntType(false)), col("Tuple(UInt8)"), LENIENT, "c");
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> converter.convert(GenericRowData.of((short) 256)));
+        assertTrue(e.getMessage().contains("Column 'c.f0'"), e.getMessage());
+        assertTrue(e.getMessage().contains("UInt8 range 0..255"), e.getMessage());
+    }
+
+    @Test
+    void multisetRejectsNegativeCounts() {
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                multisetOfString(), col("Map(String, UInt64)"), LENIENT, "c");
+        Map<Object, Object> counts = new LinkedHashMap<>();
+        counts.put(StringData.fromString("a"), -1);
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class,
+                () -> converter.convert(new GenericMapData(counts)));
+        assertTrue(e.getMessage().contains("MULTISET count -1"), e.getMessage());
+    }
+
+    @Test
+    void uInt64MapKeysAreRejectedAtPlanning() {
+        // client-v2 hardcodes Long.parseLong for UInt64 map keys, so keys above 2^63-1 fail.
+        MapType mapType = new MapType(false,
+                new DecimalType(false, 20, 0), new VarCharType(false, VarCharType.MAX_LENGTH));
+        TypeMappingException e = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(mapType, col("Map(UInt64, String)"), LENIENT, "c"));
+        assertTrue(e.getMessage().contains("Map keys of type UInt64"), e.getMessage());
+        assertTrue(e.getMessage().contains("upper half of the UInt64 range"), e.getMessage());
+
+        TypeMappingException multisetError = assertThrows(TypeMappingException.class,
+                () -> ClickHouseTypeMapper.converterFor(
+                        new MultisetType(false, new DecimalType(false, 20, 0)),
+                        col("Map(UInt64, UInt64)"), LENIENT, "c"));
+        assertTrue(multisetError.getMessage().contains("Map keys of type UInt64"),
+                multisetError.getMessage());
+    }
+
+    @Test
+    void uInt128MapKeysStayAccepted() {
+        // UInt128 keys use client-v2's BigInteger parse — the full range round-trips.
+        MapType mapType = new MapType(false,
+                new DecimalType(false, 38, 0), new VarCharType(false, VarCharType.MAX_LENGTH));
+        ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                mapType, col("Map(UInt128, String)"), LENIENT, "c");
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(DecimalData.fromBigDecimal(new BigDecimal("18446744073709551616"), 38, 0),
+                StringData.fromString("v"));
+        assertEquals(Map.of("18446744073709551616", "v"),
+                converter.convert(new GenericMapData(entries)));
+    }
+
+    @Test
+    void decimalMapKeysAreAccepted() {
+        // client-v2 restores Decimal map keys with new BigDecimal(String), so every width round-trips.
+        MapType mapType = new MapType(false,
+                new DecimalType(false, 9, 2), new VarCharType(false, VarCharType.MAX_LENGTH));
+        for (String key : List.of("Decimal(10, 2)", "Decimal32(2)", "Decimal64(2)", "Decimal128(2)", "Decimal256(2)")) {
+            ValueConverter converter = ClickHouseTypeMapper.converterFor(
+                    mapType, col("Map(" + key + ", String)"), LENIENT, "c");
+            Map<Object, Object> entries = new LinkedHashMap<>();
+            entries.put(DecimalData.fromBigDecimal(new BigDecimal("12.34"), 9, 2), StringData.fromString("v"));
+            assertEquals(Map.of("12.34", "v"), converter.convert(new GenericMapData(entries)), key);
+        }
+    }
+
+    /** Composite nesting: ROW inside ARRAY, MAP and ROW all reach the writer as Object[] tuples. */
+    @Test
+    void rowsNestedInArraysMapsAndRowsWriteTuples() {
+        RowType pair = rowOf(new IntType(false), new VarCharType(false, VarCharType.MAX_LENGTH));
+
+        ValueConverter arrayConverter = ClickHouseTypeMapper.converterFor(
+                new ArrayType(false, pair), col("Array(Tuple(Int32, String))"), LENIENT, "c");
+        List<?> tuples = (List<?>) arrayConverter.convert(new GenericArrayData(new Object[]{
+                GenericRowData.of(1, StringData.fromString("p")),
+                GenericRowData.of(2, StringData.fromString("q"))}));
+        assertEquals(2, tuples.size());
+        assertArrayEquals(new Object[]{1, "p"}, (Object[]) tuples.get(0));
+        assertArrayEquals(new Object[]{2, "q"}, (Object[]) tuples.get(1));
+
+        ValueConverter mapConverter = ClickHouseTypeMapper.converterFor(
+                new MapType(false, new VarCharType(false, VarCharType.MAX_LENGTH), pair),
+                col("Map(String, Tuple(Int32, String))"), LENIENT, "c");
+        Map<Object, Object> entries = new LinkedHashMap<>();
+        entries.put(StringData.fromString("k"), GenericRowData.of(1, StringData.fromString("p")));
+        Map<?, ?> payload = (Map<?, ?>) mapConverter.convert(new GenericMapData(entries));
+        assertArrayEquals(new Object[]{1, "p"}, (Object[]) payload.get("k"));
+
+        ValueConverter nestedConverter = ClickHouseTypeMapper.converterFor(
+                rowOf(new IntType(false), pair), col("Tuple(Int32, Tuple(Int32, String))"), LENIENT, "c");
+        Object[] outer = (Object[]) nestedConverter.convert(
+                GenericRowData.of(5, GenericRowData.of(6, StringData.fromString("z"))));
+        assertEquals(5, outer[0]);
+        assertArrayEquals(new Object[]{6, "z"}, (Object[]) outer[1]);
+    }
+
+    private static void assertRangeError(Executable call, String expectedFragment) {
+        IllegalArgumentException e = assertThrows(IllegalArgumentException.class, call);
+        assertTrue(e.getMessage().contains("Column 'c'"), e.getMessage());
+        assertTrue(e.getMessage().contains(expectedFragment), e.getMessage());
+    }
+
+    private static ValueConverter decimalTo(int precision, String target) {
+        return ClickHouseTypeMapper.converterFor(new DecimalType(false, precision, 0), col(target), LENIENT, "c");
+    }
+
+    private static DecimalData decimal(String unscaled) {
+        return DecimalData.fromBigDecimal(new BigDecimal(unscaled), 20, 0);
+    }
+
+    private static MultisetType multisetOfString() {
+        return new MultisetType(false, new VarCharType(false, VarCharType.MAX_LENGTH));
+    }
+
+    private static RowType rowOf(LogicalType... fieldTypes) {
+        List<RowType.RowField> fields = new ArrayList<>();
+        for (int i = 0; i < fieldTypes.length; i++) {
+            fields.add(new RowType.RowField("f" + i, fieldTypes[i]));
+        }
+        return new RowType(false, fields);
+    }
+}

--- a/flink-connector-clickhouse-table/src/test/java/org/apache/flink/connector/clickhouse/table/schema/DataWriterContractTest.java
+++ b/flink-connector-clickhouse-table/src/test/java/org/apache/flink/connector/clickhouse/table/schema/DataWriterContractTest.java
@@ -1,0 +1,147 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+import com.clickhouse.data.format.BinaryStreamUtils;
+import com.clickhouse.utils.writer.DataWriter;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.EnumMap;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/** Pins the planning-time lists in {@link ClickHouseTypeMapper} and {@link SchemaResolver} to DataWriter's actual behavior. */
+class DataWriterContractTest {
+
+    /** A sample column expression per writable type; extend when WRITABLE_TARGETS grows. */
+    private static final Map<ClickHouseDataType, String> TYPE_EXPRESSIONS = buildTypeExpressions();
+
+    private static Map<ClickHouseDataType, String> buildTypeExpressions() {
+        Map<ClickHouseDataType, String> m = new EnumMap<>(ClickHouseDataType.class);
+        m.put(ClickHouseDataType.Bool, "Bool");
+        m.put(ClickHouseDataType.Int8, "Int8");
+        m.put(ClickHouseDataType.Int16, "Int16");
+        m.put(ClickHouseDataType.Int32, "Int32");
+        m.put(ClickHouseDataType.Int64, "Int64");
+        m.put(ClickHouseDataType.Int128, "Int128");
+        m.put(ClickHouseDataType.Int256, "Int256");
+        m.put(ClickHouseDataType.UInt8, "UInt8");
+        m.put(ClickHouseDataType.UInt16, "UInt16");
+        m.put(ClickHouseDataType.UInt32, "UInt32");
+        m.put(ClickHouseDataType.UInt64, "UInt64");
+        m.put(ClickHouseDataType.UInt128, "UInt128");
+        m.put(ClickHouseDataType.UInt256, "UInt256");
+        m.put(ClickHouseDataType.Float32, "Float32");
+        m.put(ClickHouseDataType.Float64, "Float64");
+        m.put(ClickHouseDataType.Decimal, "Decimal(10, 2)");
+        m.put(ClickHouseDataType.Decimal32, "Decimal32(2)");
+        m.put(ClickHouseDataType.Decimal64, "Decimal64(2)");
+        m.put(ClickHouseDataType.Decimal128, "Decimal128(2)");
+        m.put(ClickHouseDataType.Decimal256, "Decimal256(2)");
+        m.put(ClickHouseDataType.String, "String");
+        m.put(ClickHouseDataType.FixedString, "FixedString(4)");
+        m.put(ClickHouseDataType.UUID, "UUID");
+        m.put(ClickHouseDataType.JSON, "JSON");
+        m.put(ClickHouseDataType.Date, "Date");
+        m.put(ClickHouseDataType.Date32, "Date32");
+        m.put(ClickHouseDataType.DateTime, "DateTime");
+        m.put(ClickHouseDataType.DateTime64, "DateTime64(3)");
+        m.put(ClickHouseDataType.Array, "Array(Int32)");
+        m.put(ClickHouseDataType.Map, "Map(String, Int32)");
+        m.put(ClickHouseDataType.Tuple, "Tuple(Int32, String)");
+        return m;
+    }
+
+    /** Whitelist drift, direction one: planning admits a type whose every record would die. */
+    @Test
+    void everyWritableTargetDispatchesInDataWriter() {
+        for (ClickHouseDataType type : ClickHouseTypeMapper.WRITABLE_TARGETS) {
+            String expression = TYPE_EXPRESSIONS.get(type);
+            assertNotNull(expression, "add a sample column expression for " + type);
+            assertTrue(dispatches(expression),
+                    type + " is in WRITABLE_TARGETS but DataWriter has no case for it");
+        }
+    }
+
+    /** Whitelist drift, direction two: fails when DataWriter learns a type unsupportedTargetReason still cites. */
+    @Test
+    void knownUnwritableTargetsStayUndispatched() {
+        for (String expression : List.of("Enum8('a' = 1)", "Enum16('a' = 1)", "Variant(String, Int32)", "Time", "Time64(3)")) {
+            assertFalse(dispatches(expression),
+                    expression + " became writable — update WRITABLE_TARGETS and unsupportedTargetReason");
+        }
+    }
+
+    /**
+     * Canary for {@link SchemaResolver#NULL_HANDLING_BROKEN_TARGETS} (issue #144): when an
+     * assertion fails, the writer learned that null — remove the type there and here.
+     */
+    @Test
+    void nullHandlingBrokenTargetsStayBroken() throws IOException {
+        assertArrayEquals(serialize(0, column("Nullable(UInt8)")),
+                serialize(null, column("Nullable(UInt8)")));
+        assertArrayEquals(serialize(0, column("Nullable(UInt16)")),
+                serialize(null, column("Nullable(UInt16)")));
+        assertArrayEquals(serialize(0L, column("Nullable(UInt32)")),
+                serialize(null, column("Nullable(UInt32)")));
+        assertThrows(NullPointerException.class,
+                () -> serialize(null, column("Nullable(UInt64)")));
+        // The set and the assertions above must cover exactly the same types.
+        assertEquals(EnumSet.of(ClickHouseDataType.UInt8, ClickHouseDataType.UInt16,
+                        ClickHouseDataType.UInt32, ClickHouseDataType.UInt64),
+                SchemaResolver.NULL_HANDLING_BROKEN_TARGETS);
+    }
+
+    /** The mapper spells its type ranges out; while the client still ships them, the two must agree. */
+    @Test
+    @SuppressWarnings("deprecation")
+    void rangeBoundsMatchTheClientsConstants() {
+        assertEquals(BinaryStreamUtils.U_INT8_MAX, ClickHouseTypeMapper.UINT8_MAX);
+        assertEquals(BinaryStreamUtils.U_INT16_MAX, ClickHouseTypeMapper.UINT16_MAX);
+        assertEquals(BinaryStreamUtils.U_INT32_MAX, ClickHouseTypeMapper.UINT32_MAX);
+        assertEquals(BinaryStreamUtils.U_INT64_MAX, ClickHouseTypeMapper.UINT64_MAX);
+        assertEquals(BinaryStreamUtils.U_INT16_MAX, ClickHouseTypeMapper.DATE_MAX_EPOCH_DAY);
+        assertEquals(BinaryStreamUtils.DATE32_MIN, ClickHouseTypeMapper.DATE32_MIN_EPOCH_DAY);
+        assertEquals(BinaryStreamUtils.DATE32_MAX, ClickHouseTypeMapper.DATE32_MAX_EPOCH_DAY);
+        assertEquals(BinaryStreamUtils.U_INT32_MAX, ClickHouseTypeMapper.DATETIME_MAX_EPOCH_SECOND);
+        assertEquals(BinaryStreamUtils.DATETIME64_MIN, ClickHouseTypeMapper.DATETIME64_MIN_EPOCH_SECOND);
+        assertEquals(BinaryStreamUtils.DATETIME64_MAX, ClickHouseTypeMapper.DATETIME64_MAX_EPOCH_SECOND);
+    }
+
+    // ------------------------------------------------------------------------------------
+
+    private static final Object PROBE = new Object();
+
+    /** True iff the writer's dispatch has a case for the type — the probe value is never valid. */
+    private static boolean dispatches(String typeExpression) {
+        try {
+            serialize(PROBE, column(typeExpression));
+            return true;
+        } catch (IOException e) {
+            return !e.getMessage().startsWith("Unsupported ClickHouseDataType");
+        } catch (RuntimeException e) {
+            return true; // reached a typed writer (e.g. ClassCastException on the probe)
+        }
+    }
+
+    private static byte[] serialize(Object value, ClickHouseColumn column) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        DataWriter.of(out).writeValue(value, column);
+        return out.toByteArray();
+    }
+
+    private static ClickHouseColumn column(String typeExpression) {
+        return ClickHouseColumn.of("c", typeExpression);
+    }
+}

--- a/flink-connector-clickhouse-table/src/test/java/org/apache/flink/connector/clickhouse/table/schema/SchemaResolverTest.java
+++ b/flink-connector-clickhouse-table/src/test/java/org/apache/flink/connector/clickhouse/table/schema/SchemaResolverTest.java
@@ -1,0 +1,321 @@
+package org.apache.flink.connector.clickhouse.table.schema;
+
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseColumn;
+
+import org.apache.flink.connector.clickhouse.table.data.RowDataDataMapper;
+import org.apache.flink.connector.clickhouse.convertor.ColumnBinding;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SchemaResolverTest {
+
+    private static final ZoneId UTC = ZoneId.of("UTC");
+
+    private static SchemaResolverOptions options(boolean ignoreUnknownColumns) {
+        return new SchemaResolverOptions("analytics", "events", UTC, ignoreUnknownColumns);
+    }
+
+    private static TableSchema clickHouseSchema(String columnList) {
+        return new TableSchema(ClickHouseColumn.parse(columnList));
+    }
+
+    /** Schema exercising scalars, UUID pairing, composites and reordering. */
+    private static ResolvedSchema flinkSchema() {
+        return ResolvedSchema.of(
+                Column.physical("id", DataTypes.BIGINT().notNull()),
+                Column.physical("name", DataTypes.STRING().notNull()),
+                Column.physical("amount", DataTypes.DECIMAL(18, 4).notNull()),
+                Column.physical("created_at", DataTypes.TIMESTAMP(3).notNull()),
+                Column.physical("uid", DataTypes.STRING().notNull()),
+                Column.physical("tags", DataTypes.ARRAY(DataTypes.STRING().notNull()).notNull()),
+                Column.physical("props",
+                        DataTypes.MAP(DataTypes.STRING(), DataTypes.STRING().notNull()).notNull()));
+    }
+
+    /** Deliberately not in Flink order — the mapping order must come from the Flink schema. */
+    private static final String CH_COLUMNS =
+            "uid UUID, id Int64, name String, amount Decimal(18, 4), "
+            + "created_at DateTime64(3), tags Array(String), props Map(String, String)";
+
+    @Test
+    void resolvesColumnsInFlinkOrderWithCanonicalTypeExpressions() {
+        List<ResolvedColumnMapping> mappings = SchemaResolver.resolve(
+                flinkSchema(), clickHouseSchema(CH_COLUMNS), options(false));
+
+        assertEquals(List.of("id", "name", "amount", "created_at", "uid", "tags", "props"),
+                mappings.stream().map(ResolvedColumnMapping::columnName).collect(Collectors.toList()));
+        assertEquals(List.of("Int64", "String", "Decimal(18, 4)", "DateTime64(3)", "UUID",
+                        "Array(String)", "Map(String, String)"),
+                mappings.stream().map(ResolvedColumnMapping::typeExpression).collect(Collectors.toList()));
+    }
+
+    @Test
+    void mapperSurvivesSerializationAndProducesPlainJavaValues() throws Exception {
+        RowDataDataMapper mapper = serializationRoundTrip(RowDataDataMapper.of(
+                SchemaResolver.resolve(flinkSchema(), clickHouseSchema(CH_COLUMNS), options(false))));
+
+        List<ColumnBinding> bindings = mapper.bindings();
+        assertEquals(7, bindings.size());
+        assertEquals("Int64", bindings.get(0).column.getOriginalTypeName());
+        assertEquals("UUID", bindings.get(4).column.getOriginalTypeName());
+
+        UUID uuid = UUID.randomUUID();
+        LocalDateTime wallClock = LocalDateTime.of(2026, 1, 2, 3, 4, 5, 678_000_000);
+        Map<Object, Object> props = new LinkedHashMap<>();
+        props.put(StringData.fromString("k1"), StringData.fromString("v1"));
+        GenericRowData row = GenericRowData.of(
+                1L,
+                StringData.fromString("alice"),
+                DecimalData.fromBigDecimal(new BigDecimal("12.5000"), 18, 4),
+                TimestampData.fromLocalDateTime(wallClock),
+                StringData.fromString(uuid.toString()),
+                new GenericArrayData(new Object[]{
+                        StringData.fromString("a"), StringData.fromString("b")}),
+                new GenericMapData(props));
+
+        Map<String, Object> map = new HashMap<>();
+        mapper.toMap(row, map);
+
+        assertEquals(1L, map.get("id"));
+        assertEquals("alice", map.get("name"));
+        assertEquals(new BigDecimal("12.5000"), map.get("amount"));
+        assertEquals(ZonedDateTime.of(wallClock, UTC), map.get("created_at"));
+        assertEquals(uuid, map.get("uid"));
+        assertEquals(List.of("a", "b"), map.get("tags"));
+        assertEquals(Map.of("k1", "v1"), map.get("props"));
+    }
+
+    @Test
+    void unknownFlinkColumnFailsWithPreciseMessage() {
+        ResolvedSchema schema = ResolvedSchema.of(
+                Column.physical("id", DataTypes.BIGINT().notNull()),
+                Column.physical("nickname", DataTypes.STRING().notNull()));
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(schema, clickHouseSchema("id Int64"), options(false)));
+        assertTrue(e.getMessage().contains(
+                "Column 'nickname' declared in the Flink schema does not exist in analytics.events"),
+                e.getMessage());
+        assertTrue(e.getMessage().contains("sink.ignore-unknown-flink-columns"), e.getMessage());
+    }
+
+    @Test
+    void tableNamesNeedingQuotesAreRejectedBeforeIntrospection() {
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                new SchemaResolverOptions("analytics", "my-table", UTC, false));
+        assertTrue(e.getMessage().contains("'my-table'"), e.getMessage());
+        assertTrue(e.getMessage().contains("unquoted"), e.getMessage());
+        // Unusual but unquoted-legal names stay accepted.
+        assertEquals("_events_2", new SchemaResolverOptions("analytics", "_events_2", UTC, false).table);
+    }
+
+    @Test
+    void unknownFlinkColumnIsDroppedWhenIgnoreIsEnabled() {
+        ResolvedSchema schema = ResolvedSchema.of(
+                Column.physical("nickname", DataTypes.STRING().notNull()),
+                Column.physical("id", DataTypes.BIGINT().notNull()));
+        List<ResolvedColumnMapping> mappings = SchemaResolver.resolve(
+                schema, clickHouseSchema("id Int64"), options(true));
+        assertEquals(1, mappings.size());
+        assertEquals("id", mappings.get(0).columnName());
+        // The dropped column still occupies its position in the incoming row.
+        GenericRowData row = GenericRowData.of(StringData.fromString("ignored"), 9L);
+        assertEquals(9L, mappings.get(0).accessor.get(row));
+    }
+
+    @Test
+    void reservedColumnNameIsDroppedLikeAnyUnknownColumnWhenIgnoreIsEnabled() {
+        ResolvedSchema schema = ResolvedSchema.of(
+                Column.physical("__clickhouse_raw__", DataTypes.STRING().notNull()),
+                Column.physical("id", DataTypes.BIGINT().notNull()));
+        List<ResolvedColumnMapping> mappings = SchemaResolver.resolve(
+                schema, clickHouseSchema("id Int64"), options(true));
+        assertEquals(List.of("id"),
+                mappings.stream().map(ResolvedColumnMapping::columnName).collect(Collectors.toList()));
+    }
+
+    @Test
+    void reservedColumnNameThatWouldMapIsRejected() {
+        ResolvedSchema schema = ResolvedSchema.of(
+                Column.physical("__clickhouse_raw__", DataTypes.STRING().notNull()));
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(schema,
+                        clickHouseSchema("__clickhouse_raw__ String"), options(true)));
+        assertTrue(e.getMessage().contains("reserved"), e.getMessage());
+    }
+
+    @Test
+    void nullableFlinkColumnCannotTargetNonNullableClickHouseColumn() {
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT()));
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(schema, clickHouseSchema("id Int64"), options(false)));
+        assertTrue(e.getMessage().contains("is not Nullable"), e.getMessage());
+        // The relaxed direction works: nullable Flink column into a Nullable column.
+        List<ResolvedColumnMapping> mappings = SchemaResolver.resolve(
+                schema, clickHouseSchema("id Nullable(Int64)"), options(false));
+        assertEquals("Nullable(Int64)", mappings.get(0).typeExpression());
+    }
+
+    /** The nullability hint is a dead end when the target type itself is unsupported, so type support is checked first. */
+    @Test
+    void unsupportedTargetIsReportedBeforeNullability() {
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical("status", DataTypes.STRING()));
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(schema, clickHouseSchema("status Enum8('a' = 1)"), options(false)));
+        assertTrue(e.getMessage().contains("not yet supported"), e.getMessage());
+        assertFalse(e.getMessage().contains("is not Nullable"), e.getMessage());
+    }
+
+    /** Nullable(Array(...)) is invalid in ClickHouse, so the hint must not suggest it for composite columns. */
+    @Test
+    void nullableColumnHintIsDroppedForCompositeClickHouseTypes() {
+        ResolvedSchema scalar = ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT()));
+        ValidationException scalarError = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(scalar, clickHouseSchema("id Int64"), options(false)));
+        assertTrue(scalarError.getMessage().endsWith("NOT NULL or make the ClickHouse column Nullable."),
+                scalarError.getMessage());
+
+        ResolvedSchema composite = ResolvedSchema.of(
+                Column.physical("tags", DataTypes.ARRAY(DataTypes.STRING().notNull())));
+        ValidationException compositeError = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(composite, clickHouseSchema("tags Array(String)"), options(false)));
+        assertTrue(compositeError.getMessage().endsWith("Declare the Flink column NOT NULL."),
+                compositeError.getMessage());
+    }
+
+    @Test
+    void unsupportedPairFailsWithColumnAndBothTypesNamed() {
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical("v", DataTypes.INT().notNull()));
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(schema, clickHouseSchema("v String"), options(false)));
+        assertTrue(e.getMessage().startsWith(
+                "Column 'v': Flink type INT NOT NULL cannot be written to ClickHouse column 'v String'"),
+                e.getMessage());
+    }
+
+    @Test
+    void nestedSimpleAggregateFunctionIsRejectedAtPlanning() {
+        // client-v2 has no serializer case for SAF inside a composite; accepted schemas would
+        // fail on the first record, so planning rejects them.
+        ValidationException array = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(
+                        ResolvedSchema.of(Column.physical("v",
+                                DataTypes.ARRAY(DataTypes.BIGINT().notNull()).notNull())),
+                        clickHouseSchema("v Array(SimpleAggregateFunction(max, Int64))"),
+                        options(false)));
+        assertTrue(array.getMessage().contains("only writable as a top-level column"),
+                array.getMessage());
+        assertTrue(array.getMessage().contains("array element"), array.getMessage());
+
+        ValidationException map = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(
+                        ResolvedSchema.of(Column.physical("m",
+                                DataTypes.MAP(DataTypes.STRING().notNull(),
+                                        DataTypes.BIGINT().notNull()).notNull())),
+                        clickHouseSchema("m Map(String, SimpleAggregateFunction(max, Int64))"),
+                        options(false)));
+        assertTrue(map.getMessage().contains("map value"), map.getMessage());
+    }
+
+    @Test
+    void omittedClickHouseColumnsAreAllowedRegardlessOfDefaults() {
+        ResolvedSchema schema = ResolvedSchema.of(Column.physical("id", DataTypes.BIGINT().notNull()));
+        // Nullable extra column: allowed, server default applies.
+        SchemaResolver.resolve(schema, clickHouseSchema("id Int64, note Nullable(String)"), options(false));
+        // Non-Nullable extra column without a DEFAULT: allowed too (warned) — the writer sets
+        // input_format_defaults_for_omitted_fields=1, so the server fills the type default.
+        SchemaResolver.resolve(schema, clickHouseSchema("id Int64, note String"), options(false));
+        // And with a DEFAULT: allowed.
+        TableSchema withDefault = clickHouseSchema("id Int64, note String");
+        ClickHouseColumn note = withDefault.getColumnByName("note");
+        note.setHasDefault(true);
+        note.setDefaultValue(ClickHouseColumn.DefaultValue.DEFAULT);
+        SchemaResolver.resolve(schema, withDefault, options(false));
+    }
+
+    @Test
+    void materializedColumnsAreNotInsertable() {
+        TableSchema schema = clickHouseSchema("id Int64, mat String");
+        ClickHouseColumn mat = schema.getColumnByName("mat");
+        mat.setHasDefault(true);
+        mat.setDefaultValue(ClickHouseColumn.DefaultValue.MATERIALIZED);
+        // Unmapped: fine, and excluded from the required-column check.
+        SchemaResolver.resolve(ResolvedSchema.of(
+                Column.physical("id", DataTypes.BIGINT().notNull())), schema, options(false));
+        // Mapped: rejected.
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(ResolvedSchema.of(
+                        Column.physical("id", DataTypes.BIGINT().notNull()),
+                        Column.physical("mat", DataTypes.STRING().notNull())), schema, options(false)));
+        assertTrue(e.getMessage().contains("MATERIALIZED"), e.getMessage());
+        assertTrue(e.getMessage().contains("the server computes it"), e.getMessage());
+    }
+
+    /** EPHEMERAL is insertable SQL-wise, but only via a column list the sink never sends. */
+    @Test
+    void ephemeralColumnsAreRejectedBecauseTheSinkSendsNoColumnList() {
+        TableSchema schema = clickHouseSchema("id Int64, raw String");
+        ClickHouseColumn raw = schema.getColumnByName("raw");
+        raw.setHasDefault(true);
+        raw.setDefaultValue(ClickHouseColumn.DefaultValue.EPHEMERAL);
+        ValidationException e = assertThrows(ValidationException.class, () ->
+                SchemaResolver.resolve(ResolvedSchema.of(
+                        Column.physical("id", DataTypes.BIGINT().notNull()),
+                        Column.physical("raw", DataTypes.STRING().notNull())), schema, options(false)));
+        assertTrue(e.getMessage().contains("is EPHEMERAL"), e.getMessage());
+        assertTrue(e.getMessage().contains("without a column list"), e.getMessage());
+    }
+
+    @Test
+    void jsonColumnsAreDetectedForTheAutoEnable() {
+        ResolvedSchema schema = ResolvedSchema.of(
+                Column.physical("id", DataTypes.BIGINT().notNull()),
+                Column.physical("payload", DataTypes.STRING().notNull()));
+        List<ResolvedColumnMapping> withJson = SchemaResolver.resolve(
+                schema, clickHouseSchema("id Int64, payload JSON"), options(false));
+        assertTrue(SchemaResolver.targetsJsonColumn(withJson));
+        List<ResolvedColumnMapping> withoutJson = SchemaResolver.resolve(
+                schema, clickHouseSchema("id Int64, payload String"), options(false));
+        assertFalse(SchemaResolver.targetsJsonColumn(withoutJson));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T serializationRoundTrip(T value) throws Exception {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+            out.writeObject(value);
+        }
+        try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+            return (T) in.readObject();
+        }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,5 +9,5 @@ plugins {
 }
 
 rootProject.name = "flink-connector-clickhouse"
-include("flink-connector-clickhouse-base", "flink-connector-clickhouse-2.0.0", "flink-connector-clickhouse-1.17", "flink-connector-clickhouse-integration")
+include("flink-connector-clickhouse-base", "flink-connector-clickhouse-table", "flink-connector-clickhouse-2.0.0", "flink-connector-clickhouse-1.17", "flink-connector-clickhouse-integration")
 


### PR DESCRIPTION
## Summary

Registers the `clickhouse` SQL identifier, so `CREATE TABLE … WITH ('connector' = 'clickhouse')` + `INSERT INTO` work on both Flink generations. Sink only, insert-only changelog.

At planning the factory validates options, pings, **introspects the target table's real column types** and resolves the Flink schema against them — type matrix, name matching, nullability, defaults — so every mismatch fails at job submission with a precise message. It then terminates in a `RowDataDataMapper` feeding the existing typed `ClickHouseAsyncSink`, reusing batching, retries and metrics unchanged.

Closes #42

**Where things landed**
- `flink-connector-clickhouse-table` (new module, compiled once against `flink-table-common` 1.17.2, used unchanged on 2.x): connector options, `ClickHouseTypeMapper` (table-driven matrix + a guard over every `LogicalTypeRoot`), `SchemaResolver`, `RowDataDataMapper`
- `-base`: `TableIntrospector`, memoized per `(url, database, table)` so `EXPLAIN`/statement sets don't re-ping
- per version module: `ClickHouseDynamicTableSinkFactory`/`Sink` (byte-identical copies) + SPI registration
- `DataWriter` untouched: Enum8/16 (#43), `BINARY`/`BYTES`, nullable→`Nullable(UInt8..64)` (#144), `Time` (#91), `Variant` (#60) are **rejected at planning** with issue links

**Design decisions**
- **Four buckets per pair**: safe from the types alone; range-checked per record (narrower or unsigned column); value-checked per record (`Date`/`DateTime` ranges, `FixedString` bytes, UUID text — no column takes every value); or rejected as narrowing (`DOUBLE`→`Float32`, smaller decimal scale or timestamp precision). `sink.strict-numeric-mapping = 'true'` moves the *numeric* range checks to planning, since those have a wider column to switch to.
- **Upstream client-v2 limitation — `Nullable` Map values and Tuple elements**: client-v2 writes no non-null marker for nested values, so such inserts corrupt at first flush. Pre-existing (the DataStream path has it too); the sink rejects the pair at planning because Flink DDL makes inner types nullable by default. `Array(Nullable(T))` is fine — its serializer handles element markers.
- **Nullability applies recursively** to array elements, map values and ROW fields; Flink DDL is nullable by default, so `ARRAY<INT NOT NULL> NOT NULL` → `Array(Int32)`.
- **State serializer gained a V3 entry format**: `writeUTF` caps at 64 KB, so a buffered row with a larger STRING value or map key failed every checkpoint that caught it. V1/V2 still restore.

**Verification** — 54 unit tests in `-table`, most parameterized, pinning the matrix cell by cell against every ClickHouse scalar column; 50 integration tests per version module on Flink **1.17.2 and 2.0.0** covering every scalar type at its bounds, every converting pair, composites and named tuples at every nesting, all sink options, and a row per planning rejection and per deferred value check. Pre-existing suites pass unchanged; shaded jars verified.

The `examples/maven/flink-v2` SQL example lands separately.

## Checklist
- [x] Closes #42
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

🤖 Generated with [Claude Code](https://claude.com/claude-code)




